### PR TITLE
AI Counting Fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Issue Number
+`#0000`
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_cache:
 stages:
   - name: test
   - name: build
-    if: tag IS present AND tag =~ /^\d+.\d+.\d+[a-z]?-(beta|stable|test)$/
+    if: tag IS present
 
 jobs:
   include:
@@ -31,32 +31,32 @@ jobs:
         - yarn int-test
         - yarn build --linux --publish never
     - stage: build
-      name: build_electron
-      os: osx
-      osx_image: xcode10.2
-      script:
-        - mkdir -p ~/$TRAVIS_BUILD_NUMBER/mac
-        - yarn electron:build -mwl --publish never
-      deploy:
-      - provider: releases
-        skip_cleanup: true
-        api_key: $GH_TOKEN
-        file_glob: true
-        file:
-        - "electron/dist/COMPCON*.AppImage"
-        - "electron/dist/COMPCON*.exe"
-        - "electron/dist/COMPCON*mac.zip"
-        skip_cleanup: true
-        draft: true
-        on:
-          tags: true
-          all_branches: true
-      - provider: script
-        skip_cleanup: true
-        on:
-          tags: true
-          all_branches: true
-        script: bash build_scripts/deploy_butler.sh
+      # name: build_electron
+      # os: osx
+      # osx_image: xcode10.2
+      # script:
+      #   - mkdir -p ~/$TRAVIS_BUILD_NUMBER/mac
+      #   - yarn electron:build -mwl --publish never
+      # deploy:
+      # - provider: releases
+      #   skip_cleanup: true
+      #   api_key: $GH_TOKEN
+      #   file_glob: true
+      #   file:
+      #   - "electron/dist/COMPCON*.AppImage"
+      #   - "electron/dist/COMPCON*.exe"
+      #   - "electron/dist/COMPCON*mac.zip"
+      #   skip_cleanup: true
+      #   draft: true
+      #   on:
+      #     tags: true
+      #     branch: master
+      # - provider: script
+      #   skip_cleanup: true
+      #   on:
+      #     tags: true
+      #     branch: master
+      #   script: bash build_scripts/deploy_butler.sh
     - name: build_web
       os: linux
       script:
@@ -72,4 +72,4 @@ jobs:
         skip_cleanup: true
         on:
           tags: true
-          all_branches: true
+          branch: master

--- a/src/classes/mech/MechLoadout.ts
+++ b/src/classes/mech/MechLoadout.ts
@@ -103,7 +103,12 @@ class MechLoadout extends Loadout {
   }
 
   public get Equipment(): MechEquipment[] {
-    return (this.Weapons as MechEquipment[]).concat(this.Systems as MechEquipment[])
+    let mods = this.Weapons.map(x => x.Mod).filter(x => x != null)
+    let equip = ((this.Weapons as MechEquipment[])
+                  .concat(this.Systems as MechEquipment[])
+                  .concat(this.IntegratedSystems as MechEquipment[]))
+    if (mods.length > 0) return equip.concat(mods as MechEquipment[])
+    else return equip
   }
 
   public get Weapons(): MechWeapon[] {
@@ -223,6 +228,8 @@ class MechLoadout extends Loadout {
   }
 
   public get AICount(): number {
+    console.log(`AI count: ${this.Equipment.filter(x => x.IsAI).length}`)
+    console.log(this.Equipment.filter(x => x.IsAI))
     return this.Equipment.filter(x => x.IsAI).length
   }
 

--- a/src/classes/mech/MechLoadout.ts
+++ b/src/classes/mech/MechLoadout.ts
@@ -228,8 +228,6 @@ class MechLoadout extends Loadout {
   }
 
   public get AICount(): number {
-    console.log(`AI count: ${this.Equipment.filter(x => x.IsAI).length}`)
-    console.log(this.Equipment.filter(x => x.IsAI))
     return this.Equipment.filter(x => x.IsAI).length
   }
 


### PR DESCRIPTION
Fix #585.

Add integrated systems and weapon mods to the results of `MechLoadout.Equipment` so that they get checked for AI tags as well.

<strong>Note:</strong> The Technophile 3 AI currently doesn't have the bonus AI tag, so it will disallow other AIs until lancer-data is updated.