### PR TITLE
Generate version string based on environment

### DIFF
--- a/src/features/main_menu/_components/MainTitle.vue
+++ b/src/features/main_menu/_components/MainTitle.vue
@@ -14,7 +14,7 @@
     <div id="subtitle">
       <span>A digital toolset for the LANCER TTRPG</span>
       <v-icon size="8pt" color="white" class="ml-2 mr-2">mdi-delta</v-icon>
-      <span>VERSION: {{ versionString }} // LANCER CORE {{ lancerVersion }}</span>
+      <span>VERSION: {{ $appVersion }} // LANCER CORE {{ $lancerVersion }}</span>
     </div>
   </div>
 </template>
@@ -22,13 +22,7 @@
 <script lang="ts">
 import Vue from 'vue'
 export default Vue.extend({
-  name: 'cci-banner',
-  data: () => ({
-    versionString: ''
-  }),
-  mounted() {
-    this.versionString = process.env.VERSION_STRING;
-  }
+  name: 'cci-banner'
 })
 </script>
 

--- a/src/features/main_menu/_components/MainTitle.vue
+++ b/src/features/main_menu/_components/MainTitle.vue
@@ -14,7 +14,7 @@
     <div id="subtitle">
       <span>A digital toolset for the LANCER TTRPG</span>
       <v-icon size="8pt" color="white" class="ml-2 mr-2">mdi-delta</v-icon>
-      <span>V2 PREVIEW / COMMIT {{ commitRef }} // LANCER CORE {{ lancerVersion }}</span>
+      <span>VERSION: {{ versionString }} // LANCER CORE {{ lancerVersion }}</span>
     </div>
   </div>
 </template>
@@ -24,10 +24,10 @@ import Vue from 'vue'
 export default Vue.extend({
   name: 'cci-banner',
   data: () => ({
-    commitRef: ''
+    versionString: ''
   }),
   mounted() {
-    this.commitRef = process.env.COMMIT_REF;
+    this.versionString = process.env.VERSION_STRING;
   }
 })
 </script>

--- a/src/features/nav/index.vue
+++ b/src/features/nav/index.vue
@@ -40,7 +40,7 @@
 
     <v-toolbar-title>
       <span class="heading">COMP/CON</span>
-      <span class="flavor-text white--text">v{{ version }}</span>
+      <span class="flavor-text white--text">{{ $appVersion }}</span>
     </v-toolbar-title>
 
     <v-spacer />

--- a/src/features/nav/pages/About.vue
+++ b/src/features/nav/pages/About.vue
@@ -3,9 +3,9 @@
     <p class="heading mech">COMP/CON</p>
     <div class="mx-2">
       C/C version:
-      <b class="primary--text">{{ version }}//[{{ commitRef }}]</b>
+      <b class="primary--text">{{ $appVersion }}</b>
       // LANCER CORE version:
-      <b class="primary--text">{{ lancerVersion }}</b>
+      <b class="primary--text">{{ $lancerVersion }}</b>
     </div>
     <p align="center" class="my-2">
       <a href="https://app.netlify.com/sites/compcon/deploys">

--- a/src/io/BulkData.ts
+++ b/src/io/BulkData.ts
@@ -35,7 +35,7 @@ const importAll = async function(file): Promise<void> {
   const promises = arr.map(o => writeFile(o.filename, o.data))
   Promise.all(promises).then(() => {
     Extlog('Loading import data...')
-    Startup(Vue.prototype.version, Vue.prototype.lancerVersion, store)
+    Startup(Vue.prototype.$appVersion, Vue.prototype.$lancerVersion, store)
     Extlog('Import data loaded!')
   })
 }
@@ -44,7 +44,7 @@ const clearAllData = async function(): Promise<void> {
   const promises = files.map(file => writeFile(file, ''))
   Promise.all(promises).then(() => {
     Extlog('Erasing all COMP/CON data...')
-    Startup(Vue.prototype.version, Vue.prototype.lancerVersion, store)
+    Startup(Vue.prototype.$appVersion, Vue.prototype.$lancerVersion, store)
     Extlog('All data erased!')
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,8 @@ import { Capacitor } from '@capacitor/core'
 Object.defineProperty(Vue.prototype, '$_', { value: _ })
 Object.defineProperty(Vue.prototype, '$platform', { value: Capacitor.platform })
 
-Vue.prototype.lancerVersion = `${lancerData.info.version} [${require('lancer-data/package.json').version}]`
+Vue.prototype.$appVersion = process.env.VERSION_STRING
+Vue.prototype.$lancerVersion = `${lancerData.info.version} [${require('lancer-data/package.json').version}]`
 
 Vue.use(Vuetify)
 Vue.use(VueMousetrap)
@@ -49,7 +50,7 @@ new Vue({
   router,
   store,
   created() {
-    Startup(Vue.prototype.version, Vue.prototype.lancerVersion, store)
+    Startup(Vue.prototype.$appVersion, Vue.prototype.$lancerVersion, store)
   },
   render: h => h(App),
 }).$mount('#app')

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,8 +30,7 @@ import { Capacitor } from '@capacitor/core'
 Object.defineProperty(Vue.prototype, '$_', { value: _ })
 Object.defineProperty(Vue.prototype, '$platform', { value: Capacitor.platform })
 
-Vue.prototype.version = '2.0.0'
-Vue.prototype.lancerVersion = lancerData.info.version
+Vue.prototype.lancerVersion = `${lancerData.info.version} [${require('lancer-data/package.json').version}]`
 
 Vue.use(Vuetify)
 Vue.use(VueMousetrap)

--- a/src/shims/shims-vue.d.ts
+++ b/src/shims/shims-vue.d.ts
@@ -2,8 +2,9 @@ import Vue from 'vue'
 
 declare module 'vue/types/vue' {
   interface Vue {
+    $appVersion: string
+    $lancerVersion: string
     $platform: string
-    lancerVersion: string
     $notify: (text: string, type?: string, onClick?: () => void) => void
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,23 @@ const DefinePlugin = require('webpack').DefinePlugin
 const path = require('path');
 const merge = require('webpack-merge')
 
+
+function versionString() {
+  // Versioned releases
+  // Travis should only build on tags - therefore TRAVIS_TAG should always exist
+  // when we are in a Travis environment.
+  if (process.env.TRAVIS_TAG) {
+    return process.env.TRAVIS_TAG
+    // Otherwise, if COMMIT_REF exists, we are being built by Netlify (usually previews)
+  } else if (process.env.COMMIT_REF) {
+    const commitRef = process.env.COMMIT_REF.substring(0, 7)
+    return `PREVIEW @ ${commitRef}`
+    // Otherwise this is probably a local build
+  } else {
+    return 'UNKNOWN'
+  }
+}
+
 const baseConfig = {
   entry: {
     app: './src/main.ts',
@@ -146,7 +163,7 @@ const baseConfig = {
       template: path.resolve(__dirname, 'public/index.html')
     }),
     new DefinePlugin({
-      'process.env.COMMIT_REF': JSON.stringify((process.env.COMMIT_REF && process.env.COMMIT_REF.substring(0, 7)) || 'UNKNOWN')
+      'process.env.VERSION_STRING': JSON.stringify(versionString())
     }),
   ]
 }


### PR DESCRIPTION
Generates a version string, which will be either: the tag on a (full release) Travis build, the commit ref on a Netlify (nightly/preview) build, or otherwise "Unknown".

Also adds the package.json version to the LANCER CORE version.

Resolves #483.