### PR TITLE
text area tweaks

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -99,7 +99,7 @@ if (process.platform === 'darwin') {
         {
           label: 'Quit',
           accelerator: 'CmdOrCtrl+Q',
-          click: function() {
+          click: function () {
             app.quit()
           },
         },
@@ -108,6 +108,9 @@ if (process.platform === 'darwin') {
     {
       label: 'Edit',
       submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
         {
           label: 'Cut',
           accelerator: 'CmdOrCtrl+X',

--- a/src/renderer/features/pilot_management/ConfigSheet/index.vue
+++ b/src/renderer/features/pilot_management/ConfigSheet/index.vue
@@ -123,7 +123,6 @@
               auto-grow
               rows="1"
               label="Configuration Notes"
-              clearable
             />
             <!-- Req. Licenses -->
             <v-layout class="mt-0">

--- a/src/renderer/features/pilot_management/PilotSheet/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/index.vue
@@ -294,7 +294,6 @@
                   auto-grow
                   rows="1"
                   label="History"
-                  clearable
                 />
               </v-flex>
             </v-layout>
@@ -351,7 +350,6 @@
                   auto-grow
                   rows="1"
                   label="Description"
-                  clearable
                 />
               </v-flex>
             </v-layout>
@@ -525,7 +523,6 @@
                 auto-grow
                 rows="1"
                 label="Pilot Notes"
-                clearable
               />
             </div>
           </v-flex>


### PR DESCRIPTION
- removed clear button from long form text inputs such as pilot history
- don't have a mac to test this but i added undo/redo options to the electron menu which should fix the shortcuts not working in macOS