### PR TITLE
Homebrew fixes

### DIFF
--- a/src/classes/ContentPack.ts
+++ b/src/classes/ContentPack.ts
@@ -1,4 +1,6 @@
-import { Manufacturer, CoreBonus, Frame, MechWeapon, MechSystem, WeaponMod, PilotGear, Talent, Tag, NpcClass, NpcTemplate, NpcFeature, NpcWeapon, NpcReaction, NpcTrait, NpcSystem, NpcTech } from '@/class'
+import { mapValues } from 'lodash'
+
+import { Manufacturer, CoreBonus, Frame, MechWeapon, MechSystem, WeaponMod, PilotGear, Talent, Tag, NpcClass, NpcTemplate, NpcFeature, NpcWeapon, NpcReaction, NpcTrait, NpcSystem, NpcTech, CompendiumItem } from '@/class'
 import { IManufacturerData, ICoreBonusData, IFrameData, IMechWeaponData, IMechSystemData, IWeaponModData, IPilotEquipmentData, ITalentData, INpcClassData, INpcFeatureData, INpcTemplateData,
   INpcWeaponData, INpcReactionData, INpcSystemData, INpcTechData } from '@/interface'
 
@@ -98,7 +100,7 @@ export class ContentPack {
 
     this._active = active
     this._manifest = manifest
-    this._data = data
+    this._data = mapValues(data, (items: any) => items.map(item => ({ ...item, brew: id })))
     this._id = id
     
     this._Manufacturers = this._data.manufacturers?.map(x => new Manufacturer(x)) || []

--- a/src/classes/ContentPack.ts
+++ b/src/classes/ContentPack.ts
@@ -2,11 +2,12 @@ import { mapValues } from 'lodash'
 
 import { Manufacturer, CoreBonus, Frame, MechWeapon, MechSystem, WeaponMod, PilotGear, Talent, Tag, NpcClass, NpcTemplate, NpcFeature, NpcWeapon, NpcReaction, NpcTrait, NpcSystem, NpcTech, CompendiumItem } from '@/class'
 import { IManufacturerData, ICoreBonusData, IFrameData, IMechWeaponData, IMechSystemData, IWeaponModData, IPilotEquipmentData, ITalentData, INpcClassData, INpcFeatureData, INpcTemplateData,
-  INpcWeaponData, INpcReactionData, INpcSystemData, INpcTechData } from '@/interface'
+  INpcWeaponData, INpcReactionData, INpcSystemData, INpcTechData, ITagCompendiumData } from '@/interface'
 
 
 export interface IContentPackManifest {
   name: string
+  item_prefix: string
   author: string
   version: string
   description?: string
@@ -22,7 +23,7 @@ interface IContentPackData {
   mods: IWeaponModData[]
   pilotGear: IPilotEquipmentData[]
   talents: ITalentData[]
-  tags: ITagData[]
+  tags: ITagCompendiumData[]
 
   npcClasses: INpcClassData[]
   npcFeatures: INpcFeatureData[]

--- a/src/classes/Manufacturer.ts
+++ b/src/classes/Manufacturer.ts
@@ -38,6 +38,7 @@ class Manufacturer {
   }
 
   public get Short(): string {
+    if (this.LogoIsExternal) return this.ID
     return this._logo.toUpperCase()
   }
 

--- a/src/classes/Manufacturer.ts
+++ b/src/classes/Manufacturer.ts
@@ -38,8 +38,7 @@ class Manufacturer {
   }
 
   public get Short(): string {
-    if (this.LogoIsExternal) return this.ID
-    return this._logo.toUpperCase()
+    return this._logo?.toUpperCase() || this.ID
   }
 
   public get Description(): string {

--- a/src/classes/Tag.ts
+++ b/src/classes/Tag.ts
@@ -1,6 +1,14 @@
 import { ItemType } from '@/class'
 import { store } from '@/store'
+import { ICompendiumItemData } from '@/interface'
 
+export interface ITagCompendiumData extends ICompendiumItemData {
+  id: string
+  name: string
+  description: string
+  filter_ignore?: boolean
+  hidden?: boolean
+}
 class Tag {
   private _id: string
   private _name: string
@@ -11,7 +19,7 @@ class Tag {
   private _item_type: ItemType
   private _brew: string
 
-  public constructor(tagData: any) {
+  public constructor(tagData: ITagCompendiumData) {
     this._id = tagData.id
     this._name = tagData.name
     this._description = tagData.description

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -90,81 +90,81 @@ export class CompendiumStore extends VuexModule {
   private _Base_NpcTemplates: NpcTemplate[] = []
   private _Base_NpcFeatures: NpcFeature[] = []
 
-  public get NpcClasses(): NpcClass[] {
+  get NpcClasses(): NpcClass[] {
     return [
       ...this._Base_NpcClasses,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcClasses),
     ]
   }
-  public get NpcTemplates(): NpcTemplate[] {
+  get NpcTemplates(): NpcTemplate[] {
     return [
       ...this._Base_NpcTemplates,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcTemplates),
     ]
   }
-  public get NpcFeatures(): NpcFeature[] {
+  get NpcFeatures(): NpcFeature[] {
     return [
       ...this._Base_NpcFeatures,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcFeatures),
     ]
   }
 
-  public get Talents(): Talent[] {
+  get Talents(): Talent[] {
     return [
       ...this._Base_Talents,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Talents),
     ]
   }
-  public get CoreBonuses(): CoreBonus[] {
+  get CoreBonuses(): CoreBonus[] {
     return [
       ...this._Base_CoreBonuses,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.CoreBonuses),
     ]
   }
-  public get Frames(): Frame[] {
+  get Frames(): Frame[] {
     return [
       ...this._Base_Frames,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Frames),
     ]
   }
-  public get Manufacturers(): Manufacturer[] {
+  get Manufacturers(): Manufacturer[] {
     return [
       ...this._Base_Manufacturers,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Manufacturers),
     ]
   }
-  public get MechWeapons(): MechWeapon[] {
+  get MechWeapons(): MechWeapon[] {
     return [
       ...this._Base_MechWeapons,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.MechWeapons),
     ]
   }
-  public get WeaponMods(): WeaponMod[] {
+  get WeaponMods(): WeaponMod[] {
     return [
       ...this._Base_WeaponMods,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.WeaponMods),
     ]
   }
-  public get MechSystems(): MechSystem[] {
+  get MechSystems(): MechSystem[] {
     return [
       ...this._Base_MechSystems,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.MechSystems),
     ]
   }
-  public get PilotGear(): PilotGear[] {
+  get PilotGear(): PilotGear[] {
     return [
       ...this._Base_PilotGear,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.PilotGear),
     ]
   }
-  public get Tags(): Tag[] {
+  get Tags(): Tag[] {
     return [
       ...this._Base_Tags,
       ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Tags),
     ]
   }
 
-  public get Licenses(): License[] {
+  get Licenses(): License[] {
     return this.Frames.filter(x => x.Source !== 'GMS').map(frame => new License(frame))
   }
 
@@ -271,13 +271,13 @@ export class CompendiumStore extends VuexModule {
     content.forEach(c => this.context.commit(LOAD_PACK, c))
   }
 
-  public get packAlreadyInstalled(): any {
+  get packAlreadyInstalled(): any {
     return (packID: string) => this.ContentPacks.map(pak => pak.ID).includes(packID)
   }
 
   private nfErr = { err: 'ID not found' }
 
-  public get instantiate(): any | { err: string } {
+  get instantiate(): any | { err: string } {
     return (itemType: string, id: string) => {
       if (this[itemType] && this[itemType] instanceof Array) {
         const i = this[itemType].find((x: any) => x.ID === id || x.id === id)
@@ -287,7 +287,7 @@ export class CompendiumStore extends VuexModule {
     }
   }
 
-  public get referenceByID(): any | { err: string } {
+  get referenceByID(): any | { err: string } {
     return (itemType: string, id: string) => {
       if (this[itemType] && this[itemType] instanceof Array) {
         const i = this[itemType].find((x: any) => x.ID === id || x.id === id)
@@ -297,17 +297,17 @@ export class CompendiumStore extends VuexModule {
     }
   }
 
-  public get getItemCollection(): any {
+  get getItemCollection(): any {
     return (itemType: string) => {
       return this[itemType]
     }
   }
 
-  public get getUserProfile(): UserProfile {
+  get getUserProfile(): UserProfile {
     return this.UserProfile
   }
 
-  public get getVersion(): string {
+  get getVersion(): string {
     return this.CCVersion
   }
 

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -48,6 +48,7 @@ import {
   INpcSystemData,
   INpcTechData,
   IContentPack,
+  ITagCompendiumData
 } from '@/interface'
 import ExtLog from '@/io/ExtLog'
 import { saveData as saveUserData, loadData as loadUserData } from '@/io/Data'
@@ -132,7 +133,7 @@ export class CompendiumStore extends VuexModule {
     else if (x.type === 'armor') return new PilotArmor(x as IPilotArmorData)
     return new PilotGear(x as IPilotGearData)
   })) PilotGear: PilotGear[]
-  @Brewable(() => lancerData.tags.map((x: ITagData) => new Tag(x))) Tags: Tag[]
+  @Brewable(() => lancerData.tags.map((x: ITagCompendiumData) => new Tag(x))) Tags: Tag[]
 
   get Licenses(): License[] {
     return this.Frames.filter(x => x.Source !== 'GMS').map(frame => new License(frame))

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -26,6 +26,7 @@ import {
   NpcSystem,
   NpcTech,
   ContentPack,
+  CompendiumItem
 } from '@/class'
 import {
   ICoreBonusData,
@@ -58,6 +59,32 @@ export const LOAD_PACK = 'LOAD_PACK'
 export const DELETE_PACK = 'DELETE_PACK'
 export const SET_PACK_ACTIVE = 'SET_PACK_ACTIVE'
 
+
+function Brewable<T extends CompendiumItem>(base: () => T[]): Function {
+  return function(self: CompendiumStore, name: string) {
+
+    const baseName = `__Base_${name}`
+    
+    Object.defineProperty(self, baseName, {
+      get: base
+    })
+    Object.defineProperty(self, name, {
+      get: function() {
+        return [
+          ...this[baseName],
+          ...this
+            .ContentPacks
+            .filter(pack => pack.Active)
+            .flatMap(pack => pack[name]
+              // .forEach((item: T /* ? */) => item._brew = pack.ID)
+            )
+        ]
+      }
+    })
+  }
+}
+
+
 @Module({
   name: 'datastore',
 })
@@ -76,93 +103,36 @@ export class CompendiumStore extends VuexModule {
 
   ContentPacks: ContentPack[] = []
 
-  private _Base_Talents: Talent[] = []
-  private _Base_CoreBonuses: CoreBonus[] = []
-  private _Base_Frames: Frame[] = []
-  private _Base_Manufacturers: Manufacturer[] = []
-  private _Base_MechWeapons: MechWeapon[] = []
-  private _Base_WeaponMods: WeaponMod[] = []
-  private _Base_MechSystems: MechSystem[] = []
-  private _Base_PilotGear: PilotGear[] = []
-  private _Base_Tags: Tag[] = []
-
-  private _Base_NpcClasses: NpcClass[] = []
-  private _Base_NpcTemplates: NpcTemplate[] = []
-  private _Base_NpcFeatures: NpcFeature[] = []
-
-  get NpcClasses(): NpcClass[] {
-    return [
-      ...this._Base_NpcClasses,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcClasses),
-    ]
-  }
-  get NpcTemplates(): NpcTemplate[] {
-    return [
-      ...this._Base_NpcTemplates,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcTemplates),
-    ]
-  }
-  get NpcFeatures(): NpcFeature[] {
-    return [
-      ...this._Base_NpcFeatures,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.NpcFeatures),
-    ]
-  }
-
-  get Talents(): Talent[] {
-    return [
-      ...this._Base_Talents,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Talents),
-    ]
-  }
-  get CoreBonuses(): CoreBonus[] {
-    return [
-      ...this._Base_CoreBonuses,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.CoreBonuses),
-    ]
-  }
-  get Frames(): Frame[] {
-    return [
-      ...this._Base_Frames,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Frames),
-    ]
-  }
-  get Manufacturers(): Manufacturer[] {
-    return [
-      ...this._Base_Manufacturers,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Manufacturers),
-    ]
-  }
-  get MechWeapons(): MechWeapon[] {
-    return [
-      ...this._Base_MechWeapons,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.MechWeapons),
-    ]
-  }
-  get WeaponMods(): WeaponMod[] {
-    return [
-      ...this._Base_WeaponMods,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.WeaponMods),
-    ]
-  }
-  get MechSystems(): MechSystem[] {
-    return [
-      ...this._Base_MechSystems,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.MechSystems),
-    ]
-  }
-  get PilotGear(): PilotGear[] {
-    return [
-      ...this._Base_PilotGear,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.PilotGear),
-    ]
-  }
-  get Tags(): Tag[] {
-    return [
-      ...this._Base_Tags,
-      ...this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Tags),
-    ]
-  }
+  @Brewable(() => lancerData.npc_classes.map((x: INpcClassData) => new NpcClass(x))) NpcClasses: NpcClass[]
+  @Brewable(() => lancerData.npc_templates.map(
+    (x: INpcTemplateData) => new NpcTemplate(x)
+  )) NpcTemplates: NpcTemplate[]
+  @Brewable(() => lancerData.npc_features.map(function(x: any) {
+    if (x.type.toLowerCase() === 'weapon') return new NpcWeapon(x as INpcWeaponData)
+    else if (x.type.toLowerCase() === 'reaction') return new NpcReaction(x as INpcReactionData)
+    else if (x.type.toLowerCase() === 'trait') return new NpcTrait(x as INpcFeatureData)
+    else if (x.type.toLowerCase() === 'system') return new NpcSystem(x as INpcSystemData)
+    return new NpcTech(x as INpcTechData)
+  })) NpcFeatures: NpcFeature[]
+  @Brewable(() => 
+    lancerData.talents.map((x: ITalentData) => new Talent(x))
+  ) Talents: Talent[]
+  @Brewable(
+    () => lancerData.core_bonuses.map((x: ICoreBonusData) => new CoreBonus(x))
+  ) CoreBonuses: CoreBonus[]
+  @Brewable(() => 
+    lancerData.frames.map((x: IFrameData) => new Frame(x))
+  ) Frames: Frame[]
+  @Brewable(() => lancerData.manufacturers.map((x: IManufacturerData) => new Manufacturer(x))) Manufacturers: Manufacturer[]
+  @Brewable(() => lancerData.weapons.map((x: IMechWeaponData) => new MechWeapon(x))) MechWeapons: MechWeapon[]
+  @Brewable(() => lancerData.mods.map((x: IWeaponModData) => new WeaponMod(x))) WeaponMods: WeaponMod[]
+  @Brewable(() => lancerData.systems.map((x: IMechSystemData) => new MechSystem(x))) MechSystems: MechSystem[]
+  @Brewable(() => lancerData.pilot_gear.map(function(x: any) {
+    if (x.type === 'weapon') return new PilotWeapon(x as IPilotWeaponData)
+    else if (x.type === 'armor') return new PilotArmor(x as IPilotArmorData)
+    return new PilotGear(x as IPilotGearData)
+  })) PilotGear: PilotGear[]
+  @Brewable(() => lancerData.tags.map((x: ITagData) => new Tag(x))) Tags: Tag[]
 
   get Licenses(): License[] {
     return this.Frames.filter(x => x.Source !== 'GMS').map(frame => new License(frame))
@@ -186,34 +156,6 @@ export class CompendiumStore extends VuexModule {
     this.Environments = lancerData.environments
     this.Sitreps = lancerData.sitreps
 
-    this._Base_CoreBonuses = lancerData.core_bonuses.map((x: ICoreBonusData) => new CoreBonus(x))
-    this._Base_Talents = lancerData.talents.map((x: ITalentData) => new Talent(x))
-    this._Base_Frames = lancerData.frames.map((x: IFrameData) => new Frame(x))
-    this._Base_MechWeapons = lancerData.weapons.map((x: IMechWeaponData) => new MechWeapon(x))
-    this._Base_WeaponMods = lancerData.mods.map((x: IWeaponModData) => new WeaponMod(x))
-    this._Base_MechSystems = lancerData.systems.map((x: IMechSystemData) => new MechSystem(x))
-    this._Base_Tags = lancerData.tags.map((x: ITagData) => new Tag(x))
-    // TODO: use type guards
-    this._Base_PilotGear = lancerData.pilot_gear.map(function(x: any) {
-      if (x.type === 'weapon') return new PilotWeapon(x as IPilotWeaponData)
-      else if (x.type === 'armor') return new PilotArmor(x as IPilotArmorData)
-      return new PilotGear(x as IPilotGearData)
-    })
-    this._Base_Manufacturers = lancerData.manufacturers.map(
-      (x: IManufacturerData) => new Manufacturer(x)
-    )
-    // TODO: use type guards
-    this._Base_NpcFeatures = lancerData.npc_features.map(function(x: any) {
-      if (x.type.toLowerCase() === 'weapon') return new NpcWeapon(x as INpcWeaponData)
-      else if (x.type.toLowerCase() === 'reaction') return new NpcReaction(x as INpcReactionData)
-      else if (x.type.toLowerCase() === 'trait') return new NpcTrait(x as INpcFeatureData)
-      else if (x.type.toLowerCase() === 'system') return new NpcSystem(x as INpcSystemData)
-      return new NpcTech(x as INpcTechData)
-    })
-    this._Base_NpcClasses = lancerData.npc_classes.map((x: INpcClassData) => new NpcClass(x))
-    this._Base_NpcTemplates = lancerData.npc_templates.map(
-      (x: INpcTemplateData) => new NpcTemplate(x)
-    )
   }
 
   @Mutation

--- a/src/features/main_menu/_components/CCLog.vue
+++ b/src/features/main_menu/_components/CCLog.vue
@@ -31,10 +31,10 @@ export default Vue.extend({
       cursor: false,
       startDelete: false,
       beforeString: () => {
-        this.$refs.output.scrollIntoView({ block: 'end' })
+        this.$refs.output?.scrollIntoView({ block: 'end' })
       },
       afterString: () => {
-        this.$refs.output.scrollIntoView({ block: 'end' })
+        this.$refs.output?.scrollIntoView({ block: 'end' })
       },
       afterComplete: () => {
         this.lock = false
@@ -152,10 +152,10 @@ export default Vue.extend({
         nextStringDelay: 7,
         cursor: false,
         beforeString: () => {
-          this.$refs.output.scrollIntoView({ block: 'end' })
+          this.$refs.output?.scrollIntoView({ block: 'end' })
         },
         afterString: () => {
-          this.$refs.output.scrollIntoView({ block: 'end' })
+          this.$refs.output?.scrollIntoView({ block: 'end' })
         },
         afterComplete: () => {
           this.lock = false

--- a/src/features/nav/pages/ExtraContent/PackInstall.vue
+++ b/src/features/nav/pages/ExtraContent/PackInstall.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-layout class="packInstaller" style="height: 600px;">
+  <v-layout class="packInstaller white" style="height: 600px;">
     <v-flex style="height: 100%; min-width: 25%; max-width: 25%" class="px-3 py-4">
       <v-file-input
         v-model="value"
@@ -8,7 +8,7 @@
         mr2
         accept=".lcp"
         prepend-inner-icon="mdi-package"
-        prepend-icon=""
+        prepend-icon
         @change="fileChange($event)"
       />
       <v-btn
@@ -36,9 +36,7 @@
         </v-fade-transition>
         <span v-show="!done">{{ packAlreadyInstalled ? 'Replace' : 'Install' }}</span>
       </v-btn>
-      <p v-if="error" style="color: red">
-        {{ error }}
-      </p>
+      <p v-if="error" style="color: red">{{ error }}</p>
       <v-alert
         :value="packAlreadyInstalled && !(installing || done)"
         type="info"

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -38,6 +38,7 @@ import {
 import { IEncounterData, IMissionData, IActiveMissionData } from './classes/encounter/interfaces'
 import { IContentPackManifest, IContentPack } from './classes/ContentPack'
 import { ICounterData } from './classes/Counter'
+import { ITagCompendiumData } from './classes/Tag'
 
 export {
   ICompendiumItemData,
@@ -76,4 +77,5 @@ export {
   IContentPackManifest,
   IContentPack,
   ICounterData,
+  ITagCompendiumData
 }

--- a/src/io/ContentPackParser.ts
+++ b/src/io/ContentPackParser.ts
@@ -9,6 +9,7 @@ import {
   ITalentData,
   IPilotEquipmentData,
   IContentPackManifest,
+  ITagCompendiumData,
   IContentPack,
   INpcClassData,
   INpcFeatureData,
@@ -57,19 +58,41 @@ async function getZipData<T>(zip: JSZip, filename: string): Promise<T[]> {
 const parseContentPack = async function(binString: string): Promise<IContentPack> {
   const zip = await JSZip.loadAsync(binString)
 
+
   const manifest = await readZipJSON<IContentPackManifest>(zip, 'lcp_manifest.json')
   if (!manifest) throw new Error('Content pack has no manifest')
   if (!isValidManifest(manifest)) throw new Error('Content manifest is invalid')
 
-  const manufacturers = await getZipData<IManufacturerData>(zip, 'manufacturers.json')
-  const coreBonuses = await getZipData<ICoreBonusData>(zip, 'core_bonus.json')
-  const frames = await getZipData<IFrameData>(zip, 'frames.json')
-  const weapons = await getZipData<IMechWeaponData>(zip, 'weapons.json')
-  const systems = await getZipData<IMechSystemData>(zip, 'systems.json')
-  const mods = await getZipData<IWeaponModData>(zip, 'mods.json')
-  const pilotGear = await getZipData<IPilotEquipmentData>(zip, 'pilot_gear.json')
-  const talents = await getZipData<ITalentData>(zip, 'talents.json')
-  const tags = await getZipData<ITagData>(zip, 'tags.json')
+  const generateItemID = (type: string, name: string): string => `${manifest.item_prefix}__${type}_${name}`
+
+
+  const manufacturers = (await getZipData<IManufacturerData>(zip, 'manufacturers.json'))
+    .map(x => ({...x, id: x.id || generateItemID('mfr', x.name)}))
+  
+  const coreBonuses = (await getZipData<ICoreBonusData>(zip, 'core_bonus.json'))
+    .map(x => ({...x, id: x.id || generateItemID('cb', x.name)}))
+
+  const frames = (await getZipData<IFrameData>(zip, 'frames.json'))
+    .map(x => ({...x, id: x.id || generateItemID('mf', x.name)}))
+
+  const weapons = (await getZipData<IMechWeaponData>(zip, 'weapons.json'))
+    .map(x => ({...x, id: x.id || generateItemID('mw', x.name)}))
+
+  const systems = (await getZipData<IMechSystemData>(zip, 'systems.json'))
+    .map(x => ({...x, id: x.id || generateItemID('ms', x.name)}))
+
+  const mods = (await getZipData<IWeaponModData>(zip, 'mods.json'))
+    .map(x => ({...x, id: x.id || generateItemID('wm', x.name)}))
+
+  const pilotGear = (await getZipData<IPilotEquipmentData>(zip, 'pilot_gear.json'))
+    .map(x => ({...x, id: x.id || generateItemID('pg', x.name)}))
+
+  const talents = (await getZipData<ITalentData>(zip, 'talents.json'))
+    .map(x => ({...x, id: x.id || generateItemID('t', x.name)}))
+
+  const tags = (await getZipData<ITagCompendiumData>(zip, 'tags.json'))
+    .map(x => ({...x, id: x.id || generateItemID('tg', x.name)}))
+
 
   const npcClasses = (await readZipJSON<INpcClassData[]>(zip, 'npc_classes.json')) || []
   const npcFeatures = (await readZipJSON<INpcFeatureData[]>(zip, 'npc_features.json')) || []

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -19,17 +19,12 @@ import {
   INpcSystemData,
   INpcTechData,
   INpcTemplateData,
+  ITagCompendiumData
 } from './interface'
 
 
 type IFrameData_Fixed = Omit<IFrameData,
 'license' | 'license_level'>
-
-interface compendiumTagData {
-  id: string
-  name: string
-  description: string
-}
 
 type NoBrew<T> = Omit<T, 'brew'>
 
@@ -46,8 +41,7 @@ export type SCHEMA__pilot_gear = (
   NoBrew<IPilotGearData>
 )[]
 export type SCHEMA__talents = NoBrew<ITalentData>[]
-// temporary until we have a proper interface for compendium tag data
-export type SCHEMA__tags = compendiumTagData[]
+export type SCHEMA__tags = Omit<NoBrew<ITagCompendiumData>, 'filter_ignore' | 'hidden'>[]
 
 export type SCHEMA__npc_classes = NoBrew<INpcClassData>[]
 export type SCHEMA__npc_features = (

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -26,7 +26,7 @@ import {
 type IFrameData_Fixed = Omit<IFrameData,
 'license' | 'license_level'>
 
-type NoBrew<T> = Omit<T, 'brew'>
+type NoBrew<T> = Omit<T, 'brew' | 'id'>
 
 export type SCHEMA__manifest = IContentPackManifest
 export type SCHEMA__manufacturers = NoBrew<IManufacturerData>[]

--- a/src/ui/components/selectors/CCCoreBonusSelector.vue
+++ b/src/ui/components/selectors/CCCoreBonusSelector.vue
@@ -2,8 +2,8 @@
   <selector title="Pilot CORE Bonuses" height="60vh" :success="!pilot.IsMissingCBs">
     <template v-slot:left-column>
       <v-row v-for="b in pilot.CoreBonuses" :key="`summary_${b.ID}`">
-        <missing-item v-if="b.err" @remove="remove(b)" />
-        <span v-else>
+        <!-- <missing-item v-if="b.err" @remove="pilot.RemoveCoreBonus(b)" /> -->
+        <span>
           <v-icon small color="primary">cci-corebonus</v-icon>
           <strong>{{ b.Name }}</strong>
           <span class="overline">{{ b.Source }}</span>
@@ -17,50 +17,44 @@
           icon="check_circle"
           class="stat-text"
           :value="!pilot.IsMissingCBs"
-        >
-          CORE Bonus Selection Complete
-        </v-alert>
+        >CORE Bonus Selection Complete</v-alert>
         <v-alert
           outlined
           color="primary"
           icon="warning"
           class="stat-text"
           :value="pilot.IsMissingCBs"
-        >
-          {{ pilot.CurrentCBPoints }} / {{ pilot.MaxCBPoints }} CORE Bonuses selected
-        </v-alert>
+        >{{ pilot.CurrentCBPoints }} / {{ pilot.MaxCBPoints }} CORE Bonuses selected</v-alert>
         <v-btn
           block
           text
           small
           :disabled="!pilot.CoreBonuses.length"
           @click="pilot.ClearCoreBonuses()"
-        >
-          Reset
-        </v-btn>
+        >Reset</v-btn>
       </v-row>
     </template>
 
     <template v-slot:right-column>
       <v-expansion-panels>
         <v-expansion-panel
-          v-for="m in Object.keys(coreBonuses)"
-          :key="`panel_m${m}`"
+          v-for="{ manufacturer, coreBonuses } in manufacturersWithCBs"
+          :key="`panel_m${manufacturer.ID}`"
           class="no-shadow"
         >
           <v-expansion-panel-header>
             <div>
-              <span class="heading mech" :style="`color: ${manufacturer(m).Color}`">
-                <cc-logo :source="manufacturer(m)" size="xLarge" class="pt-4" />
-                {{ manufacturer(m).Name }}
+              <span class="heading mech" :style="`color: ${manufacturer.Color}`">
+                <cc-logo :source="manufacturer" size="xLarge" class="pt-4" />
+                {{ manufacturer.Name }}
               </span>
               <br />
-              <v-alert outlined :color="manufacturer(m).color" class="py-1 my-2">
+              <v-alert outlined :color="manufacturer.Color" class="py-1 my-2">
                 <v-row class="text-center">
                   <span
                     class="flavor-text text--text"
                     style="width: 100%"
-                    v-html="requirement(m)"
+                    v-html="requirement(manufacturer)"
                   />
                 </v-row>
               </v-alert>
@@ -69,12 +63,12 @@
 
           <v-expansion-panel-content>
             <core-bonus-select-item
-              v-for="b in coreBonuses[m]"
+              v-for="b in coreBonuses"
               :key="b.ID"
               :bonus="b"
               :is-selectable="isSelectable(b)"
               :is-selected="isSelected(b)"
-              :color="manufacturer(m).Color"
+              :color="manufacturer.Color"
               @add="pilot.AddCoreBonus(b)"
               @remove="pilot.RemoveCoreBonus(b)"
             />
@@ -87,83 +81,82 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop, Watch } from 'vue-property-decorator'
+
 import Selector from './components/_SelectorBase.vue'
 import MissingItem from './components/_MissingItem.vue'
 import CoreBonusSelectItem from './components/_CoreBonusSelectItem.vue'
+
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
-import { CoreBonus } from '@/class'
+import { Pilot, CoreBonus, Manufacturer } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-core-bonus-selector',
+
+@Component({
   components: { Selector, CoreBonusSelectItem, MissingItem },
-  props: {
-    pilot: {
-      type: Object,
-      required: true,
-    },
-    levelUp: Boolean,
-  },
-  data: () => ({
-    coreBonuses: [],
-    panels: [],
-  }),
-  computed: {
-    selectionComplete(): boolean {
-      return this.levelUp && !this.pilot.IsMissingCBs
-    },
-  },
-  watch: {
-    selectionComplete() {
-      window.scrollTo(0, document.body.scrollHeight)
-    },
-  },
-  created() {
-    const compendium = getModule(CompendiumStore, this.$store)
-    this.coreBonuses = this.$_.groupBy(compendium.CoreBonuses, 'Source')
-    compendium.Manufacturers.forEach(m => {
-      this.panels.push(!!(this.availableCount(m.ID) || this.selectedCount(m.ID)))
-    })
-  },
-  methods: {
-    manufacturer(id: string) {
-      const compendium = getModule(CompendiumStore, this.$store)
-      return compendium.Manufacturers.find(x => x.Short === id)
-    },
-    requirement(mID: string): string {
-      const m = this.manufacturer(mID)
-      const abbr = `<b>${m.Short}</b>`
-      const name = `<b>${m.Name}</b>`
-      if (m.Short === 'GMS')
-        return `<b>${this.selectedCount(
-          m.Short
-        )}</b> ${abbr} CORE Bonuses Selected<br>${name} CORE Bonuses do not have a license requirement`
-      var lvl = `<b>${this.pilot.LicenseLevel(m.Short)}</b>`
-      var output = `${lvl} ${abbr} Licenses Acquired &emsp;//&emsp; `
-      var remain = (3 % this.pilot.Level || 3) - this.pilot.LicenseLevel(m.Short)
-      output += `<b>${this.availableCount(
-        m.Short
-      )}</b> ${abbr} CORE Bonuses Available &emsp;//&emsp; `
-      output += `<b>${this.selectedCount(m.Short)}</b> ${abbr} CORE Bonuses Selected`
-      if (this.pilot.Level < 12)
-        output += `<br>${
-          this.pilot.Level < 3 ? 'First' : 'Next'
-        } ${name} CORE Bonus available in <b>${remain}</b> License Level${remain === 1 ? '' : 's'}`
-      return output
-    },
-    selectedCount(m: string): number {
-      return this.pilot.CoreBonuses.filter((x: CoreBonus) => x.Source === m).length
-    },
-    availableCount(m: string): number {
-      if (m.toUpperCase() === 'GMS') return Infinity
-      return Math.floor(this.pilot.LicenseLevel(m) / 3) - this.selectedCount(m)
-    },
-    isSelectable(b: CoreBonus): boolean {
-      return this.availableCount(b.Source) > 0 && this.pilot.IsMissingCBs
-    },
-    isSelected(b: CoreBonus): boolean {
-      return this.pilot.has('CoreBonus', b.ID)
-    },
-  },
 })
+export default class CCCoreBonusSelector extends Vue {
+
+  @Prop({ type: Object, required: true }) pilot!: Pilot;
+  @Prop(Boolean) levelUp!: boolean;
+
+  get coreBonuses(): CoreBonus[] {
+    return getModule(CompendiumStore, this.$store).CoreBonuses
+  }
+  get manufacturersWithCBs(): {
+    manufacturer: Manufacturer,
+    coreBonuses: CoreBonus[]
+  }[] {
+    const manufacturers = getModule(CompendiumStore, this.$store).Manufacturers
+
+    return manufacturers.map(manufacturer => ({
+      manufacturer,
+      coreBonuses: this.coreBonuses.filter(cb => cb.Manufacturer === manufacturer)
+    })).filter(x => x.coreBonuses.length > 0)
+
+  }
+
+  get selectionComplete(): boolean {
+    return this.levelUp && !this.pilot.IsMissingCBs
+  }
+  @Watch('selectionComplete') onSelectionComplete() {
+    window.scrollTo(0, document.body.scrollHeight)
+  }
+
+  requirement(m: Manufacturer): string {
+    const abbr = `<b>${m.Short}</b>`
+    const name = `<b>${m.Name}</b>`
+    if (m.Short === 'GMS')
+      return `<b>${this.selectedCount(
+        m.Short
+      )}</b> ${abbr} CORE Bonuses Selected<br>${name} CORE Bonuses do not have a license requirement`
+    var lvl = `<b>${this.pilot.LicenseLevel(m.Short)}</b>`
+    var output = `${lvl} ${abbr} Licenses Acquired &emsp;//&emsp; `
+    var remain = (3 % this.pilot.Level || 3) - this.pilot.LicenseLevel(m.Short)
+    output += `<b>${this.availableCount(
+      m.Short
+    )}</b> ${abbr} CORE Bonuses Available &emsp;//&emsp; `
+    output += `<b>${this.selectedCount(m.Short)}</b> ${abbr} CORE Bonuses Selected`
+    if (this.pilot.Level < 12)
+      output += `<br>${this.pilot.Level < 3 ? 'First' : 'Next'} ${name} CORE Bonus available in <b>${remain}</b> License Level${remain === 1 ? '' : 's'}`
+    return output
+  }
+
+  selectedCount(m: string): number {
+    return this.pilot.CoreBonuses.filter((x: CoreBonus) => x.Source === m).length
+  }
+  availableCount(m: string): number {
+    if (m.toUpperCase() === 'GMS') return Infinity
+    return Math.floor(this.pilot.LicenseLevel(m) / 3) - this.selectedCount(m)
+  }
+  isSelectable(b: CoreBonus): boolean {
+    return this.availableCount(b.Source) > 0 && this.pilot.IsMissingCBs
+  }
+  isSelected(b: CoreBonus): boolean {
+    return this.pilot.has('CoreBonus', b.ID)
+  }
+
+
+}
 </script>


### PR DESCRIPTION
- **Refactor(homebrew):** Use a @Brewable decorator for properties on the compendium store that
take items from content packs. Also fixes several bugs (I think) caused by using `private` inside vuex-module-decorator modules
- **Feat(homebrew):** Generates homebrew item IDs if they are not defined in the item. Also removes IDs from the schema to avoid unneeded complexity for end users

See commits for other changes