### PR TITLE
Automatically push release to itch.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 build/
 node_modules/
 thumbs.db
+7z.so
+butler*
+libc7zip.dylib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,27 @@ install:
   - yarn
 sudo: false
 
+# We go through some contortions in here and the package.json
+# calls because a) we have to hardwire a build location
+# into packages's build.directories.output and b) we need to match
+# a number of specific folder names for itch.io's outputs.
+# The last is because, at the time of automation, there was already
+# a pipeline with subscribers on itch that we had to not disrupt.
+# That said, I'm sure a refactor could improve all this.
 matrix:
   include:
   - name: osx_build
     os: osx
     osx_image: xcode10.2
-    script: yarn dist -m
+    script: BUILD_OS=osx ./build_scripts/build.sh
   - name: linux_build
     os: linux
     dist: xenial
-    script: yarn dist -l
+    script: BUILD_OS=linux ./build_scripts/build.sh
   - name: win_build
     os: osx
     osx_image: xcode10.2
-    script: yarn dist -w
+    script: BUILD_OS=win ./build_scripts/build.sh
 
 env:
   global:
@@ -33,4 +40,3 @@ branches:
     - stable
     - beta
     - tso_ci_pipeline
-    

--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# error out of the script (fail the build) on any non-zero return status
+set -e
+
+# for whatever reason, we can't rely on electron-builder env vars here
+# (out of scope?), so we pass in our own for the OS and version
+if [  -z "$BUILD_OS" ]
+then 
+  echo "Failing build - BUILD_OS is unset"
+  exit 1
+else
+  echo "BUILD_OS set to ${BUILD_OS}"
+fi
+
+# create BUILD_VER from the package.json, then test we have it
+export BUILD_VER=`node build_scripts/create-version-env.ts`
+
+if [  -z "$BUILD_VER" ]
+then 
+  echo "Failing build - BUILD_VER is unset"
+  exit 1
+else
+  echo "BUILD_VER set to ${BUILD_VER}"
+fi
+
+echo "Installing Butler"
+if [ ${BUILD_OS} = "osx" ] || [ ${BUILD_OS} = "win" ]
+then
+  curl -L -o butler.zip https://broth.itch.ovh/butler/darwin-amd64/LATEST/archive/default
+elif [ ${BUILD_OS} = "linux" ]
+then
+  curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+fi
+unzip butler.zip
+# GNU unzip tends to not set the executable bit even though it's set in the .zip
+chmod +x butler
+./butler -V
+
+echo "---Starting Build---"
+if [ ${BUILD_OS} = "osx" ]
+then
+  yarn dist-travis -m --publish never
+  cat build/${BUILD_OS}-${TRAVIS_BRANCH}/latest-mac.yml
+  rm -rf build/${BUILD_OS}-${TRAVIS_BRANCH}/mac build/${BUILD_OS}-${TRAVIS_BRANCH}/latest-mac.yml
+elif [ ${BUILD_OS} = "linux" ]
+then
+  yarn dist-travis -l --publish never
+  cat build/${BUILD_OS}-${TRAVIS_BRANCH}/latest-linux.yml
+  rm -rf build/${BUILD_OS}-${TRAVIS_BRANCH}/linux-unpacked build/${BUILD_OS}-${TRAVIS_BRANCH}/latest-linux.yml
+elif [ ${BUILD_OS} = "win" ]
+then
+  yarn dist-travis -w --publish never
+  rm -rf build/${BUILD_OS}-${TRAVIS_BRANCH}/win-ia32-unpacked build/${BUILD_OS}-${TRAVIS_BRANCH}/win-unpacked
+fi
+echo "---Pushing ${BUILD_OS} build for branch ${TRAVIS_BRANCH} to Itch.io---"
+echo "./butler push build/${BUILD_OS}-${TRAVIS_BRANCH} beeftime/compcon:${BUILD_OS}-${TRAVIS_BRANCH}  --userversion ${BUILD_VER}"
+./butler push build/${BUILD_OS}-${TRAVIS_BRANCH} beeftime/compcon:${BUILD_OS}-${TRAVIS_BRANCH}  --userversion ${BUILD_VER}
+echo "---Build and Deployment for ${BUILD_OS} platform, ${TRAVIS_BRANCH} branch complete!"

--- a/build_scripts/create-version-env.ts
+++ b/build_scripts/create-version-env.ts
@@ -1,0 +1,4 @@
+var fs = require("fs")
+var contents = fs.readFileSync("./package.json")
+var jsonContent = JSON.parse(contents)
+console.log(jsonContent.version)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "electron-webpack dev",
     "compile": "electron-webpack",
-    "dist": "yarn compile && electron-builder",
+    "dist": "yarn compile && BUILD_OS=local TRAVIS_BRANCH=build electron-builder",
+    "dist-travis": "yarn compile && electron-builder",
     "lint": "eslint **/*.ts --ignore-pattern node_modules/",
     "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null",
     "unit-test": "jest unit",
@@ -24,27 +25,12 @@
     "productName": "compcon",
     "appId": "com.jarena.compcon",
     "directories": {
-      "output": "build"
+      "output": "build/${env.BUILD_OS}-${env.TRAVIS_BRANCH}"
     },
     "files": [
       "dist/main/**/*",
       "dist/renderer/**/*"
     ],
-    "dmg": {
-      "contents": [
-        {
-          "x": 410,
-          "y": 150,
-          "type": "link",
-          "path": "/Applications"
-        },
-        {
-          "x": 130,
-          "y": 150,
-          "type": "file"
-        }
-      ]
-    },
     "mac": {
       "icon": "icons/icon.icns",
       "target": [


### PR DESCRIPTION
Lots going on here!

From an end-user (i.e. dev) perspective, check out the package.json for a couple changes to script names.  Additionally, doing a `yarn dist` will now put your build into `/build/local-build/`.  The `yarn dist-travis` command will only work in a travis environment, and gets called by the shell script.

The mess of stuff we're now doing with environment variables is to let us name folders in the same fashion they already are on itch, but based on gleaning this info from the environment.

I tested this pretty thoroughly from a Travis / itch perspective, and realized tonight there were some bugs left in doing local `yarn dist` builds.  I think I fixed it all, but let me know if you see any issues.