### PR TITLE
Autofocus input field

### DIFF
--- a/src/renderer/features/pilot_management/RosterView/AddPilotMenu.vue
+++ b/src/renderer/features/pilot_management/RosterView/AddPilotMenu.vue
@@ -27,7 +27,7 @@
               <v-card>
                 <v-card-title class="title">Enter Share ID</v-card-title>
                 <v-card-text>
-                  <v-text-field v-model="shareIDText" label="Share ID" outline clearable />
+                  <v-text-field v-model="shareIDText" label="Share ID" outline clearable autofocus />
                   <span class="effect-text red--text">{{ errorText }}</span>
                 </v-card-text>
                 <v-divider />


### PR DESCRIPTION
The Import Cloud ID field wasn't set to autofocus. It's the only input field available and it's initiated directly by user input, so I think saving a click would be a good idea.