### PR TITLE
Vcc base components conversion (fixed)

### DIFF
--- a/src/mixins/getColor.ts
+++ b/src/mixins/getColor.ts
@@ -6,11 +6,10 @@ export default class GetColorMixin extends Vue {
   color!: string
 
   getColor(color?: string, vuetifyRef?: Framework): string {
-    if (color === undefined) 
-      color = this.color
+    color = color ?? this.color
     if (vuetifyRef === undefined)
       vuetifyRef = this.$vuetify
-    if (color.substring(0, 1) === '#') return color
+    if (color?.substring(0, 1) === '#') return color
     return vuetifyRef.theme.currentTheme[color].toString()
   }
 }

--- a/src/mixins/getColor.ts
+++ b/src/mixins/getColor.ts
@@ -1,6 +1,7 @@
-import { Vue } from "vue-property-decorator";
+import { Vue, Component } from "vue-property-decorator";
 import { Framework } from 'vuetify';
 
+@Component
 export default class GetColorMixin extends Vue {
   color!: string
 

--- a/src/mixins/getColor.ts
+++ b/src/mixins/getColor.ts
@@ -1,8 +1,15 @@
-export default {
-  methods: {
-    getColor(): string {
-      if (this.color.substring(0, 1) === '#') return this.color
-      return this.$vuetify.theme.currentTheme[this.color]
-    },
-  },
+import { Vue } from "vue-property-decorator";
+import { Framework } from 'vuetify';
+
+export default class GetColorMixin extends Vue {
+  color!: string
+
+  getColor(color?: string, vuetifyRef?: Framework): string {
+    if (color === undefined) 
+      color = this.color
+    if (vuetifyRef === undefined)
+      vuetifyRef = this.$vuetify
+    if (color.substring(0, 1) === '#') return color
+    return vuetifyRef.theme.currentTheme[color].toString()
+  }
 }

--- a/src/mixins/getColor.unit.test.ts
+++ b/src/mixins/getColor.unit.test.ts
@@ -1,0 +1,27 @@
+import 'jest'
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import GetColorMixin from "@/mixins/getColor"
+import { Vue, Mixins } from 'vue-property-decorator'
+import Vuetify from 'vuetify'
+
+Vue.use(Vuetify)
+
+class Tester extends Mixins(GetColorMixin) {
+  render(h) {
+    return h('button', {
+      'color': 'getColor()'
+    },[
+      h('p', 'test')
+    ])
+  }
+}
+
+describe('getColor', () => {
+  it('can be used as a mixin', () => {
+    beforeEach(()=>{
+      const localVue = createLocalVue()
+      localVue.use(Vuetify)
+    })
+    expect(shallowMount(Tester).isVueInstance()).toBe(true)
+  })
+})

--- a/src/ui/components/CCBtn.vue
+++ b/src/ui/components/CCBtn.vue
@@ -20,62 +20,40 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-btn',
-  props: {
-    large: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    xLarge: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    disabled: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    dark: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-    light: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    outlined: {
-      type: Boolean,
-      required: false,
-    },
-    to: {
-      type: [String, Object],
-      required: false,
-      default: '',
-    },
-  },
-  computed: {
-    bgColor(): string {
-      if (this.disabled) return 'gray'
-      else return this.getColor(this.color, this.$vuetify)
-    },
-  },
-})
+import { Vue, Component, Prop, Mixins } from 'vue-property-decorator'
+import GetColorMixin from '@/mixins/getColor'
+import { Route } from 'vue-router'
+
+
+@Component({ name: 'cc-btn', })
+export default class CCBtn extends Mixins(GetColorMixin) {
+  @Prop({ type: Boolean, required: false, default: false, }) 
+  readonly large: boolean
+  @Prop({ type: Boolean, required: false, default: false, })
+  readonly xLarge: boolean
+  @Prop({ type: Boolean, required: false, default: false, })
+  readonly small: boolean
+
+  get bgColor(): string {
+    if (this.disabled) return 'gray'
+    else return this.getColor(this.color, this.$vuetify)
+  }
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string 
+  @Prop({ type: Boolean, required: false, default: true, })
+  readonly dark: boolean
+  @Prop({ type: Boolean, required: false, default: false, })
+  readonly light: boolean
+
+  @Prop({ type: Boolean, required: false, })
+  readonly outlined?: boolean
+
+  @Prop({ type: Boolean, required: false, default: false, })
+  readonly disabled: boolean
+
+  @Prop({ type: [String, Object], required: false, default: '', })
+  readonly to: string | Route
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCComboSelect.vue
+++ b/src/ui/components/CCComboSelect.vue
@@ -21,24 +21,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-short-string-editor',
-  props: {
-    items: {
-      type: Array,
-      required: true,
-    },
-  },
-  data: () => ({
-    sel: '',
-    menu: false,
-  }),
-  watch: {
-    sel() {
-      const s = typeof this.sel === 'string' ? this.sel : this.sel.value
-      this.$emit('set', s)
-    },
-  },
-})
+import { Vue, Component, Prop, Watch, Mixins } from 'vue-property-decorator'
+import GetColorMixin from '@/mixins/getColor'
+
+@Component({ name: 'cc-combo-select', })
+export default class CCComboSelect extends Mixins(GetColorMixin) {
+
+  @Prop({ type: Array, required: true, })
+  readonly items!: { 
+    text: string | number | object,
+    value: string | number | object,
+  }[]
+  
+  sel: string | number | {value: any} = ''
+  menu = false
+  
+  @Watch('sel')
+  onSelChange() {
+    const s = typeof this.sel === 'object' ? this.sel.value : this.sel
+    this.$emit('set', s)
+  }
+}
 </script>

--- a/src/ui/components/CCDamageElement.vue
+++ b/src/ui/components/CCDamageElement.vue
@@ -29,19 +29,18 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Damage } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-damage-element',
-  props: {
-    damage: {
-      type: Array,
-      required: true,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-  },
-})
+
+@Component({ name: 'cc-damage-element' })
+export default class CCDamageElement extends Vue {
+
+  @Prop({ type: Array, required: true, validator: (prop: Damage[]) => prop.every((dmg) => dmg instanceof Damage) }) 
+  readonly damage: Damage[]
+
+  @Prop({ type: Boolean, required: false, })
+  readonly small: boolean
+  
+}
 </script>

--- a/src/ui/components/CCDialog.vue
+++ b/src/ui/components/CCDialog.vue
@@ -64,7 +64,7 @@ export default class CCDialog extends Vue {
   @Prop({ type: Boolean, })
   readonly noConfirm?: boolean
 
-  dialog: false
+  dialog = false
 
   @Emit()
   confirm() {

--- a/src/ui/components/CCDialog.vue
+++ b/src/ui/components/CCDialog.vue
@@ -42,47 +42,33 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-dialog',
-  props: {
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    smallBtn: {
-      type: Boolean,
-    },
-    large: {
-      type: Boolean,
-      required: false,
-    },
-    flat: {
-      type: Boolean,
-      required: false,
-    },
-    dark: {
-      type: Boolean,
-      required: false,
-    },
-    noConfirm: {
-      type: Boolean,
-      required: false,
-    },
-  },
-  data: () => ({
-    dialog: false,
-  }),
-  methods: {
-    confirm() {
-      this.dialog = false
-      this.$emit('confirm')
-    },
-  },
-})
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator'
+
+
+@Component({ name: 'cc-dialog' })
+export default class CCDialog extends Vue {
+  @Prop({ type: Boolean, })
+  readonly small?: boolean 
+  @Prop({ type: Boolean, })
+  readonly smallBtn?: boolean 
+  @Prop({ type: Boolean, })
+  readonly large?: boolean 
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string 
+
+  @Prop({ type: Boolean, })
+  readonly flat?: boolean 
+  @Prop({ type: Boolean, })
+  readonly dark?: boolean 
+  @Prop({ type: Boolean, })
+  readonly noConfirm?: boolean
+
+  dialog: false
+
+  @Emit()
+  confirm() {
+    this.dialog = false
+  }
+}
 </script>

--- a/src/ui/components/CCExtendedTag.vue
+++ b/src/ui/components/CCExtendedTag.vue
@@ -19,15 +19,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Tag } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-tag',
-  props: {
-    tag: {
-      type: Object,
-      required: true,
-    },
-  },
-})
+
+@Component({ name: 'cc-tag' })
+export default class CCExtendedTag extends Vue {
+  @Prop({ type: Object, required: true, })
+  readonly tag: Tag
+}
 </script>

--- a/src/ui/components/CCGmHeader.vue
+++ b/src/ui/components/CCGmHeader.vue
@@ -13,22 +13,18 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-gm-header',
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    flip: {
-      type: Boolean,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+
+@Component({ name: 'cc-gm-header' })
+export default class CCGmHeader extends Vue{
+  
+  @Prop({ type: String, required: true, })
+  readonly title!: string
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+  @Prop({ type: Boolean, })
+  readonly flip: boolean
+}
 </script>

--- a/src/ui/components/CCItemUses.vue
+++ b/src/ui/components/CCItemUses.vue
@@ -14,55 +14,39 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { MechEquipment, MechSystem, PilotGear } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-item-uses',
-  props: {
-    item: {
-      type: Object,
-      required: true,
-    },
-    bonus: {
-      type: Number,
-      required: false,
-      default: 0,
-    },
-    small: {
-      type: Boolean,
-    },
-    large: {
-      type: Boolean,
-    },
-    emptyIcon: {
-      type: String,
-      required: false,
-      default: 'mdi-hexagon-outline',
-    },
-    fullIcon: {
-      type: String,
-      required: false,
-      default: 'mdi-hexagon-slice-6',
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-  },
-  computed: {
-    max() {
-      return this.item.MaxUses + this.bonus
-    },
-    current() {
-      return this.item.Uses
-    },
-  },
-  methods: {
-    set(val) {
-      if (val > this.current) Vue.set(this.item, 'Uses', this.item.Uses + 1)
-      else Vue.set(this.item, 'Uses', this.item.Uses - 1)
-    },
-  },
-})
+
+@Component({ name: 'cc-item-uses' })
+export default class CCItemUses extends Vue{
+  
+  @Prop({ type: Boolean, })
+  readonly small?: boolean
+  @Prop({ type: Boolean, })
+  readonly large?: boolean
+  @Prop({ type: String, required: false, default: 'mdi-hexagon-outline', })
+  readonly emptyIcon: string 
+  @Prop({ type: String, required: false, default: 'mdi-hexagon-slice-6', })
+  readonly fullIcon: string
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+
+  @Prop({ type: Object, required: true, validator: (item) => item.MaxUses && item.Uses, })
+  readonly item!: MechEquipment | MechSystem | PilotGear
+  @Prop({ type: Number, required: false, default: 0, })
+  readonly bonus: number
+
+  get max() {
+    return this.item.MaxUses + this.bonus
+  }
+  get current() {
+    return this.item.Uses
+  }
+
+  set(val) {
+    if (val > this.current) Vue.set(this.item, 'Uses', this.item.Uses + 1)
+    else Vue.set(this.item, 'Uses', this.item.Uses - 1)
+  }
+}
 </script>

--- a/src/ui/components/CCMajorBtn.vue
+++ b/src/ui/components/CCMajorBtn.vue
@@ -41,30 +41,23 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-major-btn',
-  props: {
-    icon: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    name: {
-      type: String,
-      required: true,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+
+@Component({ name: 'cc-major-btn' })
+export default class CCMajorButton extends Vue {
+  @Prop({ type: String, required: true, })
+  readonly name!: string
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly icon: string
+
+  @Prop({ type: Boolean, required: false, })
+  readonly small?: boolean
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCMechStatusAlert.vue
+++ b/src/ui/components/CCMechStatusAlert.vue
@@ -67,88 +67,83 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'status-alert',
-  props: {
-    type: {
-      type: String,
-      required: true,
-    },
-    criticalOnly: {
-      type: Boolean,
-    },
-    hideClear: {
-      type: Boolean,
-    },
-  },
-  computed: {
-    show() {
-      if (!this.criticalOnly) return true
-      switch (this.type) {
-        case 'overSP':
-        case 'underSP':
-        case 'unfinished':
-        case 'unlicensed':
-          return false
-        default:
-          return true
-      }
-    },
-    icon() {
-      switch (this.type) {
-        case 'ejected':
-          return 'mdi-account-off-outline'
-          break
-        case 'destroyed':
-          return 'mdi-image-broken-variant'
-          break
-        case 'meltdown':
-          return 'mdi-alert-outline'
-          break
-        case 'reactorDestroyed':
-          return 'mdi-nuke'
-          break
-        case 'cascading':
-          return 'mdi-link-variant-off'
-          break
-        case 'overSP':
-        case 'underSP':
-          return 'cci-system'
-          break
-        case 'unfinished':
-          return 'mdi-alert'
-          break
-        case 'unlicensed':
-          return 'mdi-view-week'
-          break
-        default:
-          return ''
-          break
-      }
-    },
-    color() {
-      switch (this.type) {
-        case 'destroyed':
-        case 'cascading':
-          return 'error'
-          break
-        case 'meltdown':
-          return 'dangerzone'
-          break
-        case 'reactorDestroyed':
-          return 'accent darken-1'
-          break
-        case 'overSP':
-        case 'ejected':
-        case 'unlicensed':
-          return 'warning darken-1'
-          break
-        default:
-          return 'grey darken-1'
-          break
-      }
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'status-alert' })
+export default class CCMechStatusAlert extends Vue {
+  
+  @Prop({ type: String, required: true, })
+  readonly type!: string
+  @Prop({ type: Boolean, })
+  readonly criticalOnly?: boolean
+  @Prop({ type: Boolean, })
+  readonly hideClear?: boolean
+
+  get show() {
+    if (!this.criticalOnly) return true
+    switch (this.type) {
+      case 'overSP':
+      case 'underSP':
+      case 'unfinished':
+      case 'unlicensed':
+        return false
+      default:
+        return true
+    }
+  }
+  get icon() {
+    switch (this.type) {
+      case 'ejected':
+        return 'mdi-account-off-outline'
+        break
+      case 'destroyed':
+        return 'mdi-image-broken-variant'
+        break
+      case 'meltdown':
+        return 'mdi-alert-outline'
+        break
+      case 'reactorDestroyed':
+        return 'mdi-nuke'
+        break
+      case 'unshackled':
+        return 'mdi-link-variant-off'
+        break
+      case 'overSP':
+      case 'underSP':
+        return 'cci-system'
+        break
+      case 'unfinished':
+        return 'mdi-alert'
+        break
+      case 'unlicensed':
+        return 'mdi-view-week'
+        break
+      default:
+        return ''
+        break
+    }
+  }
+  get color() {
+    switch (this.type) {
+      case 'destroyed':
+      case 'cascading':
+        return 'error'
+        break
+      case 'meltdown':
+        return 'dangerzone'
+        break
+      case 'reactorDestroyed':
+        return 'accent darken-1'
+        break
+      case 'overSP':
+      case 'ejected':
+      case 'unlicensed':
+        return 'warning darken-1'
+        break
+      default:
+        return 'grey darken-1'
+        break
+    }
+  }
+}
 </script>

--- a/src/ui/components/CCNotification.vue
+++ b/src/ui/components/CCNotification.vue
@@ -8,26 +8,20 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-notification',
-  props: {
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-  },
-  data: () => ({
-    model: false,
-  }),
-  methods: {
-    close() {
-      this.model = false
-    },
-    open() {
-      this.model = true
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-notification' })
+export default class CCNotification extends Vue{
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+    
+  model = false
+  close() {
+    this.model = false
+  }
+  open() {
+    this.model = true
+  }
+}
 </script>

--- a/src/ui/components/CCPopup.vue
+++ b/src/ui/components/CCPopup.vue
@@ -26,23 +26,19 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-popup',
-  props: {
-    icon: {
-      type: Boolean,
-      required: false,
-    },
-  },
-  data: () => ({
-    dialog: false,
-  }),
-  methods: {
-    confirm() {
-      this.dialog = false
-      this.$emit('confirm')
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-popup' })
+export default class CCPopup extends Vue {
+  @Prop({ type: Boolean, required: false, })
+  readonly flat?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly icon?: boolean
+
+  dialog = false
+  confirm() {
+    this.dialog = false
+    this.$emit('confirm')
+  }
+}
 </script>

--- a/src/ui/components/CCRangeElement.vue
+++ b/src/ui/components/CCRangeElement.vue
@@ -36,7 +36,7 @@ import { Range } from '@/class'
 
 @Component({ name: 'cc-range-element' })
 export default class CCRangeElement extends Vue{
-  @Prop({ type: Array, required: true, validator: (elem) => elem instanceof Range })
+  @Prop({ type: Array, required: true, })
   readonly range!: Range[]
 
   @Prop({ type: Boolean, required: false, })

--- a/src/ui/components/CCRangeElement.vue
+++ b/src/ui/components/CCRangeElement.vue
@@ -31,19 +31,15 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Range } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-range-element',
-  props: {
-    range: {
-      type: Array,
-      required: true,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-  },
-})
+@Component({ name: 'cc-range-element' })
+export default class CCRangeElement extends Vue{
+  @Prop({ type: Array, required: true, validator: (elem) => elem instanceof Range })
+  readonly range!: Range[]
+
+  @Prop({ type: Boolean, required: false, })
+  readonly small?: boolean
+}
 </script>

--- a/src/ui/components/CCRating.vue
+++ b/src/ui/components/CCRating.vue
@@ -15,28 +15,20 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-ranking',
-  props: {
-    model: {
-      type: Number,
-      required: true,
-    },
-    max: {
-      type: Number,
-      required: false,
-      default: 6,
-    },
-    dense: {
-      type: Boolean,
-      required: false,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary'
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-rating', })
+export default class CCRating extends Vue {
+  @Prop({ type: Number, required: true, })
+  readonly model!: number
+  @Prop({ type: Number, required: false, default: 6, })
+  readonly max: number
+
+  @Prop({ type: Boolean, required: false, })
+  readonly dense?: boolean
+  @Prop({ type: String, required: false, default: 'primary' })
+  readonly color: string
+}
+
+export { CCRating as CCRanking }
 </script>

--- a/src/ui/components/CCShortStringEditor.vue
+++ b/src/ui/components/CCShortStringEditor.vue
@@ -24,37 +24,32 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-short-string-editor',
-  props: {
-    inline: {
-      type: Boolean,
-      required: false,
-    },
-    large: {
-      type: Boolean,
-    },
-    before: {
-      type: Boolean,
-    },
-  },
-  data: () => ({
-    newStr: '',
-    editing: false,
-  }),
-  methods: {
-    edit() {
-      this.editing = true
-      this.newStr = this.$slots.default[0].text.trim()
-    },
-    submit() {
-      if (this.newStr.length) this.$emit('set', this.newStr)
-      this.editing = false
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-short-string-editor', })
+export default class CCShortStringEditor extends Vue {
+  
+  @Prop({ type: Boolean, required: false, })
+  readonly inline?: boolean
+  @Prop({ type: Boolean, })
+  readonly large?: boolean
+  @Prop({ type: Boolean, })
+  readonly before?: boolean
+  
+  newStr = ''
+  editing = false
+
+  edit() {
+    this.editing = true
+    this.newStr = this.$slots.default[0].text.trim()
+  }
+  submit() {
+    if (this.newStr.length) this.$emit('set', this.newStr)
+    this.editing = false
+  }
+}
 </script>
+
 
 <style scoped>
 .name.fade-transition-enter-active {

--- a/src/ui/components/CCSimpleSelect.vue
+++ b/src/ui/components/CCSimpleSelect.vue
@@ -12,14 +12,16 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-short-string-editor',
-  props: {
-    items: {
-      type: Array,
-      required: true,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-simple-select', })
+export default class CCSimpleSelect extends Vue {
+
+  @Prop({ type: Array, required: true, validator: (item) => item.text && item.text.toString })
+  readonly items!: { 
+    text: string | number | object
+    value: string | number | object
+  }[]
+
+}
 </script>

--- a/src/ui/components/CCSlashes.vue
+++ b/src/ui/components/CCSlashes.vue
@@ -3,15 +3,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-slashes',
-  props: {
-    size: {
-      type: [String, Number],
-      required: false,
-      default: '',
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-slashes', })
+export default class CCSlashes extends Vue {
+  
+  @Prop({ type: [String, Number], required: false, default: '', })
+  readonly size: string | number 
+}
 </script>

--- a/src/ui/components/CCSoloDialog.vue
+++ b/src/ui/components/CCSoloDialog.vue
@@ -8,7 +8,7 @@
     <v-card tile class="background">
       <cc-titlebar :clipped="!noTitleClip" large :icon="icon" :color="color" :fixed="fullscreen">
         {{ title }}
-        <v-btn slot="items" dark icon @click="dialog = false">
+        <v-btn slot="items" dark icon @click="hide">
           <v-icon large left>close</v-icon>
         </v-btn>
       </cc-titlebar>
@@ -23,10 +23,10 @@
 
       <v-card-actions v-if="noConfirm">
         <v-spacer />
-        <v-btn text @click="dialog = false">dismiss</v-btn>
+        <v-btn text @click="hide">dismiss</v-btn>
       </v-card-actions>
       <v-card-actions v-else>
-        <v-btn text @click="dialog = false">cancel</v-btn>
+        <v-btn text @click="hide">cancel</v-btn>
         <v-spacer />
         <cc-btn @click="confirm">confirm</cc-btn>
       </v-card-actions>
@@ -35,65 +35,45 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-solo-dialog',
-  props: {
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    large: {
-      type: Boolean,
-      required: false,
-    },
-    fullscreen: {
-      type: Boolean,
-      required: false,
-    },
-    noConfirm: {
-      type: Boolean,
-      required: false,
-    },
-    noPad: {
-      type: Boolean,
-      required: false,
-    },
-    noTitleClip: {
-      type: Boolean,
-      required: false,
-    },
-    title: {
-      type: String,
-      required: true,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    icon: {
-      type: String,
-      required: false,
-      default: '',
-    },
-  },
-  data: () => ({
-    dialog: false,
-  }),
-  methods: {
-    confirm() {
-      this.$emit('confirm')
-      this.dialog = false
-    },
-    show() {
-      this.dialog = true
-    },
-    hide() {
-      this.dialog = false
-    },
-  },
-})
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator'
+
+@Component({ name: 'cc-solo-dialog', })
+export default class CCSoloDialog extends Vue {
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+  @Prop({ type: String, required: false, default: '', })
+  readonly icon: string
+  
+  @Prop({ type: Boolean, required: false, })
+  readonly small?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly large?: boolean
+
+  @Prop({ type: Boolean, required: false, })
+  readonly fullscreen?: boolean
+
+  @Prop({ type: Boolean, required: false, })
+  readonly noConfirm?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly noPad?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly noTitleClip?: boolean
+
+  @Prop({ type: String, required: false, })
+  readonly title?: string
+  
+  dialog = false
+  @Emit()
+  confirm() {
+    this.dialog = false
+  }
+  show() {
+    this.dialog = true
+  }
+  hide() {
+    this.dialog = false
+  }
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCStatblockPanel.vue
+++ b/src/ui/components/CCStatblockPanel.vue
@@ -20,18 +20,15 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-statblock-panel',
-  props: {
-    name: {
-      type: String,
-      required: true,
-    },
-    value: {
-      type: [String, Number],
-      required: true,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-statblock-panel', })
+export default class CCStatblockPanel extends Vue {
+
+  @Prop({ type: String, required: true, })
+  readonly name!: string
+  
+  @Prop({ type: [String, Number], required: true, })
+  readonly value!: string | number
+}
 </script>

--- a/src/ui/components/CCStatusSelect.vue
+++ b/src/ui/components/CCStatusSelect.vue
@@ -32,41 +32,32 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'status-select',
-  props: {
-    items: {
-      type: Array,
-      required: true,
-    },
-    model: {
-      type: Array,
-      required: true,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    label: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    dark: {
-      type: Boolean,
-    },
-  },
-  computed: {
-    arr: {
-      get() {
-        return this.model
-      },
-      set(val) {
-        this.$emit('set', val)
-      },
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'status-select', })
+export default class CCStatusSelect extends Vue {
+  
+  @Prop({ type: Array, required: true, })
+  readonly items!: Status[]
+
+  @Prop({ type: Array, required: true, })
+  readonly model!: Status[]
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly color: string
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly label: string
+
+  @Prop({ type: Boolean, })
+  readonly dark?: boolean
+
+  get arr() {
+    return this.model
+  }
+  set arr(val) {
+    this.$emit('set', val)
+  }
+
+}
 </script>

--- a/src/ui/components/CCStepperContent.vue
+++ b/src/ui/components/CCStepperContent.vue
@@ -26,26 +26,20 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-stepper-content',
-  props: {
-    complete: {
-      type: Boolean,
-      required: true,
-    },
-    back: {
-      type: Boolean,
-      required: false,
-    },
-    exit: {
-      type: String,
-      required: true,
-    },
-    noConfirm: {
-      type: Boolean,
-      required: false,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-stepper-content', })
+export default class CCStepperContent extends Vue{
+
+  @Prop({ type: Boolean, required: false, })
+  readonly noConfirm?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly back?: boolean
+
+  @Prop({ type: Boolean, required: true, })
+  readonly complete!: boolean
+  @Prop({ type: String, required: true, })
+  readonly exit!: string
+
+}
 </script>

--- a/src/ui/components/CCStringEdit.vue
+++ b/src/ui/components/CCStringEdit.vue
@@ -13,35 +13,29 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
 import EditButton from './subcomponents/_EditButton.vue'
 
-export default Vue.extend({
+@Component({ 
   name: 'cc-string-edit',
   components: { EditButton },
-  props: {
-    label: {
-      type: String,
-      required: false,
-      default: ' ',
-    },
-    placeholder: {
-      type: String,
-      required: true,
-    },
-    dark: {
-      type: Boolean,
-      required: false,
-    },
-  },
-  data: () => ({
-    newString: '',
-  }),
-  methods: {
-    save() {
-      if (this.newString) this.$emit(this.newString)
-      this.newString = ''
-    },
-  },
 })
+export default class CCStringEdit extends Vue{
+  
+  @Prop({ type: String, required: false, default: ' ', })
+  readonly label: string
+
+  @Prop({ type: String, required: true, })
+  readonly placeholder!: string 
+    
+  @Prop({ type: Boolean, required: false, })
+  readonly dark?: boolean 
+  
+  newString = ''
+
+  save() {
+    if (this.newString) this.$emit(this.newString)
+    this.newString = ''
+  }
+}
 </script>

--- a/src/ui/components/CCTag.vue
+++ b/src/ui/components/CCTag.vue
@@ -14,35 +14,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Pilot, Tag } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-tag',
-  props: {
-    tag: {
-      type: Object,
-      required: true,
-    },
-    pilot: {
-      type: Object,
-      required: false,
-      default: null,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-  },
-  computed: {
-    bonus() {
-      if (!this.pilot) return 0
-      else return this.pilot.LimitedBonus
-    },
-  },
-})
+@Component({ name: 'cc-tag', })
+export default class CCTag extends Vue {
+  @Prop({ type: Boolean, required: false, })
+  readonly small?: boolean 
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+
+  @Prop({ type: Object, required: true, })
+  readonly tag!: Tag
+
+  @Prop({ type: Object, required: false, default: null, })
+  readonly pilot?: Pilot 
+
+  get bonus() {
+    if (!this.pilot) return 0
+    else return this.pilot.LimitedBonus
+  }
+}
 </script>

--- a/src/ui/components/CCTags.vue
+++ b/src/ui/components/CCTags.vue
@@ -29,7 +29,7 @@ export default class CCTags extends Vue {
   @Prop({ type: String, required: false, default: 'primary', })
   readonly color: string
 
-  @Prop({ type: Array, required: true, validator: (item) => item instanceof Tag })
+  @Prop({ type: Array, required: true,  })
   readonly tags!: Tag[]
 
   @Prop({ type: Object, required: false, default: null, })

--- a/src/ui/components/CCTags.vue
+++ b/src/ui/components/CCTags.vue
@@ -1,13 +1,13 @@
 <template>
   <v-row v-if="extended" no-gutters>
-    <v-col v-for="(t, i) in tags" :key="`${t.id}_${i}`" cols="12">
+    <v-col v-for="(t, i) in tags" :key="`${t.ID}_${i}`" cols="12">
       <cc-extended-tag :tag="t" />
     </v-col>
   </v-row>
   <div v-else>
     <cc-tag
       v-for="(t, i) in tags"
-      :key="`${t.id}_${i}`"
+      :key="`${t.ID}_${i}`"
       :tag="t"
       :small="small"
       :color="color"
@@ -17,33 +17,22 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Pilot, Tag } from '@/class'
 
-export default Vue.extend({
-  name: 'cc-tags',
-  props: {
-    tags: {
-      type: Array,
-      required: true,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    extended: {
-      type: Boolean,
-      required: false,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    pilot: {
-      type: Object,
-      required: false,
-      default: null,
-    },
-  },
-})
+@Component({ name: 'cc-tags', })
+export default class CCTags extends Vue {
+  @Prop({ type: Boolean, required: false, })
+  readonly small?: boolean
+  @Prop({ type: Boolean, required: false, })
+  readonly extended?: boolean
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+
+  @Prop({ type: Array, required: true, validator: (item) => item instanceof Tag })
+  readonly tags!: Tag[]
+
+  @Prop({ type: Object, required: false, default: null, })
+  readonly pilot?: Pilot 
+}
 </script>

--- a/src/ui/components/CCTickBar.vue
+++ b/src/ui/components/CCTickBar.vue
@@ -54,128 +54,105 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'tick-bar',
-  props: {
-    label: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    justify: {
-      type: String,
-      required: false,
-      default: 'start',
-    },
-    current: {
-      type: Number,
-      required: true,
-    },
-    max: {
-      type: Number,
-      required: true,
-    },
-    small: {
-      type: Boolean,
-    },
-    large: {
-      type: Boolean,
-    },
-    emptyIcon: {
-      type: String,
-      required: false,
-      default: 'mdi-hexagon-outline',
-    },
-    fullIcon: {
-      type: String,
-      required: false,
-      default: 'mdi-hexagon',
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    bgColor: {
-      type: String,
-      required: false,
-      default: 'grey lighten-1',
-    },
-    readonly: {
-      type: Boolean,
-    },
-    noInput: {
-      type: Boolean,
-    },
-    flipInput: {
-      type: Boolean,
-    },
-    noPips: {
-      type: Boolean,
-    },
-    clearable: {
-      type: Boolean,
-    },
-  },
-  data: () => ({
-    model: 0,
-    lock: true,
-    inputting: false,
-    myInput: '',
-  }),
-  watch: {
-    model(val: number) {
-      if (!this.lock && !isNaN(val)) {
-        this.$emit('update', val)
-      }
-    },
-  },
+import { Vue, Component, Prop, Watch, Ref } from 'vue-property-decorator'
+
+@Component({ name: 'tick-bar', })
+export default class CCTickBar extends Vue {
   created() {
     this.lock = true
     if (!this.readonly) {
       this.model = this.current > this.max ? this.max : this.current
     } else this.model = this.max
     this.lock = false
-  },
-  methods: {
-    startInputting() {
-      this.inputting = true
-      this.$nextTick(() => {
-        ; (this.$refs.pipinput as HTMLInputElement).focus()
-      })
-    },
-    sendInput() {
-      const thisInput = this.myInput
-      if (!thisInput.match(/\d/)) return
+  }
 
-      this.inputting = false
+  @Prop({ type: String, required: false, default: '', })
+  readonly label: string
 
-      let preResult = this.current
+  @Prop({ type: String, required: false, default: 'start', })
+  readonly justify: string
+  @Prop({ type: Boolean, })
+  readonly small?: boolean
+  @Prop({ type: Boolean, })
+  readonly large?: boolean
+  @Prop({ type: String, required: false, default: 'mdi-hexagon-outline', })
+  readonly emptyIcon: string
+  @Prop({ type: String, required: false, default: 'mdi-hexagon', })
+  readonly fullIcon: string
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string
+  @Prop({ type: String,required: false, default: 'grey lighten-1', })
+  readonly bgColor: string
+  @Prop({ type: Boolean, })
+  readonly noPips?: boolean
 
-      if (thisInput === '') return
-      else if (thisInput.startsWith('+')) {
-        preResult += parseInt(thisInput.substr(1))
-      } else if (thisInput.startsWith('-')) {
-        preResult -= parseInt(thisInput.substr(1))
-      } else {
-        preResult = parseInt(thisInput)
-      }
+  @Prop({ type: Boolean, })
+  readonly readonly?: boolean
+  @Prop({ type: Boolean, })
+  readonly noInput?: boolean
+  @Prop({ type: Boolean, })
+  readonly flipInput?: boolean
+  @Prop({ type: Boolean, })
+  readonly clearable?: boolean
 
-      this.$emit('update', preResult)
-      this.myInput = ''
-    },
-    cancelInput() {
-      this.inputting = false
-      this.myInput = ''
-    },
-    onInputChange(e) {
-      const newVal = e.target.value
-      if (newVal.match(/^[+-\d]\d*$/) || newVal === '') this.myInput = newVal
-      else e.target.value = this.myInput
-    },
-  },
-})
+  @Prop({ type: Number, required: true, })
+  readonly current!: number
+  @Prop({ type: Number, required: true, })
+  readonly max!: number
+
+  model = 0
+  lock = true
+  inputting = false
+  myInput = ''
+
+  @Watch('model')
+  onModelChange(val: number, oldVal: number) {
+    if (!this.lock && !isNaN(val)) {
+      this.$emit('update', val)
+    }
+  }
+
+  onInputChange(e) {
+    const newVal = e.target.value
+    if (newVal.match(/^[+-\d]\d*$/) || newVal === '') this.myInput = newVal
+    else e.target.value = this.myInput
+  }
+
+  @Ref('pipinput') readonly pipinput: HTMLInputElement
+  startInputting() {
+    this.inputting = true
+    this.$nextTick(() => {
+      this.pipinput.focus()
+    })
+  }
+
+  sendInput() {
+    const thisInput = this.myInput
+    if (!thisInput.match(/\d/)) return
+
+    this.inputting = false
+
+    let preResult = this.current
+
+    if (thisInput === '') return
+    else if (thisInput.startsWith('+')) {
+      preResult += parseInt(thisInput.substr(1))
+    } else if (thisInput.startsWith('-')) {
+      preResult -= parseInt(thisInput.substr(1))
+    } else {
+      preResult = parseInt(thisInput)
+    }
+
+    this.$emit('update', preResult)
+    this.myInput = ''
+  }
+  
+  cancelInput() {
+    this.inputting = false
+    this.myInput = ''
+  }
+
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCTitle.vue
+++ b/src/ui/components/CCTitle.vue
@@ -1,45 +1,36 @@
 <template>
   <div
-    :class="`px-2 ml-n3 clipped${size()}`"
+    :class="`px-2 ml-n3 clipped${size}`"
     :style="`width: max-content; background-color: ${getColor()};`"
   >
-    <span :class="`ctitle${size()} ${dark ? 'white--text' : 'black--text'}`" class="pl-5 pr-5 pb-1">
+    <span :class="`ctitle${size} ${dark ? 'white--text' : 'black--text'}`" class="pl-5 pr-5 pb-1">
       <slot />
     </span>
   </div>
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop, Mixins } from 'vue-property-decorator'
+import GetColorMixin from '@/mixins/getColor'
 
-export default Vue.extend({
-  name: 'cc-title',
-  props: {
-    large: {
-      type: Boolean,
-      required: false,
-    },
-    small: {
-      type: Boolean,
-      required: false,
-    },
-    dark: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-  },
-  methods: {
-    size() {
-      return this.large ? '-large' : this.small ? '-small' : ''
-    },
-  },
-})
+@Component({ name: 'cc-title', })
+export default class CCTitle extends Mixins(GetColorMixin) {
+  @Prop({ type: Boolean, required: false, }) 
+  readonly large?: boolean 
+  
+  @Prop({ type: Boolean, required: false, }) 
+  readonly small?: boolean
+
+  @Prop({ type: Boolean, required: false, default: true, })
+  readonly dark: boolean 
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string 
+
+  get size() {
+    return this.large ? '-large' : this.small ? '-small' : ''
+  }
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCTitlebar.vue
+++ b/src/ui/components/CCTitlebar.vue
@@ -16,37 +16,29 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-titlebar',
-  props: {
-    fixed: {
-      type: Boolean,
-      required: false,
-    },
-    dark: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-    clipped: {
-      type: Boolean,
-      default: true,
-    },
-    color: {
-      type: String,
-      required: false,
-      default: 'primary',
-    },
-    icon: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    large: {
-      type: Boolean,
-      required: false,
-    },
-  },
-})
+import { Vue, Component, Prop, Mixins } from 'vue-property-decorator'
+import GetColorMixin from '@/mixins/getColor'
+
+@Component({ name: 'cc-titlebar', })
+export default class CCTitlebar extends Mixins(GetColorMixin) {
+
+  @Prop({ type: Boolean, required: false, })
+  readonly fixed?: boolean 
+  
+  @Prop({ type: Boolean, required: false, default: true, })
+  readonly dark: boolean 
+
+  @Prop({ type: Boolean, default: true, })
+  readonly clipped: boolean
+
+  @Prop({ type: String, required: false, default: 'primary', })
+  readonly color: string 
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly icon: string 
+
+  @Prop({ type: Boolean, required: false, })
+  readonly large?: boolean
+
+}
 </script>

--- a/src/ui/components/CCTitledPanel.vue
+++ b/src/ui/components/CCTitledPanel.vue
@@ -33,32 +33,27 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-export default Vue.extend({
-  name: 'cc-titled-panel',
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    icon: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    color: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    clickable: {
-      type: Boolean,
-    },
-    dense: {
-      type: Boolean,
-    },
-  },
-})
+import { Vue, Component, Prop } from 'vue-property-decorator'
+
+@Component({ name: 'cc-titled-panel', })
+export default class CCTitledPanel extends Vue {
+ 
+  @Prop({ type: String, required: true, })
+  readonly title!: string 
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly icon: string
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly color: string 
+
+  @Prop({ type: Boolean, })
+  readonly clickable?: boolean
+  
+  @Prop({ type: Boolean, })
+  readonly dense?: boolean
+
+}
 </script>
 
 <style scoped>

--- a/src/ui/components/CCTooltip.vue
+++ b/src/ui/components/CCTooltip.vue
@@ -23,39 +23,29 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import { Vue, Component, Prop } from 'vue-property-decorator'
 
-export default Vue.extend({
-  name: 'cc-tooltip',
-  props: {
-    err: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    simple: {
-      type: Boolean,
-      required: false,
-    },
-    inline: {
-      type: Boolean,
-      required: false,
-    },
-    delayed: {
-      type: Boolean,
-      required: false,
-    },
-    title: {
-      type: String,
-      required: false,
-      default: '',
-    },
-    content: {
-      type: String,
-      required: true,
-    },
-  },
-})
+@Component({ name: 'cc-tooltip', })
+export default class CCTooltip extends Vue {
+  @Prop({ type: String, required: false, default: '', })
+  readonly err: string
+
+  @Prop({ type: Boolean, required: false, })
+  readonly simple?: boolean
+
+  @Prop({ type: Boolean, required: false, })
+  readonly inline?: boolean
+
+  @Prop({ type: Boolean,required: false, })
+  readonly delayed?: boolean
+
+  @Prop({ type: String, required: false, default: '', })
+  readonly title: string
+
+  @Prop({ type: String, required: true, })
+  readonly content!: string
+
+}
 </script>
 
 <style scoped>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "noEmit": false,
-    "types": ["electron", "jest"],
+    "types": [
+      "vuetify",
+      "electron",
+      "jest"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
# Description
Fixes an issue with the getColor mixin and re-implements the VCC conversion of base CC components that was reversed because of said getColor mixin bug. 

## Issue Number
#563, #552, #514

## Type of change
Significant refactor & bugfix. Could require revision to any other pending branch changes (that have not yet been committed or PR'd) to the `/ui/components/CC*.vue` base components. 
