### PR TITLE
More pilot wizard fixes

### DIFF
--- a/src/features/pilot_management/New/pages/ConfirmPage.vue
+++ b/src/features/pilot_management/New/pages/ConfirmPage.vue
@@ -1,6 +1,6 @@
 <template>
   <cc-stepper-content
-    :complete="canContinue"
+    :complete="pilotReady"
     exit="pilot_management"
     back
     no-confirm

--- a/src/ui/components/selectors/CCMechSkillsSelector.vue
+++ b/src/ui/components/selectors/CCMechSkillsSelector.vue
@@ -209,6 +209,11 @@ export default Vue.extend({
   props: {
     pilot: Pilot,
   },
+  watch: {
+    'pilot.IsMissingHASE': function (newVal) {
+      if (newVal === false) window.scrollTo(0, document.body.scrollHeight)
+    }
+  },
   methods: {
     add(field: HASE) {
       this.pilot.MechSkills.Increment(field)
@@ -219,7 +224,7 @@ export default Vue.extend({
     close() {
       this.$emit('close')
     },
-  },
+  }
 })
 </script>
 

--- a/src/ui/components/selectors/CCTalentSelector.vue
+++ b/src/ui/components/selectors/CCTalentSelector.vue
@@ -20,22 +20,30 @@
           icon="check_circle"
           class="stat-text"
           :value="!pilot.IsMissingTalents && enoughSelections"
-        >Talent Selection Complete</v-alert>
+        >
+          Talent Selection Complete
+        </v-alert>
         <v-alert
           outlined
           color="primary"
           icon="warning"
           class="stat-text"
           :value="pilot.MaxTalentPoints > pilot.CurrentTalentPoints"
-        >{{ pilot.MaxTalentPoints - pilot.CurrentTalentPoints }} Talent selections remaining</v-alert>
+        >
+          {{ pilot.MaxTalentPoints - pilot.CurrentTalentPoints }} Talent selections remaining
+        </v-alert>
         <v-alert
           outlined
           color="primary"
           icon="warning"
           class="stat-text"
           :value="!enoughSelections"
-        >Must select a minimum of {{ selectedMin }} talents</v-alert>
-        <v-btn block text small :disabled="!talents.length" @click="pilot.ClearTalents()">Reset</v-btn>
+        >
+          Must select a minimum of {{ selectedMin }} talents
+        </v-alert>
+        <v-btn block text small :disabled="!talents.length" @click="pilot.ClearTalents()">
+          Reset
+        </v-btn>
       </v-row>
     </template>
 
@@ -61,7 +69,7 @@ import MissingItem from './components/_MissingItem.vue'
 import TalentSelectItem from './components/_TalentSelectItem.vue'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
-import { Pilot } from '@/class'
+import { Pilot, Talent } from '@/class'
 import { rules } from 'lancer-data'
 
 export default Vue.extend({
@@ -71,9 +79,6 @@ export default Vue.extend({
     pilot: Pilot,
     levelUp: Boolean,
   },
-  data: () => ({
-    talents: [],
-  }),
   computed: {
     newPilot(): boolean {
       return this.pilot.Level === 0
@@ -87,15 +92,15 @@ export default Vue.extend({
     selectionComplete(): boolean {
       return (this.newPilot || this.levelUp) && !this.pilot.IsMissingTalents
     },
+    talents(): Talent[] {
+      const compendium = getModule(CompendiumStore, this.$store)
+      return compendium.Talents
+    }
   },
   watch: {
     selectionComplete() {
       window.scrollTo(0, document.body.scrollHeight)
     },
-  },
-  created() {
-    const compendium = getModule(CompendiumStore, this.$store)
-    this.talents = compendium.Talents
   },
 })
 </script>

--- a/src/ui/components/selectors/components/_TalentSelectItem.vue
+++ b/src/ui/components/selectors/components/_TalentSelectItem.vue
@@ -9,83 +9,40 @@
     <v-stepper v-model="step" non-linear class="elevation-0 mt-n1">
       <v-stepper-header style="height: 50px" class="elevation-0">
         <v-stepper-step
-          step="I"
-          :complete="pilotRank >= 1"
-          complete-icon="cci-rank-1"
-          edit-icon="cci-rank-1"
+          v-for="i in 3"
+          :key="i"
+          :step="'I'.repeat(i)"
+          :complete="pilotRank >= i"
+          :complete-icon="`cci-rank-${i}`"
+          :edit-icon="`cci-rank-${i}`"
           editable
-        >{{ talent.Ranks[0].name }}</v-stepper-step>
-        <v-stepper-step
-          step="II"
-          :complete="pilotRank >= 2"
-          complete-icon="cci-rank-2"
-          edit-icon="cci-rank-2"
-          editable
-        >{{ talent.Ranks[1].name }}</v-stepper-step>
-        <v-stepper-step
-          step="III"
-          :complete="pilotRank === 3"
-          complete-icon="cci-rank-3"
-          edit-icon="cci-rank-3"
-          editable
-        >{{ talent.Ranks[2].name }}</v-stepper-step>
+        >
+          {{ talent.Ranks[i - 1].name }}
+        </v-stepper-step>
       </v-stepper-header>
 
       <v-stepper-items>
-        <v-stepper-content step="I" class="py-0 mt-n4">
+        <v-stepper-content v-for="i in 3" :key="i" :step="'I'.repeat(i)" class="py-0 mt-n4">
           <cc-talent-rank-item
-            :lock="pilotRank < 1"
-            :rank="1"
-            :description="talent.Ranks[0].description"
+            :lock="pilotRank < i"
+            :rank="i"
+            :description="talent.Ranks[i - 1].description"
           />
-          <v-btn v-if="!pilotRank" block outlined color="secondary" @click="add()">
+          <v-btn
+            v-if="pilotRank < i"
+            block
+            :disabled="!available || (newPilot && i > 1)"
+            outlined
+            color="secondary"
+            @click="add()"
+          >
             <v-icon left>cci-accuracy</v-icon>
-            Unlock {{ talent.Name }}: {{ talent.Ranks[0].name }}
+            Unlock {{ talent.Name }}: {{ talent.Ranks[i - 1].name }}
           </v-btn>
-          <v-btn v-else-if="pilotRank >= 1" block outlined color="error" @click="$emit('remove')">
+          <v-btn v-else block outlined color="error" @click="remove()">
             <v-icon left>cci-difficulty</v-icon>
-            Unlearn {{ talent.Name }}: {{ talent.Ranks[0].name }}
+            Unlearn {{ talent.Name }}: {{ talent.Ranks[i - 1].name }}
           </v-btn>
-        </v-stepper-content>
-        <v-stepper-content step="II" class="py-0 mt-n4">
-          <cc-talent-rank-item
-            :lock="pilotRank < 2"
-            :rank="2"
-            :description="talent.Ranks[1].description"
-          />
-          <div v-if="pilotRank >= 1">
-            <v-btn v-if="pilotRank === 1" block outlined color="secondary" @click="add()">
-              <v-icon left>cci-accuracy</v-icon>
-              Unlock {{ talent.Name }}: {{ talent.Ranks[1].name }}
-            </v-btn>
-            <v-btn v-else-if="pilotRank >= 2" block outlined color="error" @click="$emit('remove')">
-              <v-icon left>cci-difficulty</v-icon>
-              Unlearn {{ talent.Name }}: {{ talent.Ranks[1].name }}
-            </v-btn>
-          </div>
-        </v-stepper-content>
-        <v-stepper-content step="III" class="py-0 mt-n4">
-          <cc-talent-rank-item
-            :lock="pilotRank < 3"
-            :rank="3"
-            :description="talent.Ranks[2].description"
-          />
-          <div v-if="pilotRank >= 2">
-            <v-btn v-if="pilotRank === 2" block outlined color="secondary" @click="add()">
-              <v-icon left>cci-accuracy</v-icon>
-              Unlock {{ talent.Name }}: {{ talent.Ranks[2].name }}
-            </v-btn>
-            <v-btn
-              v-else-if="pilotRank === 3"
-              block
-              outlined
-              color="error"
-              @click="$emit('remove')"
-            >
-              <v-icon left>cci-difficulty</v-icon>
-              Unlearn {{ talent.Name }}: {{ talent.Ranks[1].name }}
-            </v-btn>
-          </div>
         </v-stepper-content>
       </v-stepper-items>
     </v-stepper>
@@ -110,6 +67,10 @@ export default Vue.extend({
       type: Boolean,
       required: false,
     },
+    available: {
+      type: Boolean,
+      default: true
+    }
   },
   data: () => ({
     step: 'I',


### PR DESCRIPTION
- Fixes bug where the talent selector allowed for selecting talents past
maximum. Also cleans up repeated code in CCTalentSelector and _TalentSelectItem.
- Stepper content in ConfirmPage was using a nonexistent canContinue value
for its complete prop. Change it to pilotReady.
- Makes it so CCMechSkillsSelector scrolls to bottom of the screen once
all selections have been made, like other selectors do.