### PR TITLE
Build on Travis; add Linux dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+osx_image: xcode10.2
+
+dist: xenial
+sudo: false
+
+language: node_js
+node_js: "10"
+cache: yarn
+
+env:
+  global:
+    - ELECTRON_CACHE=$HOME/.cache/electron
+    - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+
+os:
+  - linux
+  - osx
+
+install:
+  - yarn
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn dist; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn dist --mac --win; fi
+
+before_cache:
+  - rm -rf $HOME/.cache/electron-builder/wine
+
+branches:
+  only:
+    - stable
+    - beta
+    - tso_ci_pipeline
+    

--- a/package.json
+++ b/package.json
@@ -54,6 +54,13 @@
       "target": [
         "portable"
       ]
+    },
+    "linux": {
+      "icon": "icons",
+      "target": [
+        "AppImage"
+      ],
+      "category": "Game"
     }
   },
   "dependencies": {


### PR DESCRIPTION
- Add a build pipeline on Travis; builds off stable, beta,
and tso_ci_pipeline (for testing)
- On completion, Travis will push build artifacts back to a GitHub draft release
if there is one with a version number matching the package.json version
- Turned on creating Linux builds