### PR TITLE
Weapon SP fixes

### DIFF
--- a/src/renderer/features/pilot_management/classes/mech/MechLoadout.ts
+++ b/src/renderer/features/pilot_management/classes/mech/MechLoadout.ts
@@ -175,7 +175,7 @@ class MechLoadout extends Loadout {
   }
 
   public get TotalSP(): number {
-    const mountSP = this.equippableMounts
+    const mountSP = [...this.equippableMounts, this.improvedArmament, this.integratedWeapon]
       .flatMap(x => x.Weapons)
       .reduce(function(a, b) {
         return a + (b ? b.SP : 0)

--- a/src/renderer/features/pilot_management/classes/mech/Mount.ts
+++ b/src/renderer/features/pilot_management/classes/mech/Mount.ts
@@ -77,7 +77,7 @@ abstract class Mount {
   }
 
   public get Weapons(): MechWeapon[] {
-    return this.slots.concat(this.extra).map(x => x.Weapon).filter(y => y !== null) as MechWeapon[]
+    return this.Slots.map(x => x.Weapon).filter(y => y !== null) as MechWeapon[]
   }
 
   public get IsLocked(): boolean {

--- a/src/renderer/features/pilot_management/classes/mech/Mount.ts
+++ b/src/renderer/features/pilot_management/classes/mech/Mount.ts
@@ -77,7 +77,7 @@ abstract class Mount {
   }
 
   public get Weapons(): MechWeapon[] {
-    return this.slots.map(x => x.Weapon).filter(y => y !== null) as MechWeapon[]
+    return this.slots.concat(this.extra).map(x => x.Weapon).filter(y => y !== null) as MechWeapon[]
   }
 
   public get IsLocked(): boolean {


### PR DESCRIPTION
- Fixes the `MechLoadout` SP getter not counting Improved Armament & Integrated Weapon CBs
- Fixes the `Mount` weapons getter not counting the 2nd aux on flex mounts, since it was using `this.weapons` rather than `this.Weapons`

Fixes #232 