### PR TITLE
Adjust manufacturer handling code to data changes

### DIFF
--- a/src/classes/License.ts
+++ b/src/classes/License.ts
@@ -41,7 +41,7 @@ class License {
   }
 
   public get Manufacturer(): Manufacturer {
-    return store.getters.getItemCollection('Manufacturers').find(x => x.Short === this._source)
+    return store.getters.referenceByID('Manufacturers', this._source)
   }
 
   public get FrameID(): string {

--- a/src/classes/LicensedItem.ts
+++ b/src/classes/LicensedItem.ts
@@ -26,7 +26,7 @@ abstract class LicensedItem extends CompendiumItem {
   }
 
   public get Manufacturer(): Manufacturer {
-    return store.getters.getItemCollection('Manufacturers').find(x => x.Short === this.Source)
+    return store.getters.referenceByID('Manufacturers', this.Source)
   }
 
   public get License(): string {

--- a/src/classes/Manufacturer.ts
+++ b/src/classes/Manufacturer.ts
@@ -37,10 +37,6 @@ class Manufacturer {
     return this._name
   }
 
-  public get Short(): string {
-    return this._logo?.toUpperCase() || this.ID
-  }
-
   public get Description(): string {
     return this._description
   }
@@ -59,7 +55,8 @@ class Manufacturer {
 
   public get Logo(): string {
     if (this._logo_url) return this._logo_url
-    return getImagePath(ImageTag.Logo, `${this._logo}.svg`, true)
+    else if (this._logo) return getImagePath(ImageTag.Logo, `${this._logo}.svg`, true)
+    else return '' // TODO: placeholder logo?
   }
 }
 

--- a/src/classes/pilot/CoreBonus.ts
+++ b/src/classes/pilot/CoreBonus.ts
@@ -26,7 +26,7 @@ class CoreBonus extends CompendiumItem {
   }
 
   public get Manufacturer(): Manufacturer {
-    return store.getters.getItemCollection('Manufacturers').find(x => x.Short === this._source)
+    return store.getters.referenceByID('Manufacturers', this._source)
   }
 
   public get Effect(): string {

--- a/src/features/compendium/Views/CoreBonuses.vue
+++ b/src/features/compendium/Views/CoreBonuses.vue
@@ -56,7 +56,7 @@ export default class CoreBonuses extends Vue {
 
   public manufacturer(id: string) {
     const compendium = getModule(CompendiumStore, this.$store)
-    return compendium.Manufacturers.find(x => x.Short === id.toUpperCase())
+    return compendium.Manufacturers.find(x => x.ID === id.toUpperCase())
   }
 }
 </script>

--- a/src/features/compendium/Views/Licenses.vue
+++ b/src/features/compendium/Views/Licenses.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
   methods: {
     manufacturer(id: string) {
       const compendium = getModule(CompendiumStore, this.$store)
-      return compendium.Manufacturers.find(x => x.Short === id)
+      return compendium.Manufacturers.find(x => x.ID === id)
     },
     frame(id: string) {
       const compendium = getModule(CompendiumStore, this.$store)

--- a/src/features/compendium/Views/Manufacturers.vue
+++ b/src/features/compendium/Views/Manufacturers.vue
@@ -11,7 +11,7 @@
     >
       <v-tab v-for="(m, i) in manufacturers" :key="m.ID" ripple>
         <cc-logo size="large" :source="m" :color="tabModel == i ? 'white' : 'black'" />
-        {{ m.Short }}
+        {{ m.ID }}
       </v-tab>
       <v-tab-item v-for="m in manufacturers" :key="m.ID + 'desc'">
         <v-card flat class="px-3 py-3 light-panel clipped-x-large">

--- a/src/io/ContentPackParser.ts
+++ b/src/io/ContentPackParser.ts
@@ -73,7 +73,7 @@ const parseContentPack = async function(binString: string): Promise<IContentPack
     return data.map(x => ({...x, id: x.id || generateItemID(dataPrefix, x.name)}))
   }
 
-  const manufacturers = generateIDs(await getZipData<IManufacturerData>(zip, 'manufacturers.json'), 'mfr')
+  const manufacturers = await getZipData<IManufacturerData>(zip, 'manufacturers.json')
   const coreBonuses = generateIDs(await getZipData<ICoreBonusData>(zip, 'core_bonus.json'), 'cb')
   const frames = generateIDs(await getZipData<IFrameData>(zip, 'frames.json'), 'mf')
   const weapons = generateIDs(await getZipData<IMechWeaponData>(zip, 'weapons.json'), 'mw')

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -29,7 +29,7 @@ type IFrameData_Fixed = Omit<IFrameData,
 type NoBrew<T> = Omit<T, 'brew' | 'id'>
 
 export type SCHEMA__manifest = IContentPackManifest
-export type SCHEMA__manufacturers = NoBrew<IManufacturerData>[]
+export type SCHEMA__manufacturers = Omit<IManufacturerData, 'logo'>[]
 export type SCHEMA__core_bonus = NoBrew<ICoreBonusData>[]
 export type SCHEMA__frames = NoBrew<IFrameData_Fixed>[]
 export type SCHEMA__weapons = NoBrew<IMechWeaponData>[]

--- a/src/ui/components/selectors/CCCoreBonusSelector.vue
+++ b/src/ui/components/selectors/CCCoreBonusSelector.vue
@@ -125,19 +125,19 @@ export default class CCCoreBonusSelector extends Vue {
   }
 
   requirement(m: Manufacturer): string {
-    const abbr = `<b>${m.Short}</b>`
+    const abbr = `<b>${m.ID}</b>`
     const name = `<b>${m.Name}</b>`
-    if (m.Short === 'GMS')
+    if (m.ID === 'GMS')
       return `<b>${this.selectedCount(
-        m.Short
+        m.ID
       )}</b> ${abbr} CORE Bonuses Selected<br>${name} CORE Bonuses do not have a license requirement`
-    var lvl = `<b>${this.pilot.LicenseLevel(m.Short)}</b>`
+    var lvl = `<b>${this.pilot.LicenseLevel(m.ID)}</b>`
     var output = `${lvl} ${abbr} Licenses Acquired &emsp;//&emsp; `
-    var remain = (3 % this.pilot.Level || 3) - this.pilot.LicenseLevel(m.Short)
+    var remain = (3 % this.pilot.Level || 3) - this.pilot.LicenseLevel(m.ID)
     output += `<b>${this.availableCount(
-      m.Short
+      m.ID
     )}</b> ${abbr} CORE Bonuses Available &emsp;//&emsp; `
-    output += `<b>${this.selectedCount(m.Short)}</b> ${abbr} CORE Bonuses Selected`
+    output += `<b>${this.selectedCount(m.ID)}</b> ${abbr} CORE Bonuses Selected`
     if (this.pilot.Level < 12)
       output += `<br>${this.pilot.Level < 3 ? 'First' : 'Next'} ${name} CORE Bonus available in <b>${remain}</b> License Level${remain === 1 ? '' : 's'}`
     return output


### PR DESCRIPTION
⚠️⚠️⚠️**DO NOT PULL UNTIL ERANZIEL'S LATEST CHANGES ARE PULLED INTO LANCER-DATA**⚠️⚠️⚠️

Removes the `Manufacturer.Short` property as we are going back to using manufacturer acronyms for their IDs; changes all references to `Manufacturer.Short` to `Manufacturer.ID`. Also adjusts homebrew parsing & schemas to account for the changes.