### PR TITLE
Add Win32, refactor CI to be more parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,29 @@
-osx_image: xcode10.2
-
-dist: xenial
-sudo: false
-
 language: node_js
 node_js: "10"
 cache: yarn
+install:
+  - yarn
+sudo: false
+
+matrix:
+  include:
+  - name: osx_build
+    os: osx
+    osx_image: xcode10.2
+    script: yarn dist -m
+  - name: linux_build
+    os: linux
+    dist: xenial
+    script: yarn dist -l
+  - name: win_build
+    os: osx
+    osx_image: xcode10.2
+    script: yarn dist -w
 
 env:
   global:
     - ELECTRON_CACHE=$HOME/.cache/electron
     - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
-
-os:
-  - linux
-  - osx
-
-install:
-  - yarn
-
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then yarn dist; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then yarn dist --mac --win; fi
 
 before_cache:
   - rm -rf $HOME/.cache/electron-builder/wine

--- a/package.json
+++ b/package.json
@@ -52,14 +52,20 @@
     "win": {
       "icon": "icons/icon.ico",
       "target": [
-        "portable"
+        {
+          "target": "portable",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
       ]
     },
     "linux": {
       "icon": "icons",
-      "target": [
-        "AppImage"
-      ],
+      "target": [{
+        "target": "AppImage"
+      }],
       "category": "Game"
     }
   },


### PR DESCRIPTION
- Added Win32 compatability.  Builds in the same exe as 64, so size
is now near 140mb.  Not a lot I see to make that smaller right now.
- Rewrote the Travis settings to do three builds in parallel (Win,
OSX, Linux).  This shortens the overall build time.