### PR TITLE
Data updates and minor fixes

### DIFF
--- a/src/classes/Counter.spec.ts
+++ b/src/classes/Counter.spec.ts
@@ -6,7 +6,7 @@ import { ICounterData } from './Counter'
 const testCounterData: ICounterData = {
   id: 'test',
   name: 'Test counter',
-  defaultValue: 1,
+  default_value: 1,
   min: 1,
   max: 6
 }
@@ -18,7 +18,7 @@ describe('Counter', () => {
 
     const counter = new Counter(testCounterData)
 
-    expect(counter.Value).toBe(testCounterData.defaultValue)
+    expect(counter.Value).toBe(testCounterData.default_value)
 
   })
 
@@ -55,7 +55,7 @@ describe('Counter', () => {
 
     counter.Reset()
 
-    expect(counter.Value).toBe(testCounterData.defaultValue)
+    expect(counter.Value).toBe(testCounterData.default_value)
 
   });
 
@@ -64,7 +64,7 @@ describe('Counter', () => {
       new Counter({
         id: 'bad',
         name: 'Bad counter',
-        defaultValue: 0,
+        default_value: 0,
         min: 1
       })
     }).toThrow()
@@ -73,7 +73,7 @@ describe('Counter', () => {
       new Counter({
         id: 'bad',
         name: 'Bad counter',
-        defaultValue: 2,
+        default_value: 2,
         max: 1
       })
     }).toThrow()

--- a/src/classes/Counter.ts
+++ b/src/classes/Counter.ts
@@ -3,7 +3,7 @@ interface ICounterData {
   name: string
   min?: number
   max?: number
-  defaultValue?: number
+  default_value?: number
   custom?: boolean
 }
 
@@ -16,19 +16,19 @@ class Counter {
   public readonly Default: number
 
   constructor(data: ICounterData) {
-    const { id, name, min, max, defaultValue } = data
+    const { id, name, min, max, default_value } = data
 
-    if (max && defaultValue > max)
-      throw new Error(`Error creating Counter: Default value of ${defaultValue} is greater than max value of ${max}`)
+    if (max && default_value > max)
+      throw new Error(`Error creating Counter: Default value of ${default_value} is greater than max value of ${max}`)
     
-    if (min && defaultValue < min)
-      throw new Error(`Error creating Counter: Default value of ${defaultValue} is lesser than min value of ${min}`)
+    if (min && default_value < min)
+      throw new Error(`Error creating Counter: Default value of ${default_value} is lesser than min value of ${min}`)
 
     this.ID = id
     this.Name = name
     this.Min = min
     this.Max = max
-    this.Default = defaultValue || 0
+    this.Default = default_value || 0
 
     this._value = this.Default
 

--- a/src/classes/enums.ts
+++ b/src/classes/enums.ts
@@ -106,7 +106,7 @@ enum HASE {
 }
 
 enum ReserveType {
-  Narrative = 'Narrative',
+  Resources = 'Resources',
   Tactical = 'Tactical',
   Mech = 'Mech',
   Project = 'Project',

--- a/src/classes/mech/MechLoadout.ts
+++ b/src/classes/mech/MechLoadout.ts
@@ -182,7 +182,9 @@ class MechLoadout extends Loadout {
         if (licenseIndex > -1) {
           requirements[licenseIndex].items.push(item.Name)
         } else {
-          requirements.push(item.RequiredLicense)
+          if (item.RequiredLicense.name !== '' && item.RequiredLicense.rank > 0) {
+            requirements.push(item.RequiredLicense)
+          }
         }
       }
     })

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -434,7 +434,7 @@ class Pilot {
   }
 
   public get AICapacity(): number {
-    return this.has('corebonus', 'cb_the_lesson_of_true_shaping') ? 2 : 1
+    return this.has('corebonus', 'cb_the_lesson_of_shaping') ? 2 : 1
   }
 
   // -- Skills ------------------------------------------------------------------------------------

--- a/src/classes/pilot/reserves/Reserve.ts
+++ b/src/classes/pilot/reserves/Reserve.ts
@@ -15,7 +15,7 @@ class Reserve {
 
   public constructor(data: IReserveData) {
     this._id = data.id
-    this.type = (data.type as ReserveType) || ReserveType.Narrative
+    this.type = (data.type as ReserveType) || ReserveType.Resources
     this._name = data.name || ''
     this._label = data.label || ''
     this._resource_name = data.resource_name || ''

--- a/src/features/pilot_management/ActiveSheet/components/Counter.vue.spec.ts
+++ b/src/features/pilot_management/ActiveSheet/components/Counter.vue.spec.ts
@@ -20,7 +20,7 @@ jest.mock('@/store', () => ({
 const testCounterData: ICounterData = {
   id: 'test',
   name: 'Test counter',
-  defaultValue: 1,
+  default_value: 1,
   min: 1,
   max: 6
 }

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/BuyTime.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/BuyTime.vue
@@ -58,7 +58,7 @@
                 <v-toolbar-title class="heading h2">Bought Time</v-toolbar-title>
               </v-toolbar>
               <v-card-text>
-                <v-textarea v-model="details" auto-grow rows="1" label="Details" box />
+                <v-textarea v-model="details" auto-grow rows="1" label="Details" filled />
               </v-card-text>
             </v-card>
           </v-col>

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/BuyTime.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/BuyTime.vue
@@ -99,7 +99,7 @@ export default Vue.extend({
     addReserve() {
       let nr = new Reserve({
         id: 'reserve_boughttime',
-        type: 'Narrative',
+        type: 'Resources',
         name: 'Bought Time',
         label: '',
         description: 'More time and breathing room for you and your group to act',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/DamnDrink.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/DamnDrink.vue
@@ -65,7 +65,7 @@
                     auto-grow
                     rows="1"
                     label="Details"
-                    box
+                    filled
                   />
                 </v-col>
                 <v-col cols="6">
@@ -99,7 +99,7 @@
                       auto-grow
                       rows="1"
                       label="Details"
-                      box
+                      filled
                     />
                   </div>
                 </v-col>
@@ -119,7 +119,7 @@
                       auto-grow
                       rows="1"
                       label="Details"
-                      box
+                      filled
                     />
                   </div>
                 </v-col>

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/DamnDrink.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/DamnDrink.vue
@@ -183,7 +183,7 @@ export default Vue.extend({
       if (this.skillRoll < 10) {
         let nr = new Reserve({
           id: 'reserve_damndrink',
-          type: 'Narrative',
+          type: 'Resources',
           name: 'A Damn Drink',
           label: '',
           description: '',
@@ -199,7 +199,7 @@ export default Vue.extend({
       } else if (this.skillRoll < 20) {
         let nr = new Reserve({
           id: 'reserve_damndrink',
-          type: 'Narrative',
+          type: 'Resources',
           name: this.reserve1,
           label: '',
           description: '',
@@ -214,7 +214,7 @@ export default Vue.extend({
       } else {
         let nr = new Reserve({
           id: 'reserve_damndrink',
-          type: 'Narrative',
+          type: 'Resources',
           name: this.reserve1,
           label: '',
           description: '',
@@ -228,7 +228,7 @@ export default Vue.extend({
 
         let nr2 = new Reserve({
           id: 'reserve_damndrink',
-          type: 'Narrative',
+          type: 'Resources',
           name: this.reserve2,
           label: '',
           description: '',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/DowntimeManager.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/DowntimeManager.vue
@@ -3,31 +3,31 @@
     <span class="heading mech">DOWNTIME</span>
     <v-divider class="ma-2" />
     <div class="mx-3 pt-3">
-      <dt-action ref="atcost" action-id="action_poweratcost" class="mb-1">
+      <dt-action ref="atcost" action-id="act_power_at_a_cost" class="mb-1">
         <power-at-cost :pilot="pilot" @close="$refs.atcost.dialog = false" />
       </dt-action>
-      <dt-action ref="buytime" action-id="action_buysometime" class="mb-1">
+      <dt-action ref="buytime" action-id="act_buy_some_time" class="mb-1">
         <buy-time :pilot="pilot" @close="$refs.buytime.dialog = false" />
       </dt-action>
-      <dt-action ref="damndrink" action-id="action_damndrink" class="mb-1">
+      <dt-action ref="damndrink" action-id="act_get_a_damn_drink" class="mb-1">
         <damn-drink :pilot="pilot" @close="$refs.damndrink.dialog = false" />
       </dt-action>
-      <dt-action ref="getcreative" action-id="action_creative" class="mb-1">
+      <dt-action ref="getcreative" action-id="act_get_creative" class="mb-1">
         <get-creative :pilot="pilot" @close="$refs.getcreative.dialog = false" />
       </dt-action>
-      <dt-action ref="getfocused" action-id="action_focused" class="mb-1">
+      <dt-action ref="getfocused" action-id="act_get_focused" class="mb-1">
         <get-focused :pilot="pilot" @close="$refs.getfocused.dialog = false" />
       </dt-action>
-      <dt-action ref="getorganized" action-id="action_organized" class="mb-1">
+      <dt-action ref="getorganized" action-id="act_get_organized" class="mb-1">
         <get-organized :pilot="pilot" @close="$refs.getorganized.dialog = false" />
       </dt-action>
-      <dt-action ref="gatherinfo" action-id="action_information" class="mb-1">
+      <dt-action ref="gatherinfo" action-id="act_gather_information" class="mb-1">
         <gather-information :pilot="pilot" @close="$refs.gatherinfo.dialog = false" />
       </dt-action>
-      <dt-action ref="getconnected" action-id="action_connected" class="mb-1">
+      <dt-action ref="getconnected" action-id="act_get_connected" class="mb-1">
         <get-connected :pilot="pilot" @close="$refs.getconnected.dialog = false" />
       </dt-action>
-      <dt-action ref="scrounge" action-id="action_scrounge" class="mb-1">
+      <dt-action ref="scrounge" action-id="act_scrounge_and_barter" class="mb-1">
         <scrounge-barter :pilot="pilot" @close="$refs.scrounge.dialog = false" />
       </dt-action>
     </div>

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/DtAction.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/DtAction.vue
@@ -10,6 +10,9 @@
     :disabled="disabled"
     @click="dialog = true"
   >
+    <v-icon style="position: absolute; left: -10px">
+      $vuetify.icons.{{ action.action_type }}
+    </v-icon>
     <div style="position: absolute; right: 0">
       <v-divider dark vertical class="ml-2 mr-1" />
       <v-icon class="fadeSelect" @click.stop="infoDialog = true">mdi-help-circle-outline</v-icon>

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/GatherInformation.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/GatherInformation.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
     addReserve() {
       let nr = new Reserve({
         id: 'reserve_gatherinfo',
-        type: 'Narrative',
+        type: 'Resources',
         name: 'Information',
         label: '',
         description: '',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/GetConnected.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/GetConnected.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
     addReserve() {
       let nr = new Reserve({
         id: 'reserve_boughttime',
-        type: 'Narrative',
+        type: 'Resources',
         name: 'Connection',
         label: '',
         description: '',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/GetCreative.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/GetCreative.vue
@@ -33,7 +33,7 @@
               </v-row>
               <v-row dense>
                 <v-col class="mx-6">
-                  <v-textarea v-model="details" auto-grow rows="1" label="Details" box />
+                  <v-textarea v-model="details" auto-grow rows="1" label="Details" filled />
                 </v-col>
               </v-row>
               <v-row justify="center">

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/GetFocused.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/GetFocused.vue
@@ -24,7 +24,7 @@
     </v-card-text>
     <v-divider />
     <v-card-actions>
-      <v-btn flat @click="close()">cancel</v-btn>
+      <v-btn text @click="close()">cancel</v-btn>
       <v-spacer />
       <v-btn large tile color="primary" @click="addSkill()">
         {{ tabs === 0 ? 'Add Skill' : 'Improve Skill' }}
@@ -50,7 +50,7 @@ export default Vue.extend({
       this.pilot.Reserves.push(
         new Reserve({
           id: 'reserve_skill',
-          type: 'Narrative',
+          type: 'Resources',
           name: 'Skill Focus',
           description: 'Added via the "Get Focused" Downtime Action',
           resource_name: 'Skill Focus',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/GetOrganized.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/GetOrganized.vue
@@ -188,14 +188,14 @@
                                   Additionally, the organization takes one of the following actions:
                                 </span>
                                 <v-btn-toggle v-model="action" mandatory>
-                                  <v-btn flat large value="Pay Debts">Pay Debts</v-btn>
-                                  <v-btn flat large value="Prove Worthiness">
+                                  <v-btn text large value="Pay Debts">Pay Debts</v-btn>
+                                  <v-btn text large value="Prove Worthiness">
                                     Prove Worthiness
                                   </v-btn>
-                                  <v-btn flat large value="Get Bailed Out">
+                                  <v-btn text large value="Get Bailed Out">
                                     Get Bailed Out
                                   </v-btn>
-                                  <v-btn flat large value="Make an Aggressive Move">
+                                  <v-btn text large value="Make an Aggressive Move">
                                     Make an Aggressive Move
                                   </v-btn>
                                 </v-btn-toggle>

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/ReserveSelector.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/ReserveSelector.vue
@@ -56,7 +56,7 @@ export default Vue.extend({
     reserve: '',
     custom_name: '',
     details: '',
-    reserveTypes: ['Narrative', 'Tactical', 'Mech', 'Custom'],
+    reserveTypes: ['Resources', 'Tactical', 'Mech', 'Custom'],
   }),
   computed: {
     reserveComplete() {

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/ScroungeBarter.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/ScroungeBarter.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
     addReserve() {
       let nr = new Reserve({
         id: 'reserve_scroungebarter',
-        type: 'Narrative',
+        type: 'Resources',
         name: 'Asset',
         label: '',
         description: '',

--- a/src/features/pilot_management/ActiveSheet/turn/Downtime/ScroungeBarter.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Downtime/ScroungeBarter.vue
@@ -62,7 +62,7 @@
                     dense
                     outlined
                   />
-                  <v-textarea v-model="details" auto-grow rows="1" label="Details" box />
+                  <v-textarea v-model="details" auto-grow rows="1" label="Details" filled />
                 </v-card-text>
               </v-card>
             </v-col>

--- a/src/features/pilot_management/ActiveSheet/turn/Mission/TurnManager.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Mission/TurnManager.vue
@@ -122,21 +122,21 @@
       </div>
       <div class="overline text-center mt-2 mb-1">&mdash; ACTIONS &mdash;</div>
       <div v-if="mech.IsShutDown" key="a-boot">
-        <action-button v-if="actions >= 2" action-id="bootup" class="mb-1" @click="boot()" />
+        <action-button v-if="actions >= 2" action-id="boot_up" class="mb-1" @click="boot()" />
       </div>
       <div
         v-show="mech.Ejected && !mech.IsShutDown && !mech.Destroyed && !mech.ReactorDestroyed"
       >
         <v-scale-transition group>
           <v-row v-if="actions" key="a-r1" justify="center" dense>
-            <action-button cols="4" action-id="quickactivate" @click="quickAction()" />
+            <action-button cols="4" action-id="activate_quick" @click="quickAction()" />
             <action-button cols="4" action-id="boost" @click="boost()" />
             <action-button cols="4" action-id="hide" @click="hide()" />
             <action-button cols="6" action-id="search" @click="quickAction()" />
             <action-button cols="6" action-id="prepare" @click="setPrepare()" />
           </v-row>
           <v-row v-if="actions >= 2" key="a-r2" justify="center" dense>
-            <action-button action-id="mount" name-override="Remount Mech" @click="remount()" />
+            <action-button action-id="mount_dismount" name-override="Remount Mech" @click="remount()" />
             <action-button
               v-if="pilot.has('reserve', 'bombardment')"
               action-id="bombardment"
@@ -144,7 +144,7 @@
             />
             <action-button cols="6" action-id="fight" @click="fullAction()" />
             <action-button cols="6" action-id="jockey" @click="fullAction()" />
-            <action-button cols="6" action-id="fullactivate" @click="fullAction()" />
+            <action-button cols="6" action-id="activate_full" @click="fullAction()" />
             <action-button cols="6" action-id="disengage" @click="fullAction()" />
           </v-row>
           <v-row v-if="!braced && !overwatch && !bracedCooldown" key="a-r3" justify="center" dense>
@@ -184,8 +184,8 @@
       <v-scale-transition group>
         <v-row v-if="actions" key="a-r8" justify="center" dense>
           <action-button cols="4" action-id="skirmish" @click="quickAction()" />
-          <action-button cols="4" action-id="quickactivate" @click="quickAction()" />
-          <action-button cols="4" action-id="quicktech" @click="quickAction()" />
+          <action-button cols="4" action-id="activate_quick" @click="quickAction()" />
+          <action-button cols="4" action-id="quick_tech" @click="quickAction()" />
           <action-button cols="4" action-id="boost" @click="boost()" />
           <action-button cols="4" action-id="ram" @click="quickAction()" />
           <action-button cols="4" action-id="grapple" @click="quickAction()" />
@@ -199,8 +199,8 @@
             @click="bombard()"
           />
           <action-button cols="4" action-id="barrage" @click="fullAction()" />
-          <action-button cols="4" action-id="fullactivate" @click="fullAction()" />
-          <action-button cols="4" action-id="fulltech" @click="fullAction()" />
+          <action-button cols="4" action-id="activate_full" @click="fullAction()" />
+          <action-button cols="4" action-id="full_tech" @click="fullAction()" />
           <action-button cols="6" action-id="stabilize" @click="$refs.stabilize.show()" />
           <action-button cols="6" action-id="disengage" @click="fullAction()" />
         </v-row>
@@ -236,22 +236,22 @@
             </v-expansion-panel-header>
             <v-expansion-panel-content>
               <v-row dense>
-                <action-button v-if="actions >= 1" action-id="shutdown" @click="shutDown()" />
+                <action-button v-if="actions >= 1" action-id="shut_down" @click="shutDown()" />
                 <action-button v-if="actions >= 1" action-id="eject" @click="eject()" />
                 <action-button
                   v-if="actions >= 1"
-                  action-id="selfdestruct"
+                  action-id="self_destruct"
                   @click="quickAction()"
                 />
                 <action-button v-if="actions >= 1" action-id="prepare" @click="setPrepare()" />
                 <action-button
                   v-if="actions >= 2"
-                  action-id="mount"
+                  action-id="mount_dismount"
                   name-override="Dismount"
                   @click="dismount()"
                 />
-                <action-button v-if="actions >= 2" action-id="skillcheck" @click="fullAction()" />
-                <action-button v-if="actions >= 2" action-id="improvattack" @click="fullAction()" />
+                <action-button v-if="actions >= 2" action-id="skill_check" @click="fullAction()" />
+                <action-button v-if="actions >= 2" action-id="improvised_attack" @click="fullAction()" />
               </v-row>
             </v-expansion-panel-content>
           </v-expansion-panel>

--- a/src/features/pilot_management/ActiveSheet/turn/Mission/TurnManager.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Mission/TurnManager.vue
@@ -154,15 +154,15 @@
           <v-row v-if="!bracedCooldown && !overcharged" key="a-r4">
             <action-button action-id="overcharge" @click="$refs.overcharge.show()" />
           </v-row>
-          <v-row v-if="pilot.has('reserve', 'redundantrepair')" key="a-r5">
-            <action-button action-id="redundantrepair" @click="redundantRepair()" />
+          <v-row v-if="pilot.has('reserve', 'redundant_repair')" key="a-r5">
+            <action-button action-id="redundant_repair" @click="redundantRepair()" />
           </v-row>
-          <v-row v-if="pilot.has('reserve', 'deployableshield')" key="a-r6">
-            <action-button action-id="deployableshield" @click="deployableShield()" />
+          <v-row v-if="pilot.has('reserve', 'deployable_shield')" key="a-r6">
+            <action-button action-id="deployable_shield" @click="deployableShield()" />
           </v-row>
-          <v-row v-if="pilot.has('reserve', 'corebattery')" key="a-r7">
+          <v-row v-if="pilot.has('reserve', 'core_battery')" key="a-r7">
             <action-button
-              action-id="corebattery"
+              action-id="core_battery"
               :disabled="mech.CurrentCoreEnergy > 0"
               @click="coreBattery()"
             />
@@ -211,16 +211,16 @@
         <v-row v-if="!bracedCooldown && !overcharged" key="a-r11" justify="center" dense>
           <action-button action-id="overcharge" @click="$refs.overcharge.show()" />
         </v-row>
-        <v-row v-if="pilot.has('reserve', 'redundantrepair')" key="a-r12" justify="center" dense>
-          <action-button action-id="redundantrepair" @click="redundantRepair()" />
+        <v-row v-if="pilot.has('reserve', 'redundant_repair')" key="a-r12" justify="center" dense>
+          <action-button action-id="redundant_repair" @click="redundantRepair()" />
         </v-row>
-        <v-row v-if="pilot.has('reserve', 'deployableshield')" key="a-r13" justify="center" dense>
-          <action-button action-id="deployableshield" @click="deployableShield()" />
+        <v-row v-if="pilot.has('reserve', 'deployable_shield')" key="a-r13" justify="center" dense>
+          <action-button action-id="deployable_shield" @click="deployableShield()" />
         </v-row>
-        <v-row v-if="pilot.has('reserve', 'corebattery')" key="a-r14" justify="center" dense>
+        <v-row v-if="pilot.has('reserve', 'core_battery')" key="a-r14" justify="center" dense>
           <action-button
-            action-id="corebattery"
-            :disabled="mech.CurrentCoreEnergy"
+            action-id="core_battery"
+            :disabled="mech.CurrentCoreEnergy > 0"
             @click="coreBattery()"
           />
         </v-row>
@@ -461,18 +461,18 @@ export default Vue.extend({
       }
     },
     redundantRepair() {
-      const rridx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_redundantrepair')
+      const rridx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_redundant_repair')
       if (rridx > -1) this.pilot.Reserves[rridx].Used = true
       this.$refs.stabilize.show(true)
     },
     deployableShield() {
       this.history.push({ field: 'depshield', val: false })
-      const dsidx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_deployableshield')
+      const dsidx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_deployable_shield')
       if (dsidx > -1) this.pilot.Reserves[dsidx].Used = true
     },
     coreBattery() {
       this.history.push({ field: 'corebattery', val: false })
-      const cbidx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_corebattery')
+      const cbidx = this.pilot.Reserves.findIndex(x => x.ID === 'reserve_core_battery')
       if (cbidx > -1) this.pilot.Reserves[cbidx].Used = true
       this.mech.CurrentCoreEnergy = 1
     },

--- a/src/features/pilot_management/ActiveSheet/turn/Mission/components/ActionButton.vue
+++ b/src/features/pilot_management/ActiveSheet/turn/Mission/components/ActionButton.vue
@@ -73,7 +73,7 @@ export default Vue.extend({
     actionColor: '',
   }),
   created() {
-    this.action = actions.find(x => x.id === `action_${this.actionId}`)
+    this.action = actions.find(x => x.id === `act_${this.actionId}`)
     if (this.colorOverride) this.actionColor = this.colorOverride
     else this.actionColor = `action--${this.action.action_type}`
   },

--- a/src/features/pilot_management/PilotSheet/sections/mech/sections/attributes/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/sections/attributes/index.vue
@@ -68,7 +68,7 @@
           </v-col>
           <v-col cols="auto">
             <v-icon size="120" :color="color" class="px-4 mt-n2">
-              cci-size-{{ mech.size === 0.5 ? 'half' : mech.Size }}
+              cci-size-{{ mech.Size === 0.5 ? 'half' : mech.Size }}
             </v-icon>
           </v-col>
         </v-row>

--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -158,7 +158,7 @@
             </fieldset>
           </v-col>
           <v-col cols="auto">
-            <v-icon size="60">cci-size-{{ mech.size === 0.5 ? 'half' : mech.Size }}</v-icon>
+            <v-icon size="60">cci-size-{{ mech.Size === 0.5 ? 'half' : mech.Size }}</v-icon>
           </v-col>
         </v-row>
       </v-col>

--- a/src/ui/components/CCStatusSelect.vue
+++ b/src/ui/components/CCStatusSelect.vue
@@ -20,10 +20,7 @@
         </template>
         <v-card>
           <v-card-text>
-            <ul v-if="Array.isArray(item.effects)">
-              <li v-for="e in item.effects" :key="e" v-html="e" />
-            </ul>
-            <span v-else>{{ item.effects }}</span>
+            <p class='flavor-text' v-html="item.effects" />
           </v-card-text>
         </v-card>
       </v-menu>

--- a/src/ui/components/items/CCReserveItem.vue
+++ b/src/ui/components/items/CCReserveItem.vue
@@ -35,7 +35,7 @@
           <v-card-text>
             <v-row>
               <v-col cols="9">
-                <div v-if="reserve.Type === 'Narrative'">
+                <div v-if="reserve.Type === 'Resources'">
                   <v-text-field
                     v-model.lazy="reserve.ResourceName"
                     :label="reserve.ResourceLabel"

--- a/src/ui/components/selectors/CCReserveSelector.vue
+++ b/src/ui/components/selectors/CCReserveSelector.vue
@@ -6,7 +6,7 @@
     />
     <v-tabs background-color="primary" hide-slider grow>
       <v-tab>
-        <b>Narrative Reserve</b>
+        <b>Resources Reserve</b>
       </v-tab>
       <v-tab>
         <b>Tactical Reserve</b>
@@ -25,11 +25,11 @@
       </v-tab>
       <v-tab-item>
         <v-row dense class="px-12">
-          <v-col v-for="r in reserves['Narrative']" :key="`item_${r.ID}`" cols="6" class="px-4">
+          <v-col v-for="r in reserves['Resources']" :key="`item_${r.ID}`" cols="6" class="px-4">
             <reserve-item
               :reserve="r"
               icon="cci-pilot"
-              color="reserve--narrative"
+              color="reserve--resources"
               class="ma-2"
               @click="add(r)"
             />

--- a/src/ui/components/selectors/components/_CustomReservePanel.vue
+++ b/src/ui/components/selectors/components/_CustomReservePanel.vue
@@ -8,7 +8,7 @@
       >
         <div class="text-center">
           <v-btn-toggle v-model="customType" tile mandatory group color="secondary">
-            <v-btn value="Narrative">Narrative Reserve</v-btn>
+            <v-btn value="Resources">Resources Reserve</v-btn>
             <v-divider vertical="mx-2" />
             <v-btn value="Mech">Mech Reserve</v-btn>
             <v-divider vertical="mx-2" />
@@ -50,7 +50,7 @@ import { Reserve } from '@/class'
 export default Vue.extend({
   name: 'custom-reserve-panel',
   data: () => ({
-    customType: 'Narrative',
+    customType: 'Resources',
     customName: '',
     details: '',
   }),
@@ -71,7 +71,7 @@ export default Vue.extend({
       this.$emit('add', nr)
     },
     clear() {
-      this.customType = 'Narrative'
+      this.customType = 'Resources'
       this.customName = ''
       this.details = ''
     },

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -51,7 +51,7 @@ const themeDefaults = {
   'damage--heat': '#FF7043',
   'damage--variable': '#D500F9',
 
-  'reserve--narrative': '#00695C',
+  'reserve--resources': '#00695C',
   'reserve--tactical': '#827717',
   'reserve--mech': '#BF360C',
   'reserve--project': '#5D4037',


### PR DESCRIPTION
Updates to Reserves and Downtime actions to account for changes in lancer-data.

Also includes fixes for issues on the V2 spreadsheet:
* Line 78, Lesson of Shaping not allowing 2 AI.
* Line 84, Prototype Weapon and FRG adding a nameless license to loadout requirements.
* Line 100, Status/condition tool tips in active mode not using html formatting.
* Line 103, Size 1/2 icons missing in active mode (also fixed for printed mech sheets).