### PR TITLE
Refactor hp/heat rollover out of Vue and into Mech class

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -389,7 +389,10 @@ class Mech implements IActor {
 
   public set CurrentHP(hp: number) {
     if (hp > this.MaxHP) this._current_hp = this.MaxHP
-    else if (hp < 0) this._current_hp = 0
+    else if (hp <= 0) {
+      this.CurrentStructure -= 1
+      this.CurrentHP = this.MaxHP + hp
+    }
     else this._current_hp = hp
     this.save()
   }
@@ -397,11 +400,6 @@ class Mech implements IActor {
   public AddDamage(dmg: number, resistance?: string): void {
     if (resistance && this._resistances.includes(resistance)) {
       dmg = Math.ceil(dmg / 2)
-    }
-    while (dmg > this.CurrentHP) {
-      this.CurrentStructure -= 1
-      dmg -= this.CurrentHP
-      this._current_hp = this.MaxHP
     }
     this.CurrentHP -= dmg
   }
@@ -456,7 +454,10 @@ class Mech implements IActor {
   }
 
   public set CurrentHeat(heat: number) {
-    if (heat > this.HeatCapacity) this._current_heat = this.HeatCapacity
+    if (heat > this.HeatCapacity) {
+      this.CurrentStress = this.CurrentStress - 1
+      this.CurrentHeat = heat - this.HeatCapacity
+    }
     else if (heat < 0) this._current_heat = 0
     else this._current_heat = heat
     this.save()

--- a/src/features/pilot_management/ActiveSheet/layout/MechBlock.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/MechBlock.vue
@@ -126,9 +126,7 @@
             large
             color="hp"
             :full-icon="hpResistance ? 'mdi-octagram' : 'mdi-hexagon'"
-            rollover
             @update="mech.CurrentHP = $event"
-            @rollover="onHpRollover"
           >
             <span class="heading h3">HP: {{ mech.CurrentHP }}/{{ mech.MaxHP }}</span>
           </cc-tick-bar>
@@ -188,10 +186,8 @@
             large
             :color="mech.IsInDangerZone ? 'dangerzone' : 'heatcap'"
             :full-icon="mech.IsInDangerZone ? 'mdi-fire' : 'mdi-circle'"
-            rollover-negative
             clearable
             @update="mech.CurrentHeat = $event"
-            @rollover="onHeatRollover"
           >
             <span v-if="mech.IsInDangerZone" class="dangerzone--text heading h3">
               HEAT: {{ mech.CurrentHeat }}/{{ mech.HeatCapacity }}
@@ -292,8 +288,16 @@
         <v-col>
           <v-row>
             <cc-active-card color="frame" header="Speed" :content="mech.Speed" />
-            <cc-active-card color="frame" header="Attack Bonus" :content="`${mech.AttackBonus > 0 ? '+' : ''}${mech.AttackBonus}`" />
-            <cc-active-card color="frame" header="Tech Attack" :content="`${mech.TechAttack > 0 ? '+' : ''}${mech.TechAttack}`" />
+            <cc-active-card
+              color="frame"
+              header="Attack Bonus"
+              :content="`${mech.AttackBonus > 0 ? '+' : ''}${mech.AttackBonus}`"
+            />
+            <cc-active-card
+              color="frame"
+              header="Tech Attack"
+              :content="`${mech.TechAttack > 0 ? '+' : ''}${mech.TechAttack}`"
+            />
           </v-row>
           <v-row>
             <cc-active-card
@@ -355,6 +359,7 @@
 </template>
 
 <script lang="ts">
+import sleep from '@/util/sleep'
 import { Mech, MechLoadout } from '@/class'
 import MechSelectButton from '../components/MechSelectButton.vue'
 
@@ -384,6 +389,28 @@ export default Vue.extend({
     structRolledOver: false,
     stressRolledOver: false,
   }),
+  watch: {
+    'mech.CurrentStructure': {
+      async handler(newVal: number, oldVal: number) {
+        if (newVal < oldVal) {
+          this.structRolledOver = true
+          await sleep(500)
+          this.structRolledOver = false
+          this.$refs.structureTable.show()
+        }
+      }
+    },
+    'mech.CurrentStress': {
+      async handler(newVal: number, oldVal: number) {
+        if (newVal < oldVal) {
+          this.stressRolledOver = true
+          await sleep(500)
+          this.stressRolledOver = false
+          this.$refs.stressTable.show()
+        }
+      }
+    }
+  },
   computed: {
     mech(): Mech {
       return this.pilot.ActiveMech || null
@@ -413,36 +440,6 @@ export default Vue.extend({
         return 'variable--damage'
       }
       return 'hp'
-    },
-  },
-  methods: {
-    onHpRollover() {
-      if (this.mech.CurrentStructure <= 1) {
-        this.$nextTick(() => {
-          this.mech.CurrentHP = 0
-        })
-      }
-      this.mech.CurrentStructure = this.mech.CurrentStructure - 1
-      if (this.mech.CurrentStructure < 0) this.mech.CurrentStructure = 0
-      this.structRolledOver = true
-      setTimeout(() => {
-        this.structRolledOver = false
-        this.$refs.structureTable.show()
-      }, 500)
-    },
-    onHeatRollover() {
-      if (this.mech.CurrentStress <= 1) {
-        this.$nextTick(() => {
-          this.mech.CurrentHeat = this.mech.HeatCapacity
-        })
-      }
-      this.mech.CurrentStress = this.mech.CurrentStress - 1
-      if (this.mech.CurrentStress < 0) this.mech.CurrentStress = 0
-      this.stressRolledOver = true
-      setTimeout(() => {
-        this.stressRolledOver = false
-        this.$refs.stressTable.show()
-      }, 500)
     },
   },
 })

--- a/src/ui/components/CCTickBar.vue
+++ b/src/ui/components/CCTickBar.vue
@@ -117,8 +117,6 @@ export default Vue.extend({
     clearable: {
       type: Boolean,
     },
-    rollover: { type: Boolean, default: false },
-    rolloverNegative: { type: Boolean, default: false },
   },
   data: () => ({
     model: 0,
@@ -144,7 +142,7 @@ export default Vue.extend({
     startInputting() {
       this.inputting = true
       this.$nextTick(() => {
-        ;(this.$refs.pipinput as HTMLInputElement).focus()
+        ; (this.$refs.pipinput as HTMLInputElement).focus()
       })
     },
     sendInput() {
@@ -162,22 +160,6 @@ export default Vue.extend({
         preResult -= parseInt(thisInput.substr(1))
       } else {
         preResult = parseInt(thisInput)
-      }
-
-      if (this.rolloverNegative) {
-        while (preResult > this.max) {
-          preResult = preResult - this.max
-          this.$emit('rollover')
-        }
-      } else preResult = Math.min(preResult, this.max)
-
-      if (this.rollover) {
-        while (preResult < 1) {
-          preResult = this.max + preResult
-          this.$emit('rollover')
-        }
-      } else {
-        preResult = Math.max(0, preResult)
       }
 
       this.$emit('update', preResult)

--- a/src/util/sleep.ts
+++ b/src/util/sleep.ts
@@ -1,0 +1,7 @@
+export default function sleep(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve()
+    }, timeout);
+  })
+}


### PR DESCRIPTION
Currently, the logic for rolling over HP and heat and deducting structure/stress points accordingly is handled on the UI side inside the Vue components. This PR removes that logic from `CCTickbar` and `MechBlock` and adds it to the `Mech` class. In `MechBlock`, we instead use Vue watchers on the current structure and stress to pop up the appropriate roll table.

 The most obvious benefit, aside from keeping business logic out of the UI, is that the stress/structure rollover (& accompanying roll table popups) are now triggered by any structure loss no matter what, rather than only ones caused by CCTickBar.

Closes #555. Should also consider closing #561 - rxJS might actually be overkill, but we should think it over.