### PR TITLE
Fix weapon mod button.  Not sure what I was thinking.

### DIFF
--- a/src/renderer/features/pilot_management/ConfigSheet/LoadoutEditor/MechWeaponItem.vue
+++ b/src/renderer/features/pilot_management/ConfigSheet/LoadoutEditor/MechWeaponItem.vue
@@ -63,8 +63,7 @@
                   <div slot="activator">
                     <v-btn
                       @click.stop="toggleModModal(true)"
-                      :color="availableMod() ? 'blue-grey lighten-2' : ''"
-                      :disabled="availableMod() ? false : true"
+                      :color="availableMod() ? 'blue-grey lighten-2' : 'white grey--text'"
                       small
                       absolute
                       class="ma-0 pa-0"
@@ -256,6 +255,8 @@ export default Vue.extend({
       const weapon = this.weaponSlot.Weapon
       const allMods = vm.$store.getters.getItemCollection('WeaponMods') as WeaponMod[]
       let i = allMods.filter(x => x.Source)
+      // filter out all unlicensed mods
+      i = i.filter(x => x.Source === 'GMS' || vm.pilot.has('License', x.License, x.LicenseLevel))
       // filter out any mount size restrictions
       i = i.filter(x => !x.Restricted || !x.Restricted.includes(weapon.Size))
       // filter out any weapon type restrictions


### PR DESCRIPTION
<img width="1366" alt="Screen Shot 2019-08-14 at 7 49 12 AM" src="https://user-images.githubusercontent.com/11823614/63019253-c7d4d080-be68-11e9-85fc-238b7b605263.png">

Fixed some issues with the Mod button changes I made.  It now:
- stays active all the time, in case you want to get in there and put a mod on that you shouldn't technically have
- changes colors correctly

I'm guessing @jarena3 you don't care about the styling on it, since you're reworking that.  But if you want me to change anything, let me know.

Screenshot above shows a mount with an eligible mod and the lower slot without an eligible mod.