### PR TITLE
Fix empty slots allowing selection in Active Mode

### DIFF
--- a/src/ui/components/panels/loadout/mech_loadout/components/_SlotCardBase.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/_SlotCardBase.vue
@@ -31,8 +31,11 @@
             <div
               v-else
               class="py-3 text-center fadeSelect"
-              style="cursor: pointer; height: 100%"
-              @click="$refs.selectorDialog.show()"
+              style="height: 100%"
+              :style="{
+                cursor: readonly ? 'inherit' : 'pointer',
+              }"
+              @click="if (!readonly) $refs.selectorDialog.show()"
             >
               <v-row style="height: 100%">
                 <span class="heading h2 grey--text my-auto" style="width: 100%; ">// EMPTY //</span>
@@ -73,6 +76,10 @@ export default Vue.extend({
       type: Object,
       required: false,
       default: null,
+    },
+    readonly: {
+      type: Boolean,
+      default: false
     },
   },
 })

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <slot-card-base ref="base" :item="item">
+    <slot-card-base ref="base" :item="item" :readonly="readonly">
       <div slot="header">
         <span v-if="item">
           <equipment-options :item="item" />


### PR DESCRIPTION
In Active Mode, empty weapon slots let you select a weapon by clicking on the "EMPTY" text. Bit of an edge case since you should never be in a mission with empty weapon slots, but might as well take care of it