### PR TITLE
Small hack to easily dismiss LazyLoad dialogs

### DIFF
--- a/src/renderer/features/pilot_management/RosterView/AddPilotMenu.vue
+++ b/src/renderer/features/pilot_management/RosterView/AddPilotMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialogModel" width="500">
+  <v-dialog v-model="display" width="500">
     <v-card>
       <v-card-title class="headline grey lighten-2" primary-title>
         Add New Pilot
@@ -98,12 +98,29 @@ export default Vue.extend({
   name: 'add-pilot-menu',
   props: ['dialogModel'],
   data: () => ({
+    display: false,
     cloudDialog: false,
     cloudInfoDialog: false,
     cloudLoading: false,
     shareIDText: '',
     errorText: '',
   }),
+  watch: {
+    dialogModel (val) {
+      if (val) {
+        this.display = true
+      } else {
+        if (this.display) {
+          this.display = false
+        }
+      }
+    },
+    display (val) {
+      if (!val) {
+        this.close()
+      }
+    },
+  },
   methods: {
     close() {
       this.errorText = ''

--- a/src/renderer/features/pilot_management/components/UI/LazyDialog.vue
+++ b/src/renderer/features/pilot_management/components/UI/LazyDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <slot name="activator" @click="activate"></slot>
-    <v-dialog v-model="model" persistent width="80vw">
+    <v-dialog v-model="display" width="80vw">
       <v-card>
         <v-card-title class="title">{{ title }}</v-card-title>
         <slot name="modal-content"></slot>
@@ -36,6 +36,7 @@ export default Vue.extend({
     disableCondition: Boolean,
   },
   data: () => ({
+    display: false,
     loader: false,
   }),
   methods: {
@@ -49,6 +50,18 @@ export default Vue.extend({
     },
     accept() {
       this.$emit('accept'), (this.loader = false)
+    },
+  },
+  watch: {
+    model (val) {
+      if (val) {
+        this.display = true
+      }
+    },
+    display (val) {
+      if (!val) {
+        this.cancel()
+      }
     },
   },
 })

--- a/src/renderer/features/pilot_management/components/UI/LazyDialog.vue
+++ b/src/renderer/features/pilot_management/components/UI/LazyDialog.vue
@@ -56,6 +56,10 @@ export default Vue.extend({
     model (val) {
       if (val) {
         this.display = true
+      } else {
+        if (this.display) {
+          this.display = false
+        }
       }
     },
     display (val) {


### PR DESCRIPTION
Uses bidirectional watch to separate prop from datamodel. 

This way the components can notify parents when they've been dismissed by clicking outside them, without causing Bad Things™ to happen by directly modifying their own props.

Vuetify 2.0 comes with a click:outside event that should obsolete this, from what I've read? 

Should partially take care of #158 and #267 where affected by LazyDialog. Since I spotted it, I also gave the same treatment to AddPilotMenu. There may some more in the GM Toolkit that would need this.

First time touching Vue code, so please tell me if this does something monumentally stupid eh? 