### PR TITLE
NPC feature card updates

### DIFF
--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -1,3 +1,5 @@
+import { Tag } from '@/class'
+
 export enum NpcFeatureType {
   Trait = 'Trait',
   System = 'System',
@@ -19,6 +21,7 @@ export interface INpcFeatureData {
   locked: boolean
   effect?: string
   bonus?: object
+  tags: ITagData[]
   brew: string
   type: NpcFeatureType
 }
@@ -30,6 +33,7 @@ export abstract class NpcFeature {
   private _effect: string
   private _bonus: object
   private _locked: boolean
+  private _tags: ITagData[]
   private _brew: string
   protected type: NpcFeatureType
 
@@ -40,6 +44,7 @@ export abstract class NpcFeature {
     this._effect = data.effect || ''
     this._bonus = data.bonus || null
     this._locked = data.locked || false
+    this._tags = data.tags
     this._brew = data.brew || 'CORE'
   }
 
@@ -97,6 +102,10 @@ export abstract class NpcFeature {
 
   public get IsLocked(): boolean {
     return this._locked
+  }
+
+  public get Tags(): Tag[] {
+    return Tag.Deserialize(this._tags)
   }
 
   public get FeatureType(): NpcFeatureType {

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -1,23 +1,15 @@
-import { Tag } from '@/class'
 import { NpcFeature, NpcFeatureType } from './'
 import { INpcFeatureData } from './interfaces'
 
 export interface INpcSystemData extends INpcFeatureData {
-  tags: ITagData[]
   type: NpcFeatureType.System
 }
 
 export class NpcSystem extends NpcFeature {
-  private _tags: ITagData[]
 
   public constructor(data: INpcSystemData) {
     super(data)
-    this._tags = data.tags
     this.type = NpcFeatureType.System
-  }
-
-  public get Tags(): Tag[] {
-    return Tag.Deserialize(this._tags)
   }
 
   public get IsLimited(): boolean {

--- a/src/ui/components/cards/_NpcTechCard.vue
+++ b/src/ui/components/cards/_NpcTechCard.vue
@@ -6,17 +6,34 @@
           <v-icon x-large>cci-reticle</v-icon>
         </div>
         <span>
+          +{{ item.AttackBonus(1) }}/+{{ item.AttackBonus(2) }}/+{{ item.AttackBonus(3) }}
+          <br />
+          <div class="overline mt-n1">
+            Attack Bonus
+          </div>
+        </span>
+      </div>
+      <div v-if="item.Accuracy(1) > 0" class="text-center ml-auto mr-auto" style="display: inline-block">
+        <div class="clip-icon">
+          <v-icon x-large>cci-accuracy</v-icon>
+        </div>
+        <span>
           +{{ item.Accuracy(1) }}/+{{ item.Accuracy(2) }}/+{{ item.Accuracy(3) }}
           <br />
           <div class="overline mt-n1">
             Accuracy
           </div>
         </span>
+      </div>
+      <div v-else-if="item.Accuracy(1) < 0">
+        <div class="clip-icon">
+          <v-icon x-large>cci-difficulty</v-icon>
+        </div>
         <span>
-          +{{ item.AttackBonus(1) }}/+{{ item.AttackBonus(2) }}/+{{ item.AttackBonus(3) }}
+          +{{ Math.abs(item.Accuracy(1)) }}/+{{ Math.abs(item.Accuracy(2)) }}/+{{ Math.abs(item.Accuracy(3)) }}
           <br />
           <div class="overline mt-n1">
-            Attack Bonus
+            Difficulty
           </div>
         </span>
       </div>

--- a/src/ui/components/cards/_NpcWeaponCard.vue
+++ b/src/ui/components/cards/_NpcWeaponCard.vue
@@ -20,17 +20,17 @@
           <v-icon x-large>cci-reticle</v-icon>
         </div>
         <span>
-          +{{ item.Accuracy(1) }}/+{{ item.Accuracy(2) }}/+{{ item.Accuracy(3) }}
+          +{{ item.AttackBonus(1) }}/+{{ item.AttackBonus(2) }}/+{{ item.AttackBonus(3) }}
           <br />
           <div class="overline mt-n1">
-            Accuracy
+            Attack Bonus
           </div>
         </span>
       </div>
     </v-col>
     <v-divider vertical class="mx-4" />
     <v-col cols="auto">
-      <div class="text-center ml-auto mr-auto" style="display: inline-block">
+      <div v-if="item.Accuracy(1) > 0" class="text-center ml-auto mr-auto" style="display: inline-block">
         <div class="clip-icon">
           <v-icon x-large>cci-accuracy</v-icon>
         </div>
@@ -38,7 +38,19 @@
           +{{ item.Accuracy(1) }}/+{{ item.Accuracy(2) }}/+{{ item.Accuracy(3) }}
           <br />
           <div class="overline mt-n1">
-            Advantage
+            Accuracy
+          </div>
+        </span>
+      </div>
+      <div v-else-if="item.Accuracy(1) < 0" class="text-center ml-auto mr-auto" style="display: inline-block">
+        <div class="clip-icon">
+          <v-icon x-large>cci-difficulty</v-icon>
+        </div>
+        <span>
+          +{{ Math.abs(item.Accuracy(1)) }}/+{{ Math.abs(item.Accuracy(2)) }}/+{{ Math.abs(item.Accuracy(3)) }}
+          <br />
+          <div class="overline mt-n1">
+            Difficulty
           </div>
         </span>
       </div>

--- a/src/ui/components/cards/npc/cards/_TechCard.vue
+++ b/src/ui/components/cards/npc/cards/_TechCard.vue
@@ -5,30 +5,58 @@
     :readonly="readonly"
     @remove-feature="$emit('remove-feature', $event)"
   >
-    <div>
-      <span v-if="item.Tier" class="heading h3">
-        +{{ item.Feature.Accuracy(item.Tier) }}
-        Accuracy
-      </span>
-      <span v-else class="heading h3">
-        +{{ item.Feature.Accuracy(1) }} / +{{ item.Feature.Accuracy(2) }} / +{{
-          item.Feature.Accuracy(3)
-        }}
-        Accuracy
-      </span>
-      <!-- <span v-if="item.AttackBonus" class="mx-3">&nbsp;|&nbsp;</span> -->
-      <span v-if="item.Tier" class="heading h3">
-        +{{ item.Feature.AttackBonus(item.Tier) }}
-        Attack Bonus
-      </span>
-      <span v-else class="heading h3">
-        +{{ item.Feature.AttackBonus(1) }} / +{{ item.Feature.AttackBonus(2) }} / +{{
-          item.Feature.AttackBonus(3)
-        }}
-        Attack Bonus
-      </span>
-      <span style="float: right" class="heading h3">{{ item.Feature.TechType }} TECH</span>
-    </div>
+    <v-row class="heading h3 text-center" dense no-gutters>
+      <v-col cols="auto">
+        <span v-if="item.Tier" class="heading h3">
+          <v-icon>cci-reticle</v-icon>
+          +{{ item.Feature.AttackBonus(item.Tier) }}
+          Attack Bonus
+        </span>
+        <span v-else class="heading h3">
+          <v-icon>cci-reticle</v-icon>
+          +{{ item.Feature.AttackBonus(1) }} / +{{ item.Feature.AttackBonus(2) }} / +{{
+            item.Feature.AttackBonus(3)
+          }}
+          Attack Bonus
+        </span>
+      </v-col>
+      <v-divider vertical class="mx-4" />
+      <v-col>
+        <span v-if="item.Tier" class="heading h3">
+          <div v-if="item.Feature.Accuracy(item.Tier) > 0">
+            <v-icon>cci-accuracy</v-icon>
+            +{{ item.Feature.Accuracy(item.Tier) }}
+            Accuracy
+          </div>
+          <div v-else-if="item.Feature.Accuracy(item.Tier) < 0">
+            <v-icon>cci-difficulty</v-icon>
+            +{{ Math.abs(item.Feature.Accuracy(item.Tier)) }}
+            Difficulty
+          </div>
+        </span>
+        <span v-else class="heading h3">
+          <div v-if="item.Feature.Accuracy(1) > 0">
+            <v-icon>cci-accuracy</v-icon>
+            +{{ item.Feature.Accuracy(1) }} / +{{ item.Feature.Accuracy(2) }} / +{{
+              item.Feature.Accuracy(3)
+            }}
+            Accuracy
+          </div>
+          <div v-else-if="item.Feature.Accuracy(1) < 0">
+            <v-icon>cci-difficulty</v-icon>
+            +{{ Math.abs(item.Feature.Accuracy(1)) }} / +{{ Math.abs(item.Feature.Accuracy(2)) }} / +{{
+              Math.abs(item.Feature.Accuracy(3))
+            }}
+            Difficulty
+          </div>
+        </span>
+      </v-col>
+      <v-divider vertical class="mx-4" />
+      <v-col>
+        <!-- <span v-if="item.AttackBonus" class="mx-3">&nbsp;|&nbsp;</span> -->
+        <span style="float: right" class="heading h3">{{ item.Feature.TechType }} TECH</span>
+      </v-col>
+    </v-row>
     <span class="overline">EFFECT</span>
     <p v-if="item.Tier" class="body-1 mb-0" v-html="item.Feature.EffectByTier(item.Tier)" />
     <p v-else class="body-1 mb-0" v-html="item.Feature.Effect" />

--- a/src/ui/components/cards/npc/cards/_TraitCard.vue
+++ b/src/ui/components/cards/npc/cards/_TraitCard.vue
@@ -8,6 +8,7 @@
     <span class="overline">EFFECT</span>
     <p v-if="item.Tier" class="body-1 mb-0" v-html="item.Feature.EffectByTier(item.Tier)" />
     <p v-else class="body-1 mb-0" v-html="item.Feature.Effect" />
+    <cc-tags :tags="item.Feature.Tags" small />
   </card-base>
 </template>
 

--- a/src/ui/components/cards/npc/cards/_WeaponCard.vue
+++ b/src/ui/components/cards/npc/cards/_WeaponCard.vue
@@ -27,11 +27,13 @@
       <v-divider vertical class="mx-4" />
       <v-col>
         <span v-if="item.Tier" class="heading h3">
+          <v-icon>cci-reticle</v-icon>
           <span v-if="item.Feature.AttackBonus(item.Tier) > 0">+</span>
           {{ item.Feature.AttackBonus(item.Tier) }}
           Attack Bonus
         </span>
         <span v-else>
+          <v-icon>cci-reticle</v-icon>
           <span v-if="item.Feature.AttackBonus(1) > 0">+</span>
           {{ item.Feature.AttackBonus(1) }} /
           <span v-if="item.Feature.AttackBonus(2) > 0">+</span>
@@ -44,15 +46,37 @@
       <v-divider vertical />
       <v-col>
         <span v-if="item.Tier" class="heading h3">
-          +{{ item.Feature.Accuracy(item.Tier) }}
-          Accuracy Bonus
+          <div v-if="item.Feature.Accuracy(item.Tier) > 0">
+            <v-icon>cci-accuracy</v-icon>
+            +{{ item.Feature.Accuracy(item.Tier) }}
+            Accuracy
+          </div>
+          <div v-else-if="item.Feature.Accuracy(item.Tier) < 0">
+            <v-icon>cci-difficulty</v-icon>
+            +{{ Math.abs(item.Feature.Accuracy(item.Tier)) }}
+            Difficulty
+          </div>
         </span>
         <span v-else>
-          +{{ item.Feature.Accuracy(1) }} / +{{ item.Feature.Accuracy(2) }} / +{{
-            item.Feature.Accuracy(3)
-          }}
-          Accuracy Bonus
+          <div v-if="item.Feature.Accuracy(1) > 0">
+            <v-icon>cci-accuracy</v-icon>
+            +{{ item.Feature.Accuracy(1) }} / +{{ item.Feature.Accuracy(2) }} / +{{
+              item.Feature.Accuracy(3)
+            }}
+            Accuracy
+          </div>
+          <div v-else-if="item.Feature.Accuracy(1) < 0">
+            <v-icon>cci-difficulty</v-icon>
+            +{{ Math.abs(item.Feature.Accuracy(1)) }} / +{{ Math.abs(item.Feature.Accuracy(2)) }} / +{{
+              Math.abs(item.Feature.Accuracy(3))
+            }}
+            Difficulty
+          </div>
         </span>
+      </v-col>
+      <v-divider vertical />
+      <v-col>
+        <span style="float: right" class="heading h3">{{ item.Feature.WeaponType }}</span>
       </v-col>
     </v-row>
     <div v-if="item.Feature.OnHit">


### PR DESCRIPTION
Updates to NPC feature cards. 

Fixes #575, #576, #588.

Displays difficulty instead of "+-X Accuracy", added glyphs, made attack bonus/accuracy display order consistent between weapons and tech, added weapon type to compact cards.

Moves tag handling into the base NPCFeature class, since all types of features can have tags. Display tags on trait cards.

![weapon1](https://user-images.githubusercontent.com/49248157/73622332-da9db600-45fe-11ea-9776-bdc662280ecd.png)
![weapon3](https://user-images.githubusercontent.com/49248157/73622407-0b7deb00-45ff-11ea-9d3d-8b2d4671fe39.png)
![weapon2](https://user-images.githubusercontent.com/49248157/73622337-dd98a680-45fe-11ea-96df-d8a1d0d1f62a.png)
![tech1](https://user-images.githubusercontent.com/49248157/73622341-df626a00-45fe-11ea-82d9-bcb8920f765b.png)
