### PR TITLE
Editable UserID to allow cloud import ownership

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -307,7 +307,7 @@ class Pilot {
   }
 
   public get IsUserOwned(): boolean {
-    return this.CloudOwnerID === store.getters.getUserProfile.userID
+    return this.CloudOwnerID === store.getters.getUserProfile.ID
   }
 
   public SetCloudImage(src: string): void {
@@ -316,6 +316,9 @@ class Pilot {
   }
 
   public async CloudSave(): Promise<any> {
+    if (!this.CloudOwnerID) {
+      this.CloudOwnerID = store.getters.getUserProfile.ID
+    }
     if (!this.CloudID) {
       return gistApi.newPilot(this).then((response: any) => {
         this.setCloudInfo(response.id)
@@ -344,7 +347,7 @@ class Pilot {
 
   public setCloudInfo(id: string): void {
     this.CloudID = id
-    this.CloudOwnerID = store.getters.getUserProfile.userID
+    this.CloudOwnerID = store.getters.getUserProfile.ID
     this.LastCloudUpdate = new Date().toString()
   }
 

--- a/src/features/nav/pages/Options.vue
+++ b/src/features/nav/pages/Options.vue
@@ -5,7 +5,11 @@
       <v-col cols="8" class="mr-3">
         <div class="flavor-text">
           <b>USER ID:</b>
-          <span class="primary--text">{{ userID }}</span>
+          <span class="primary--text">
+            <cc-short-string-editor class="d-inline" @set="setUserID($event)">
+              {{ userID }}
+            </cc-short-string-editor>
+          </span>
         </div>
         <v-divider />
         <div class="mx-12">
@@ -131,6 +135,10 @@ export default Vue.extend({
     },
   },
   methods: {
+    setUserID(id: string) {
+      const store = getModule(CompendiumStore, this.$store)
+      store.UserProfile.ID = id
+    },
     async bulkExport() {
       exportAll().then(res => {
         saveFile(

--- a/src/features/pilot_management/PilotSheet/components/CloudDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/CloudDialog.vue
@@ -34,7 +34,7 @@
             Vault
           </span>
           <span v-else>
-            {{ pilot.Callsign }} data is stored in
+            {{ pilot.Callsign }}'s data is stored in
             <b class="primary--text">someone else's</b>
             Vault
           </span>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/IdentBlock.vue
@@ -36,8 +36,16 @@
       <v-col class="pt-0" dense>
         <span class="overline">OMNINET UPLINK ID</span>
         <br />
-        <span v-if="pilot.CloudID">{{ pilot.CloudID }}</span>
-        <span v-else class="stat-text error--text">// NOT SYNCED //</span>
+        <span v-if="pilot.CloudID">
+          <cc-short-string-editor class="d-inline" @set="pilot.CloudID = $event">
+            {{ pilot.CloudID }}
+          </cc-short-string-editor>
+        </span>
+        <span v-else class="stat-text error--text">
+          <cc-short-string-editor class="d-inline" @set="setCloudID($event)">
+            // NOT SYNCED //
+          </cc-short-string-editor>
+        </span>
         <cc-tooltip
           v-if="!syncing"
           inline
@@ -116,6 +124,11 @@ export default vueMixins(activePilot).extend({
         default:
           return 'text'
           break
+      }
+    },
+    setCloudID(id: string) {
+      if (id && id != "// NOT SYNCED //") {
+        this.pilot.CloudID = id
       }
     },
     sync() {

--- a/src/features/pilot_management/Roster/components/add_panels/CloudImport.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/CloudImport.vue
@@ -72,8 +72,13 @@ export default Vue.extend({
       this.cloudLoading = false
     },
     confirmImport() {
-      this.importPilot.RenewID()
-      getModule(PilotManagementStore, this.$store).addPilot(this.importPilot)
+      let importPilot = this.importPilot as Pilot
+      if (importPilot.IsUserOwned) {
+        importPilot.CloudID = this.importID
+      } else {
+        importPilot.RenewID()
+      }
+      getModule(PilotManagementStore, this.$store).addPilot(importPilot)
       this.reset()
       this.dialog = false
       this.importID = ''


### PR DESCRIPTION
Allows the user to edit their User ID, as well as edit the Cloud ID in the Pilot Dossier view. This allows a user to essentially claim ownership of a cloud save from multiple computers if they enter the same User ID on all of them.

In order for this to work, the cloud import was refactored to retain the pilot's cloud ID and cloud owner ID if the owner ID matches the user ID.

This also fixes a couple bugs to do with `Pilot.CloudOwnerID`. It was not set before uploading a pilot to the cloud initially, so currently all new cloud saves have no associated owner ID. 