### PR TITLE
Add confirmation dialog when leaving pilot wizard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app id="app">
     <!-- <global-snackbar /> -->
+    <global-confirm ref="confirm" />
     <nav />
     <v-slide-x-transition mode="out-in">
       <router-view />
@@ -11,27 +12,33 @@
 <script lang="ts">
 import Vue from 'vue'
 // import GlobalSnackbar from './UI/GlobalSnackbar.vue'
+import GlobalConfirm from '@/ui/GlobalConfirm.vue'
 
 export default Vue.extend({
   name: 'compcon',
-  // components: { GlobalSnackbar },
+  components: { 
+    // GlobalSnackbar,
+    GlobalConfirm,
+  },
   mounted() {
-    const vm = this as any
-    vm.$mousetrap.bind('g r', () => {
+    this.$mousetrap.bind('g r', () => {
       this.$router.push('/pilot_management')
     })
-    vm.$mousetrap.bind('g h', () => {
+    this.$mousetrap.bind('g h', () => {
       this.$router.push('/hangar')
     })
-    vm.$mousetrap.bind('g c', () => {
+    this.$mousetrap.bind('g c', () => {
       this.$router.push('/compendium')
     })
-    vm.$mousetrap.bind(['ctrl+left', 'backspace'], () => {
+    this.$mousetrap.bind(['ctrl+left', 'backspace'], () => {
       this.$router.go(-1)
     })
-    vm.$mousetrap.bind('ctrl+right', () => {
+    this.$mousetrap.bind('ctrl+right', () => {
       this.$router.go(1)
     })
+
+    Vue.prototype.$confirm = this.$refs.confirm.open
+
   },
 })
 </script>

--- a/src/features/pilot_management/New/index.vue
+++ b/src/features/pilot_management/New/index.vue
@@ -93,5 +93,16 @@ export default Vue.extend({
   created() {
     this.pilot = new Pilot()
   },
+  async beforeRouteLeave(to, from, next) {
+
+    const confirmLeave = await this.$confirm(
+      'Exit wizard?',
+      'Are you sure you want to exit the wizard? Your pilot will be discarded.'
+    )
+
+    if (confirmLeave) next()
+    else next(false)
+
+  }
 })
 </script>

--- a/src/ui/GlobalConfirm.vue
+++ b/src/ui/GlobalConfirm.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    :max-width="options.width"
+    :style="{ zIndex: options.zIndex }"
+    @keydown.esc="cancel"
+  >
+    <v-card>
+      <v-toolbar dark :color="options.color" dense flat>
+        <v-toolbar-title class="white--text">{{ title }}</v-toolbar-title>
+      </v-toolbar>
+      <v-card-text v-show="!!message" class="pa-4">{{ message }}</v-card-text>
+      <v-card-actions class="pt-0">
+        <v-spacer></v-spacer>
+        <v-btn color="primary darken-1" text @click.native="agree">Yes</v-btn>
+        <v-btn color="grey" text @click.native="cancel">Cancel</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+
+@Component
+export default class CCConfirmDialog extends Vue {
+  private dialog = false
+  private resolve = null
+  private reject = null
+  private message = null
+  private title = null
+
+  private options = {
+    color: 'primary',
+    width: 500,
+    zIndex: 200
+  }
+
+  open(title: string, message: string, options: {
+    color?: string,
+    width?: number,
+    zIndex?: number
+  } = {}) {
+    this.dialog = true
+    this.title = title
+    this.message = message
+    this.options = Object.assign({}, this.options, options)
+    return new Promise((resolve, reject) => {
+      this.resolve = resolve
+      this.reject = reject
+    })
+  }
+
+  agree() {
+    this.resolve(true)
+    this.dialog = false
+  }
+  
+  cancel() {
+    this.resolve(false)
+    this.dialog = false
+  }
+
+}
+</script>


### PR DESCRIPTION
- Adds a confirm dialog that can be called from any component with `this.$confirm(...)` (returns a boolean promise)
- Adds a navigation guard for the pilot wizard that warns the user their in-progress pilot will be lost.