### PR TITLE
add two more ordinal values for loadouts.

### DIFF
--- a/src/renderer/features/_shared/classes/Loadout.ts
+++ b/src/renderer/features/_shared/classes/Loadout.ts
@@ -11,6 +11,8 @@ const ordArr = [
   'Octonary',
   'Nonary',
   'Denary',
+  'Undenary',
+  'Duodenary',
 ]
 
 abstract class Loadout {

--- a/src/renderer/features/_shared/classes/Loadout.ts
+++ b/src/renderer/features/_shared/classes/Loadout.ts
@@ -10,7 +10,7 @@ const ordArr = [
   'Septenary',
   'Octonary',
   'Nonary',
-  'Denary',
+  'Decenary',
   'Undenary',
   'Duodenary',
 ]


### PR DESCRIPTION
Add to more ordinal name values for Loadouts, based on wikipedia: https://en.wikipedia.org/wiki/Ordinal_numeral
So now it works up to twelve loadouts.