### PR TITLE
Show linebreaks in pilot biography & appearance blocks

### DIFF
--- a/src/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/AppearanceBlock.vue
@@ -7,7 +7,7 @@
     <div class="my-2">
       <p
         v-if="pilot.TextAppearance"
-        class="flavor-text text--text mx-2"
+        class="flavor-text text--text mx-2 preserve-linebreaks"
         v-html="pilot.TextAppearance"
       />
       <no-data-block v-else />

--- a/src/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/HistoryBlock.vue
@@ -5,7 +5,7 @@
       Pilot Biography
     </cc-title>
     <div class="my-2">
-      <p v-if="pilot.History" class="flavor-text text--text mx-2" v-html="pilot.History" />
+      <p v-if="pilot.History" class="flavor-text text--text mx-2 preserve-linebreaks" v-html="pilot.History" />
       <no-data-block v-else />
     </div>
     <cc-solo-dialog

--- a/src/ui/style/typography.css
+++ b/src/ui/style/typography.css
@@ -173,6 +173,10 @@ code.horus:hover {
   animation: distort-subtle 5s infinite;
 }
 
+.preserve-linebreaks {
+  white-space: pre-wrap;
+}
+
 @keyframes distort {
   0% {
     text-shadow: 2px 1px #ff00ff, -2px -3px #00ffff;


### PR DESCRIPTION
# Description

Adds the `white-space: pre-wrap` style to the pilot biography & appearance blocks so that they preserve user line breaks. Bit of a bandaid while we implement #606 

- [x] Bug fix (non-breaking change which fixes an issue)