### PR TITLE
Fix counters in Active Mode

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -945,7 +945,7 @@ class Pilot {
       this.ActiveMech?.ActiveLoadout.Systems.flatMap(system => system.Counters),
       this.ActiveMech?.ActiveLoadout.Weapons.flatMap(weapon => [
         ...weapon.Counters,
-        ...weapon.Mod.Counters,
+        ...(weapon.Mod?.Counters || []),
       ]),
       this.ActiveMech?.Frame.CoreSystem.Integrated?.Counters,
       this.CustomCounterData,

--- a/src/features/pilot_management/ActiveSheet/index.vue
+++ b/src/features/pilot_management/ActiveSheet/index.vue
@@ -6,8 +6,7 @@
       <pilot-block :pilot="pilot" />
       <v-divider class="mt-2 mb-4" />
       <mech-block :pilot="pilot" />
-      <!-- TODO: fix counters block -->
-      <!-- <counters-block :counter-data="pilot.CounterData" /> -->
+      <counters-block :counter-data="pilot.CounterData" />
     </div>
   </v-container>
 </template>
@@ -17,7 +16,7 @@ import Vue from 'vue'
 import TurnSidebar from './turn/index.vue'
 import PilotBlock from './layout/PilotBlock.vue'
 import MechBlock from './layout/MechBlock.vue'
-// import CountersBlock from './layout/CountersBlock.vue'
+import CountersBlock from './layout/CountersBlock.vue'
 
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
@@ -27,7 +26,7 @@ export default Vue.extend({
     TurnSidebar,
     PilotBlock,
     MechBlock,
-    // CountersBlock,
+    CountersBlock,
   },
   mixins: [activePilot],
 })


### PR DESCRIPTION
Counters were failing to load due to trying to pull from nonexistant
weapon mods