### PR TITLE
Persist active pilot

### DIFF
--- a/src/renderer/features/nav/index.vue
+++ b/src/renderer/features/nav/index.vue
@@ -59,7 +59,7 @@
           </v-btn>
         </template>
         <v-list two-line subheader>
-          <v-list-item to="/active">
+          <v-list-item :to="`/pilot/${pilot.ID}/active`">
             <v-list-item-icon class="ma-0 mr-2 mt-3">
               <v-icon large>cci-activate</v-icon>
             </v-list-item-icon>

--- a/src/renderer/features/nav/index.vue
+++ b/src/renderer/features/nav/index.vue
@@ -138,6 +138,7 @@ import Vue from 'vue'
 // import OptionsPage from './Pages/OptionsPage.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
+import activePilot from '../pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'cc-nav',
@@ -151,12 +152,7 @@ export default Vue.extend({
     helpDialog: false,
     optionsDialog: false,
   }),
-  computed: {
-    pilot() {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
   methods: {
     home() {
       this.$router.push('/')

--- a/src/renderer/features/pilot_management/ActiveSheet/index.vue
+++ b/src/renderer/features/pilot_management/ActiveSheet/index.vue
@@ -15,6 +15,7 @@ import PilotBlock from './layout/PilotBlock.vue'
 import MechBlock from './layout/MechBlock.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
+import activePilot from '../mixins/activePilot'
 
 export default Vue.extend({
   name: 'active-sheet',
@@ -23,11 +24,6 @@ export default Vue.extend({
     PilotBlock,
     MechBlock,
   },
-  computed: {
-    pilot() {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
 })
 </script>

--- a/src/renderer/features/pilot_management/ActiveSheet/index.vue
+++ b/src/renderer/features/pilot_management/ActiveSheet/index.vue
@@ -15,7 +15,7 @@ import PilotBlock from './layout/PilotBlock.vue'
 import MechBlock from './layout/MechBlock.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
-import activePilot from '../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'active-sheet',

--- a/src/renderer/features/pilot_management/Level/index.vue
+++ b/src/renderer/features/pilot_management/Level/index.vue
@@ -59,7 +59,7 @@
         <v-stepper-step
           editable
           :complete="pilot.HasFullCB"
-          :color="pilot.CBEligible ? pilot.HasFullCB ? 'success' : 'primary' : 'grey'"
+          :color="pilot.CBEligible ? (pilot.HasFullCB ? 'success' : 'primary') : 'grey'"
           edit-icon="mdi-check"
           step="6"
         >
@@ -126,8 +126,9 @@ export default Vue.extend({
   }),
   computed: {
     currentPilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
+      return getModule(PilotManagementStore, this.$store).Pilots.find(
+        p => p.ID === this.$route.params.pilotID
+      )
     },
   },
   watch: {

--- a/src/renderer/features/pilot_management/Level/pages/ConfirmPage.vue
+++ b/src/renderer/features/pilot_management/Level/pages/ConfirmPage.vue
@@ -18,23 +18,26 @@
           <span
             class="stat-text white--text"
             style="position: relative; top: 25px; font-size: 95px; line-height: 30px"
-          >{{ pilot.Level }}</span>
+          >
+            {{ pilot.Level }}
+          </span>
         </v-col>
       </v-row>
 
       <v-row class="primary" dense>
-        <span
-          class="flavor-text white--text ml-6"
-        >Union Administrative RM-4 Pilot Identification Protocol (IDENT) Record {{ pilot.ID }}</span>
+        <span class="flavor-text white--text ml-6">
+          Union Administrative RM-4 Pilot Identification Protocol (IDENT) Record {{ pilot.ID }}
+        </span>
       </v-row>
 
       <div class="ml-2">
         <v-row dense>
-          <span v-if="!pilot.Name" class="flavor-text">ERR NAME NOT FOUND UNABLE TO GENERATE UUID</span>
-          <span
-            v-else
-            class="flavor-text"
-          >{{ flipName(pilot.Name) }}:{{ pilot.ID }}//NDL-C-{{ missionName() }}</span>
+          <span v-if="!pilot.Name" class="flavor-text">
+            ERR NAME NOT FOUND UNABLE TO GENERATE UUID
+          </span>
+          <span v-else class="flavor-text">
+            {{ flipName(pilot.Name) }}:{{ pilot.ID }}//NDL-C-{{ missionName() }}
+          </span>
         </v-row>
         <v-row dense>
           <v-col cols="8">
@@ -43,18 +46,21 @@
                 <span class="flavor-text">
                   Callsign:
                   <b class="primary--text">{{ pilot.Callsign }}</b>
-                  <br />Name (or legal alias):
+                  <br />
+                  Name (or legal alias):
                   <b class="primary--text">{{ pilot.Name }}</b>
-                  <br />Background:
-                  <b
-                    class="primary--text"
-                  >{{ pilot.Background || 'PILOT HISTORY NOT REGISTERED' }}</b>
+                  <br />
+                  Background:
+                  <b class="primary--text">
+                    {{ pilot.Background || 'PILOT HISTORY NOT REGISTERED' }}
+                  </b>
                 </span>
               </v-col>
               <v-col>
                 <span class="flavor-text grey--text">
                   CALLSIGN CONFIRMED
-                  <br />IDENTITY VERIFIED
+                  <br />
+                  IDENTITY VERIFIED
                   <br />
                   {{ pilot.Background ? 'PH/HR DATA VALIDATED' : '--' }}
                 </span>
@@ -69,32 +75,31 @@
             <v-row>
               <span class="flavor-text ml-3" style="font-size: 22px; line-height: 15px">
                 [ HULL:
-                <span
-                  class="stat-text primary--text"
-                  style="font-size: 24px"
-                >{{ pilot.MechSkills.Hull }}&emsp;</span> AGI:
-                <span
-                  class="stat-text primary--text"
-                  style="font-size: 24px"
-                >{{ pilot.MechSkills.Agi }}&emsp;</span> SYS:
-                <span
-                  class="stat-text primary--text"
-                  style="font-size: 24px"
-                >{{ pilot.MechSkills.Sys }}&emsp;</span> ENG:
-                <span
-                  class="stat-text primary--text"
-                  style="font-size: 24px"
-                >{{ pilot.MechSkills.Eng }}</span> ]
+                <span class="stat-text primary--text" style="font-size: 24px">
+                  {{ pilot.MechSkills.Hull }}&emsp;
+                </span>
+                AGI:
+                <span class="stat-text primary--text" style="font-size: 24px">
+                  {{ pilot.MechSkills.Agi }}&emsp;
+                </span>
+                SYS:
+                <span class="stat-text primary--text" style="font-size: 24px">
+                  {{ pilot.MechSkills.Sys }}&emsp;
+                </span>
+                ENG:
+                <span class="stat-text primary--text" style="font-size: 24px">
+                  {{ pilot.MechSkills.Eng }}
+                </span>
+                ]
               </span>
             </v-row>
             <v-row class="mt-2" dense>
               <v-col cols="6">
                 <span class="flavor-text">PILOT SKILL TRIGGER AUDIT</span>
                 <br />
-                <span
-                  v-if="!pilot.HasFullSkills"
-                  class="stat-text primary--text"
-                >&nbsp;ERR SKILL AUDIT INCOMPLETE</span>
+                <span v-if="!pilot.HasFullSkills" class="stat-text primary--text">
+                  &nbsp;ERR SKILL AUDIT INCOMPLETE
+                </span>
                 <v-chip
                   v-for="s in pilot.Skills"
                   v-else
@@ -105,16 +110,15 @@
                   label
                 >
                   <v-icon left>cci-trait</v-icon>
-                  {{ s.Skill.Trigger }} {{ "I".repeat(s.Rank) }}
+                  {{ s.Skill.Trigger }} {{ 'I'.repeat(s.Rank) }}
                 </v-chip>
               </v-col>
               <v-col cols="6">
                 <span class="flavor-text">PILOT TALENT AUDIT</span>
                 <br />
-                <span
-                  v-if="!pilot.HasFullTalents"
-                  class="stat-text primary--text"
-                >&nbsp;ERR TALENT AUDIT INCOMPLETE</span>
+                <span v-if="!pilot.HasFullTalents" class="stat-text primary--text">
+                  &nbsp;ERR TALENT AUDIT INCOMPLETE
+                </span>
                 <v-chip
                   v-for="t in pilot.Talents"
                   v-else
@@ -125,16 +129,15 @@
                   label
                 >
                   <v-icon left>cci-trait</v-icon>
-                  {{ t.Talent.Name }} {{ "I".repeat(t.Rank) }}
+                  {{ t.Talent.Name }} {{ 'I'.repeat(t.Rank) }}
                 </v-chip>
               </v-col>
               <v-col cols="6">
                 <span class="flavor-text">LICENSES REGISTERED</span>
                 <br />
-                <span
-                  v-if="!pilot.HasLicenses"
-                  class="stat-text primary--text"
-                >&nbsp;ERR LICENSE REGISTRATION INCOMPLETE</span>
+                <span v-if="!pilot.HasLicenses" class="stat-text primary--text">
+                  &nbsp;ERR LICENSE REGISTRATION INCOMPLETE
+                </span>
                 <v-chip
                   v-for="l in pilot.Licenses"
                   v-else
@@ -145,17 +148,16 @@
                   label
                 >
                   <cc-logo size="small" :source="l.License.Manufacturer" />
-                  &nbsp;{{ l.License.Name }} {{ "I".repeat(l.Rank) }}
+                  &nbsp;{{ l.License.Name }} {{ 'I'.repeat(l.Rank) }}
                 </v-chip>
               </v-col>
 
               <v-col v-if="pilot.CoreBonuses.length" cols="6">
                 <span class="flavor-text">CORE BONUSES REGISTERED</span>
                 <br />
-                <span
-                  v-if="!pilot.HasCBs"
-                  class="stat-text primary--text"
-                >&nbsp;ERR CORE BONUS REGISTRATION INCOMPLETE</span>
+                <span v-if="!pilot.HasCBs" class="stat-text primary--text">
+                  &nbsp;ERR CORE BONUS REGISTRATION INCOMPLETE
+                </span>
                 <v-chip
                   v-for="cb in pilot.CoreBonuses"
                   v-else
@@ -191,10 +193,17 @@
           </v-col>
         </v-row>
         <v-row dense>
-          <span
-            class="overline grey--text text--darken-1"
-            style="line-height: 10px"
-          >Improper use of this IDENT record and/or its constituent data by the record holder or any other persons in punishable under the DoJ/HR A-645-c. This record is the property of the Union Administrative Office and the information herein must be transmitted on request under NDL-C-DISCORDANT-BREATH encryption protocols. This RM-4 record must be updated every five (5) Cradle Standard Years of objective time to retain GMS licensing rights. Far-field operatives that anticipate deployments lasting longer than five Cradle Standard Years that have not been issued a man-portable Omninet Hook should apply for the RM-11-B IDENT Supplimental (b) Extension. Contact your local Union Adminstrative Officer for any other matters regarding this record.&emsp;&emsp;V-CDL//M-265-114-831 (A)</span>
+          <span class="overline grey--text text--darken-1" style="line-height: 10px">
+            Improper use of this IDENT record and/or its constituent data by the record holder or
+            any other persons in punishable under the DoJ/HR A-645-c. This record is the property of
+            the Union Administrative Office and the information herein must be transmitted on
+            request under NDL-C-DISCORDANT-BREATH encryption protocols. This RM-4 record must be
+            updated every five (5) Cradle Standard Years of objective time to retain GMS licensing
+            rights. Far-field operatives that anticipate deployments lasting longer than five Cradle
+            Standard Years that have not been issued a man-portable Omninet Hook should apply for
+            the RM-11-B IDENT Supplimental (b) Extension. Contact your local Union Adminstrative
+            Officer for any other matters regarding this record.&emsp;&emsp;V-CDL//M-265-114-831 (A)
+          </span>
         </v-row>
       </div>
     </v-container>
@@ -206,11 +215,13 @@
       tile
       class="mx-2 my-8"
       @click="savePilot()"
-    >Update Pilot Record // {{ pilot.Callsign }} ({{ pilot.Name }})</v-btn>
+    >
+      Update Pilot Record // {{ pilot.Callsign }} ({{ pilot.Name }})
+    </v-btn>
     <v-alert type="error" outlined :value="!pilotReady">
-      <span
-        class="stat-text primary--text"
-      >WARNING: IDENT record {{ pilot.ID }} cannot be updated due to the following reason(s):</span>
+      <span class="stat-text primary--text">
+        WARNING: IDENT record {{ pilot.ID }} cannot be updated due to the following reason(s):
+      </span>
       <ul class="flavor-text error--text">
         <li v-if="!pilot.Callsign">PILOT CALLSIGN blank or invalid</li>
         <li v-if="!pilot.Name">PILOT NAME blank or invalid</li>
@@ -256,7 +267,7 @@ export default Vue.extend({
   methods: {
     savePilot() {
       this.original.ApplyLevel(Pilot.Serialize(this.pilot))
-      this.$router.push('./pilot')
+      this.$router.push('..')
     },
     flipName(name: string): string {
       const suffixes = ['II', 'III', 'IV', 'V', 'VI', 'VII']

--- a/src/renderer/features/pilot_management/PilotSheet/components/DeletePilotDialog.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/components/DeletePilotDialog.vue
@@ -14,7 +14,7 @@
         ]
         <v-divider class="my-2" />
         <v-row dense>
-          <v-btn small text @click="deleteDialog = false">DENY</v-btn>
+          <v-btn small text @click="dialog = false">DENY</v-btn>
           <cc-btn small color="error" class="ml-auto" @click="remove()">
             CONFIRM
           </cc-btn>

--- a/src/renderer/features/pilot_management/PilotSheet/components/PilotHeader.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/components/PilotHeader.vue
@@ -125,7 +125,7 @@
 import Vue from 'vue'
 import LevelEditDialog from './LevelEditDialog.vue'
 import { Pilot } from '@/class'
-import activePilot from '../../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'pilot-header',

--- a/src/renderer/features/pilot_management/PilotSheet/components/PilotHeader.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/components/PilotHeader.vue
@@ -19,7 +19,7 @@
               </span>
               <br />
               <cc-tooltip simple inline content="Level Up" class="ml-4">
-                <v-icon large dark class="fadeSelect" @click="$router.push('level')">
+                <v-icon large dark class="fadeSelect" @click="$router.push('../level')">
                   mdi-arrow-up-bold-hexagon-outline
                 </v-icon>
               </cc-tooltip>
@@ -124,19 +124,13 @@
 <script lang="ts">
 import Vue from 'vue'
 import LevelEditDialog from './LevelEditDialog.vue'
-import { getModule } from 'vuex-module-decorators'
-import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
+import activePilot from '../../mixins/activePilot'
 
 export default Vue.extend({
   name: 'pilot-header',
   components: { LevelEditDialog },
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
 })
 </script>
 

--- a/src/renderer/features/pilot_management/PilotSheet/components/PilotNav.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/components/PilotNav.vue
@@ -6,7 +6,7 @@
       depressed
       :color="selected === '0' ? 'white' : 'primary'"
       :dark="selected !== '0'"
-      to="/sheet/0"
+      to="../sheet/0"
     >
       <span class="unskew">DOSSIER</span>
     </v-btn>
@@ -15,7 +15,7 @@
       depressed
       :color="selected === '1' ? 'white' : 'primary'"
       :dark="selected !== '1'"
-      to="/sheet/1"
+      to="../sheet/1"
     >
       <span class="unskew">NARRATIVE PROFILE</span>
     </v-btn>
@@ -24,7 +24,7 @@
       depressed
       :color="selected === '2' ? 'white' : 'primary'"
       :dark="selected !== '2'"
-      to="/sheet/2"
+      to="../sheet/2"
     >
       <span class="unskew">TACTICAL PROFILE</span>
     </v-btn>
@@ -33,7 +33,7 @@
       depressed
       :color="selected === '3' ? 'white' : 'primary'"
       :dark="selected !== '3'"
-      to="/sheet/3"
+      to="../sheet/3"
     >
       <span class="unskew">MECH HANGAR</span>
     </v-btn>
@@ -224,7 +224,7 @@ export default Vue.extend({
   },
   methods: {
     toMech() {
-      this.$router.push(`../mech/${this.pilot.ID}/${this.lastLoaded}`)
+      this.$router.push(`../mech/${this.lastLoaded}`)
     },
     deletePilot() {
       this.$router.push('/pilot_management')

--- a/src/renderer/features/pilot_management/PilotSheet/components/PrintDialog.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/components/PrintDialog.vue
@@ -3,9 +3,10 @@
     <v-card-text>
       <span class="flavor-text">A flavorful description...</span>
       <v-select
-        v-model="mechSelect"
+        v-model="selectedMechID"
         :items="pilot.Mechs"
         item-text="Name"
+        item-value="ID"
         label="Include Mech (optional)"
         outlined
         clearable
@@ -37,10 +38,10 @@ export default Vue.extend({
     },
   },
   data: () => ({
-    mechSelect: null,
+    selectedMechID: null,
   }),
   created() {
-    if (this.pilot.ActiveMech) this.mechSelect = this.pilot.ActiveMech
+    if (this.pilot.ActiveMech) this.selectedMechID = this.pilot.ActiveMech.ID
   },
   methods: {
     show() {
@@ -50,10 +51,10 @@ export default Vue.extend({
       this.$refs.dialog.hide()
     },
     print() {
-      this.$router.push(`../print/${this.pilot.ID}/${this.mechSelect.ID}`)
+      this.$router.push(`/print/${this.pilot.ID}/${this.selectedMechID}`)
     },
     printBlank() {
-      this.$router.push(`../print/blank/blank`)
+      this.$router.push(`/print/blank/blank`)
     },
   },
 })

--- a/src/renderer/features/pilot_management/PilotSheet/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/index.vue
@@ -1,17 +1,33 @@
 <template>
   <v-container fluid class="mt-7">
-    <pilot-header />
-    <router-view></router-view>
-    <v-spacer style="min-height: 80px" />
+    <template v-if="pilot">
+      <pilot-header />
+      <router-view></router-view>
+      <v-spacer style="min-height: 80px" />
+    </template>
+    <template v-else>
+      <!-- TODO: make this look fancy -->
+      <h1 style="margin-top: 50px; text-align: center">ERROR // INVALID PILOT</h1>
+    </template>
   </v-container>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 import PilotHeader from './components/PilotHeader.vue'
+import { PilotManagementStore } from '../store'
+import { getModule } from 'vuex-module-decorators'
+import activePilot from '../mixins/activePilot'
 
 export default Vue.extend({
   name: 'pilot-sheet',
   components: { PilotHeader },
+  props: {
+    pilotID: {
+      type: String,
+      required: true,
+    },
+  },
+  mixins: [activePilot],
 })
 </script>

--- a/src/renderer/features/pilot_management/PilotSheet/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/index.vue
@@ -17,7 +17,7 @@ import Vue from 'vue'
 import PilotHeader from './components/PilotHeader.vue'
 import { PilotManagementStore } from '../store'
 import { getModule } from 'vuex-module-decorators'
-import activePilot from '../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'pilot-sheet',

--- a/src/renderer/features/pilot_management/PilotSheet/layouts/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/layouts/index.vue
@@ -24,14 +24,17 @@ export default Vue.extend({
       type: String,
       required: true,
     },
+    pilotID: {
+      type: String,
+      required: true,
+    },
   },
   data: () => ({
     page: 1,
   }),
   computed: {
     pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
+      return this.$store.state.management.Pilots.find(p => p.ID === this.pilotID)
     },
     profile(): UserProfile {
       const store = getModule(CompendiumStore, this.$store)

--- a/src/renderer/features/pilot_management/PilotSheet/sections/hangar/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/hangar/index.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
     toMechSheet(mech) {
       const store = getModule(PilotManagementStore, this.$store)
       store.setLoadedMech(mech.ID)
-      this.$router.push(`../mech/${this.pilot.ID}/${mech.ID}`)
+      this.$router.push(`../mech/${mech.ID}`)
     },
   },
 })

--- a/src/renderer/features/pilot_management/PilotSheet/sections/hangar/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/hangar/index.vue
@@ -67,11 +67,13 @@ import { UserProfile } from '@/io/User'
 export default Vue.extend({
   name: 'mech-hangar-view',
   components: { MechCard, MechListItem, MechTable, NewMechMenu },
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
+  props: {
+    pilot: {
+      type: Pilot,
+      required: true,
     },
+  },
+  computed: {
     profile(): UserProfile {
       const store = getModule(CompendiumStore, this.$store)
       return store.UserProfile

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
@@ -32,6 +32,7 @@ import NoDataBlock from '../../components/NoDataBlock.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'appearance-block',
@@ -39,12 +40,7 @@ export default Vue.extend({
   data: () => ({
     appearance: '',
   }),
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
   created() {
     this.appearance = this.pilot.TextAppearance || ''
   },

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
@@ -28,6 +28,7 @@ import NoDataBlock from '../../components/NoDataBlock.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'history-block',
@@ -35,12 +36,7 @@ export default Vue.extend({
   data: () => ({
     history: '',
   }),
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
   created() {
     this.history = this.pilot.History || ''
   },

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -3,7 +3,9 @@
     <v-row class="stat-text pt-0 pb-0">
       <v-col class="pt-0">
         <span class="overline">CALLSIGN</span>
-        <cc-short-string-editor @set="pilot.Callsign = $event">{{ pilot.Callsign }}</cc-short-string-editor>
+        <cc-short-string-editor @set="pilot.Callsign = $event">
+          {{ pilot.Callsign }}
+        </cc-short-string-editor>
       </v-col>
       <v-col class="pt-0">
         <span class="overline">NAME</span>
@@ -12,10 +14,9 @@
       <v-col class="pt-0">
         <span class="overline">BACKGROUND</span>
         <br />
-        <cc-short-string-editor
-          class="d-inline"
-          @set="pilot.Background = $event"
-        >{{ pilot.Background }}</cc-short-string-editor>
+        <cc-short-string-editor class="d-inline" @set="pilot.Background = $event">
+          {{ pilot.Background }}
+        </cc-short-string-editor>
         <span>
           <cc-background-selector
             :pilot="pilot"
@@ -54,13 +55,26 @@
     <v-row class="stat-text pt-0 mt-n3">
       <v-col class="pt-0" dense>
         <span class="overline">PLAYER</span>
-        <cc-short-string-editor @set="pilot.PlayerName = $event">{{ pilot.PlayerName || '---' }}</cc-short-string-editor>
+        <cc-short-string-editor @set="pilot.PlayerName = $event">
+          {{ pilot.PlayerName || '---' }}
+        </cc-short-string-editor>
       </v-col>
       <v-col class="pt-0" dense>
         <span class="overline">FACTION</span>
-        <br />---
+        <br />
+        ---
         <cc-tooltip simple inline content="Feature In Development">
-          <v-icon small class="fadeSelect" @click="''">mdi-circle-edit-outline</v-icon>
+          <v-icon
+            small
+            class="fadeSelect"
+            @click="
+              ''
+
+
+            "
+          >
+            mdi-circle-edit-outline
+          </v-icon>
         </cc-tooltip>
       </v-col>
       <v-col class="pt-0" dense>
@@ -81,6 +95,7 @@ import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import ExtLog from '@/io/ExtLog'
+import activePilot from '../../../../mixins/activePilot'
 
 export default Vue.extend({
   name: 'ident-block',
@@ -98,12 +113,7 @@ export default Vue.extend({
     notification: '',
     syncing: false,
   }),
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
   methods: {
     statusColor(): string {
       switch (this.pilot.Status.toLowerCase()) {

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -95,7 +95,7 @@ import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import ExtLog from '@/io/ExtLog'
-import activePilot from '../../../../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'ident-block',

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
@@ -27,7 +27,7 @@ import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
-import activePilot from '../../../../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'history-block',

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
@@ -27,14 +27,10 @@ import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
+import activePilot from '../../../../mixins/activePilot'
 
 export default Vue.extend({
   name: 'history-block',
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
 })
 </script>

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
@@ -13,7 +13,7 @@ import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
-import activePilot from '../../../../mixins/activePilot'
+import activePilot from '@/features/pilot_management/mixins/activePilot'
 
 export default Vue.extend({
   name: 'notes-block',

--- a/src/renderer/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
@@ -13,14 +13,10 @@ import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
+import activePilot from '../../../../mixins/activePilot'
 
 export default Vue.extend({
   name: 'notes-block',
-  computed: {
-    pilot(): Pilot {
-      const store = getModule(PilotManagementStore, this.$store)
-      return store.ActivePilot
-    },
-  },
+  mixins: [activePilot],
 })
 </script>

--- a/src/renderer/features/pilot_management/PilotSheet/sections/mech/index.vue
+++ b/src/renderer/features/pilot_management/PilotSheet/sections/mech/index.vue
@@ -116,6 +116,8 @@ import AttributesBlock from './sections/attributes/index.vue'
 import DeleteMechDialog from '../hangar/components/DeleteMechDialog.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
+import Pilot from '../../../../../classes/pilot/Pilot'
+import Mech from '../../../../../classes/mech/Mech'
 
 export default Vue.extend({
   name: 'mech-sheet',
@@ -138,16 +140,16 @@ export default Vue.extend({
       required: true,
     },
   },
-  data: () => ({
-    pilot: {},
-    mech: {},
-    color: '#000',
-  }),
-  created() {
-    const store = getModule(PilotManagementStore, this.$store)
-    this.pilot = store.ActivePilot
-    this.mech = store.ActivePilot.Mechs.find(x => x.ID === this.mechID)
-    this.color = this.mech.Frame.Manufacturer.Color
+  computed: {
+    pilot(): Pilot {
+      return this.$store.state.management.Pilots.find(p => p.ID === this.pilotID)
+    },
+    mech(): Mech {
+      return this.pilot.Mechs.find((m: Mech) => m.ID === this.mechID)
+    },
+    color() {
+      return this.mech.Frame.Manufacturer.Color
+    },
   },
   methods: {
     deleteMech() {

--- a/src/renderer/features/pilot_management/Print/PilotPrint.vue
+++ b/src/renderer/features/pilot_management/Print/PilotPrint.vue
@@ -222,15 +222,23 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { getModule } from 'vuex-module-decorators'
+import { PilotManagementStore } from '../store'
+import Pilot from '../../../classes/pilot/Pilot'
 
 export default Vue.extend({
   name: 'pilot-print-view',
-  props: {
-    pilot: {
-      type: Object,
-      required: true,
+  computed: {
+    pilot() {
+      return getModule(PilotManagementStore, this.$store)
+      .Pilots
+      .find(p => p.ID === this.$route.params.pilotID)
     },
-  },
+    mech() {
+      return (this.pilot as Pilot).Mechs
+      .find(m => m.ID === this.$route.params.mechID)
+    }
+  }
 })
 </script>
 

--- a/src/renderer/features/pilot_management/Print/index.vue
+++ b/src/renderer/features/pilot_management/Print/index.vue
@@ -43,12 +43,6 @@ export default Vue.extend({
   created() {
     if (this.pilotID === 'blank') {
       this.blank = true
-    } else {
-      const store = getModule(PilotManagementStore, this.$store)
-      this.pilot = store.ActivePilot
-      if (this.mechID) {
-        this.mech = store.ActivePilot.Mechs.find(x => x.ID === this.mechID)
-      }
     }
   },
 })

--- a/src/renderer/features/pilot_management/Roster/components/PilotListItem.vue
+++ b/src/renderer/features/pilot_management/Roster/components/PilotListItem.vue
@@ -86,9 +86,7 @@ export default Vue.extend({
   },
   methods: {
     toPilotSheet() {
-      const store = getModule(PilotManagementStore, this.$store)
-      store.loadPilot(this.pilot)
-      this.$router.push('pilot')
+      this.$router.push(`pilot/${this.pilot.ID}`)
     },
     statusColor(status: string): string {
       switch (status.toLowerCase()) {

--- a/src/renderer/features/pilot_management/Roster/components/PilotTable.vue
+++ b/src/renderer/features/pilot_management/Roster/components/PilotTable.vue
@@ -56,10 +56,8 @@ export default Vue.extend({
     },
   },
   methods: {
-    toPilotSheet(pilot: Pilot) {
-      const store = getModule(PilotManagementStore, this.$store)
-      store.loadPilot(pilot)
-      this.$router.push('pilot')
+    toPilotSheet() {
+      this.$router.push(`pilot/${this.pilot.ID}`)
     },
     statusColor(status: string): string {
       switch (status.toLowerCase()) {

--- a/src/renderer/features/pilot_management/index.vue
+++ b/src/renderer/features/pilot_management/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="wrapper">
-    <cc-nav pilot />
+    <cc-nav pilot-management />
     <v-fade-transition leave-absolute>
       <router-view />
     </v-fade-transition>

--- a/src/renderer/features/pilot_management/mixins/activePilot.ts
+++ b/src/renderer/features/pilot_management/mixins/activePilot.ts
@@ -1,0 +1,12 @@
+import { getModule } from 'vuex-module-decorators'
+import { PilotManagementStore } from '@/store'
+
+export default {
+  computed: {
+    pilot() {
+      return getModule(PilotManagementStore, this.$store).Pilots.find(
+        p => p.ID === this.$route.params.pilotID
+      )
+    },
+  },
+}

--- a/src/renderer/features/pilot_management/store/index.ts
+++ b/src/renderer/features/pilot_management/store/index.ts
@@ -31,21 +31,7 @@ export class PilotManagementStore extends VuexModule {
 
   @Mutation
   private [SAVE_DATA](): void {
-    if (this.Pilots.length) _.debounce(savePilots, 300)(this.Pilots)
-  }
-
-  @Mutation
-  private [SET_PILOT](payload: Pilot): void {
-    this.ActivePilot = payload
-  }
-
-  @Mutation
-  private [UPDATE_PILOT](payload: Pilot): void {
-    const index = this.Pilots.findIndex(x => x.ID === this.ActivePilot.ID)
-    if (index > -1) {
-      Vue.set(this.Pilots, index, payload)
-      this.ActivePilot = payload
-    }
+    if (this.Pilots.length) _.debounce(savePilots, 1000)(this.Pilots)
   }
 
   @Mutation
@@ -53,7 +39,7 @@ export class PilotManagementStore extends VuexModule {
     // TODO: bring back validator?
     // should maybe validate in the action instead of the mutator...
     // this.Pilots = validator.checkVersion(payload).map(x => Pilot.Deserialize(x))
-    this.Pilots = payload.map(x => Pilot.Deserialize(x))
+    this.Pilots = [...payload.map(x => Pilot.Deserialize(x))]
     savePilots(this.Pilots)
   }
 
@@ -108,16 +94,6 @@ export class PilotManagementStore extends VuexModule {
   public async loadPilots() {
     const pilotData = await loadData<IPilotData>('pilots.json')
     this.context.commit(LOAD_PILOTS, pilotData)
-  }
-
-  @Action
-  public loadPilot(pilot: Pilot): void {
-    this.context.commit(SET_PILOT, pilot)
-  }
-
-  @Action
-  public updatePilot(payload: Pilot): void {
-    this.context.commit(UPDATE_PILOT, payload)
   }
 
   @Action

--- a/src/renderer/router.ts
+++ b/src/renderer/router.ts
@@ -34,43 +34,44 @@ export default new Router({
           props: true,
         },
         {
-          path: '/pilot',
+          path: '/pilot/:pilotID',
           component: require('@/features/pilot_management/PilotSheet/index').default,
+          props: true,
           children: [
             {
               name: 'pilot_sheet',
               path: '',
-              redirect: '/sheet/1',
+              redirect: 'sheet/1',
             },
             {
               name: 'mech_hangar',
               path: '',
-              redirect: '/sheet/3',
+              redirect: 'sheet/3',
             },
             {
-              path: '/sheet/:tab',
+              path: 'sheet/:tab',
               component: require('@/features/pilot_management/PilotSheet/layouts/index').default,
               props: true,
             },
             {
-              path: '/mech/:pilotID/:mechID',
+              path: 'mech/:mechID',
               component: require('@/features/pilot_management/PilotSheet/sections/mech/index')
                 .default,
               props: true,
+            },
+            {
+              path: 'level',
+              component: require('@/features/pilot_management/Level/index').default,
+            },
+            {
+              path: 'active',
+              component: require('@/features/pilot_management/ActiveSheet/index').default,
             },
           ],
         },
         {
           path: '/new',
           component: require('@/features/pilot_management/New/index').default,
-        },
-        {
-          path: '/level',
-          component: require('@/features/pilot_management/Level/index').default,
-        },
-        {
-          path: '/active',
-          component: require('@/features/pilot_management/ActiveSheet/index').default,
         },
         {
           path: '/compendium',

--- a/src/renderer/ui/components/selectors/CCLicenseSelector.vue
+++ b/src/renderer/ui/components/selectors/CCLicenseSelector.vue
@@ -16,21 +16,21 @@
           icon="check_circle"
           class="stat-text"
           :value="!pilot.IsMissingLicenses"
-        >License Selection Complete</v-alert>
+        >
+          License Selection Complete
+        </v-alert>
         <v-alert
           outlined
           color="primary"
           icon="warning"
           class="stat-text"
           :value="pilot.IsMissingLicenses"
-        >{{ pilot.CurrentLicensePoints }} / {{ pilot.MaxLicensePoints }} Licenses selected</v-alert>
-        <v-btn
-          block
-          text
-          small
-          :disabled="!pilot.Licenses.length"
-          @click="pilot.ClearLicenses()"
-        >Reset</v-btn>
+        >
+          {{ pilot.CurrentLicensePoints }} / {{ pilot.MaxLicensePoints }} Licenses selected
+        </v-alert>
+        <v-btn block text small :disabled="!pilot.Licenses.length" @click="pilot.ClearLicenses()">
+          Reset
+        </v-btn>
       </v-row>
     </template>
 
@@ -38,7 +38,7 @@
       <v-row v-for="m in Object.keys(licenses)" :key="m">
         <v-col class="text-center pa-3">
           <span class="heading mech" :style="`color: ${manufacturer(m).color}`">
-            <cc-logo :source="m" size="xLarge" class="pt-4" />
+            <cc-logo :source="manufacturer(m)" size="xLarge" class="pt-4" />
             {{ manufacturer(m).name }}
           </span>
           <v-expansion-panels accordion focusable active-class="border-primary">


### PR DESCRIPTION
This PR does away with the "ActivePilot" property in the pilot management store & instead encodes that information into the route URL for browser refresh compatibility.

To make the code less repetitive I also added an `activePilot` mixin under `pilot_management`, which automatically uses the `:pilotID` route param to grab the corresponding pilot object from the store and stores it as the `pilot` variable on the component.

Since this involved restructuring the routes a bit, a lot of router link paths had to be adjusted. I almost definitely missed some which will now lead to invalid paths, so keep an eye out.