### PR TITLE
Add mixin util for object-pattern components

### DIFF
--- a/src/features/nav/index.vue
+++ b/src/features/nav/index.vue
@@ -142,11 +142,13 @@ import Vue from 'vue'
 import Options from './pages/Options.vue'
 import activePilot from '../pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'cc-nav',
   // components: { HelpPage, AboutPage, OptionsPage },
   components: { Options },
-  mixins: [activePilot],
+
   props: {
     pilotManagement: { type: Boolean },
     encounter: { type: Boolean },

--- a/src/features/pilot_management/ActiveSheet/index.vue
+++ b/src/features/pilot_management/ActiveSheet/index.vue
@@ -20,7 +20,9 @@ import CountersBlock from './layout/CountersBlock.vue'
 
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'active-sheet',
   components: {
     TurnSidebar,
@@ -28,6 +30,6 @@ export default Vue.extend({
     MechBlock,
     CountersBlock,
   },
-  mixins: [activePilot],
+
 })
 </script>

--- a/src/features/pilot_management/ActiveSheet/layout/CountersBlock.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/CountersBlock.vue
@@ -25,9 +25,11 @@ import CounterComponent from '../components/Counter.vue'
 import NewCounter from '../components/NewCounter.vue'
 import activePilot from '../../mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   components: { CounterComponent, NewCounter },
-  mixins: [activePilot],
+
   props: {
     counterData: {
       type: Array,

--- a/src/features/pilot_management/PilotSheet/components/PilotHeader.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotHeader.vue
@@ -131,10 +131,12 @@ import Vue from 'vue'
 import LevelEditDialog from './LevelEditDialog.vue'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'pilot-header',
   components: { LevelEditDialog },
-  mixins: [activePilot],
+
   computed: {
     isLevelingUp(): boolean {
       return this.$route.name === 'pilot-level-wizard'

--- a/src/features/pilot_management/PilotSheet/index.vue
+++ b/src/features/pilot_management/PilotSheet/index.vue
@@ -17,7 +17,9 @@ import Vue from 'vue'
 import PilotHeader from './components/PilotHeader.vue'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'pilot-sheet',
   components: { PilotHeader },
   props: {
@@ -26,6 +28,6 @@ export default Vue.extend({
       required: true,
     },
   },
-  mixins: [activePilot],
+
 })
 </script>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
@@ -34,13 +34,15 @@ import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'appearance-block',
   components: { SectionEditIcon, NoDataBlock },
   data: () => ({
     appearance: '',
   }),
-  mixins: [activePilot],
+  
   created() {
     this.appearance = this.pilot.TextAppearance || ''
   },

--- a/src/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
@@ -30,13 +30,15 @@ import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'history-block',
   components: { SectionEditIcon, NoDataBlock },
   data: () => ({
     history: '',
   }),
-  mixins: [activePilot],
+  
   created() {
     this.history = this.pilot.History || ''
   },

--- a/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -85,10 +85,12 @@ import Vue from 'vue'
 import CloudManager from '../../../components/CloudManager.vue'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'ident-block',
   components: { CloudManager },
-  mixins: [activePilot],
+
   data: () => ({
     pilotStatuses: [
       { text: 'Active', value: 'ACTIVE' },

--- a/src/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
@@ -29,8 +29,10 @@ import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'history-block',
-  mixins: [activePilot],
+  
 })
 </script>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/NotesBlock.vue
@@ -15,8 +15,10 @@ import { PilotManagementStore } from '@/store'
 import { Pilot } from '@/class'
 import activePilot from '@/features/pilot_management/mixins/activePilot'
 
-export default Vue.extend({
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
   name: 'notes-block',
-  mixins: [activePilot],
+
 })
 </script>

--- a/src/features/pilot_management/mixins/activePilot.ts
+++ b/src/features/pilot_management/mixins/activePilot.ts
@@ -1,7 +1,9 @@
+import Vue from 'vue';
+
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 
-export default {
+export default Vue.extend({
   computed: {
     pilot() {
       return getModule(PilotManagementStore, this.$store).Pilots.find(
@@ -10,3 +12,4 @@ export default {
     },
   },
 }
+)

--- a/src/util/vueMixins.ts
+++ b/src/util/vueMixins.ts
@@ -1,0 +1,20 @@
+import Vue, { VueConstructor } from 'vue'
+
+export default function vueMixins<T extends VueConstructor[]> (...args: T): ExtractVue<T> extends infer V ? V extends Vue ? VueConstructor<V> : never : never
+export default function vueMixins<T extends Vue> (...args: VueConstructor[]): VueConstructor<T>
+export default function vueMixins (...args: VueConstructor[]): VueConstructor {
+  return Vue.extend({ mixins: args })
+}
+
+/**
+ * Returns the instance type from a VueConstructor
+ * Useful for adding types when using mixins().extend()
+ */
+export type ExtractVue<T extends VueConstructor | VueConstructor[]> = T extends (infer U)[]
+  ? UnionToIntersection<
+    U extends VueConstructor<infer V> ? V : never
+  >
+  : T extends VueConstructor<infer V> ? V : never
+
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never


### PR DESCRIPTION
Adds util/vueMixins.ts utility function to apply mixins to components type-safely while still using the Vue object syntax. 
Main benefit is getting proper type info/no errors when using the activePilot mixin in components that haven't been refactored to class-style components.