### PR TITLE
Add Biological NPCs

### DIFF
--- a/src/renderer/features/gm_toolkit/vuetify_theme.ts
+++ b/src/renderer/features/gm_toolkit/vuetify_theme.ts
@@ -4,6 +4,7 @@ export default {
   'role--controller': '#398ad6',
   'role--support': '#6aa84f',
   'role--artillery': '#a64d79',
+  'role--biological': '#7e52a3',
 
   'system--weapon': '#cc0000',
   'system--system': '#2aa780',


### PR DESCRIPTION
Adds a role colour for Biological NPCs (Monstrosities and Infantry Squads). Should be pulled at the same time as PR#71 on lancer-data so that these NPCs display properly.