### PR TITLE
NPC Stat Overrides

### DIFF
--- a/src/classes/npc/Npc.ts
+++ b/src/classes/npc/Npc.ts
@@ -283,26 +283,19 @@ export class Npc implements IActor {
   }
 
   setStatBonuses(feat: NpcFeature, remove?: boolean): void {
-    if (feat.Bonus) {
-      for (const key in feat.Bonus) {
-        if (feat.Bonus.hasOwnProperty(key)) {
-          if (remove) this._stats.Stats[key] -= feat.Bonus[key]
-          else this._stats.Stats[key] += feat.Bonus[key]
-        }
+    if (feat.Override) {
+      for (const key in feat.Override) {
+        if (remove && typeof this.Tier === 'number') this._stats.Stats[key] = this.Class.Stats.Stat(key, this.Tier)
+        else this._stats.Stats[key] = feat.Override[key]
       }
-    }
-    //TODO: these should be managed in the data instead
-    if (feat.ID === 'npcf_chaff') {
-      if (remove && typeof this.Tier === 'number') this._stats.HP = this.Class.Stats.HP(this.Tier)
-      else this._stats.HP = 1
-    }
-    if (feat.ID === 'npcf_weak') {
-      if (remove && typeof this.Tier === 'number') {
-        this._stats.Structure = this.Class.Stats.Structure(this.Tier)
-        this._stats.Stress = this.Class.Stats.Stress(this.Tier)
-      } else {
-        this._stats.Structure = 1
-        this._stats.Stress = 1
+    } else {
+      if (feat.Bonus) {
+        for (const key in feat.Bonus) {
+          if (feat.Bonus.hasOwnProperty(key)) {
+            if (remove) this._stats.Stats[key] -= feat.Bonus[key]
+            else this._stats.Stats[key] += feat.Bonus[key]
+          }
+        }
       }
     }
   }

--- a/src/classes/npc/NpcClassStats.ts
+++ b/src/classes/npc/NpcClassStats.ts
@@ -24,6 +24,10 @@ export class NpcClassStats {
     this._stats = data
   }
 
+  public Stat(key: string, tier: number): number {
+    return this._stats[key] ? this._stats[key][tier - 1] : 1
+  }
+
   public Activations(tier: number): number {
     return this._stats.activations[tier - 1]
   }

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -128,4 +128,8 @@ export abstract class NpcFeature {
     return ''
     // return this._origin.name
   }
+
+  public get Color(): string {
+    return 'npc--feature'
+  }
 }

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -21,6 +21,7 @@ export interface INpcFeatureData {
   locked: boolean
   effect?: string
   bonus?: object
+  override?: object
   tags: ITagData[]
   brew: string
   type: NpcFeatureType
@@ -32,6 +33,7 @@ export abstract class NpcFeature {
   private _origin: IOriginData
   private _effect: string
   private _bonus: object
+  private _override: object
   private _locked: boolean
   private _tags: ITagData[]
   private _brew: string
@@ -43,6 +45,7 @@ export abstract class NpcFeature {
     this._origin = data.origin
     this._effect = data.effect || ''
     this._bonus = data.bonus || null
+    this._override = data.override || null
     this._locked = data.locked || false
     this._tags = data.tags
     this._brew = data.brew || 'CORE'
@@ -68,6 +71,10 @@ export abstract class NpcFeature {
 
   public get Bonus(): object {
     return this._bonus
+  }
+
+  public get Override(): object {
+    return this._override
   }
 
   public get Effect(): string {

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -20,6 +20,6 @@ export class NpcReaction extends NpcFeature {
   }
 
   public get Color(): string {
-    return 'action--reaction'
+    return 'npc--reaction'
   }
 }

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -25,6 +25,6 @@ export class NpcSystem extends NpcFeature {
   }
 
   public get Color(): string {
-    return 'system'
+    return 'npc--system'
   }
 }

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -47,6 +47,6 @@ export class NpcTech extends NpcFeature {
   }
 
   public get Color(): string {
-    return 'frame'
+    return 'npc--tech'
   }
 }

--- a/src/classes/npc/NpcTrait.ts
+++ b/src/classes/npc/NpcTrait.ts
@@ -8,7 +8,7 @@ export class NpcTrait extends NpcFeature {
   }
 
   public get Color(): string {
-    return 'primary'
+    return 'npc--trait'
   }
 }
 

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -82,6 +82,6 @@ export class NpcWeapon extends NpcFeature {
   }
 
   public get Color(): string {
-    return 'weapon'
+    return 'npc--weapon'
   }
 }

--- a/src/features/encounters/npc/new/index.vue
+++ b/src/features/encounters/npc/new/index.vue
@@ -32,7 +32,8 @@
           <template v-slot:group.header="h" class="transparent">
             <div class="primary sliced">
               <span class="heading white--text ml-2">
-                <v-icon dark>cci-role-{{ h.group }}</v-icon>
+                <v-icon v-if="h.group.toLowerCase() === 'biological'" dark>mdi-heart-pulse</v-icon>
+                <v-icon v-else dark>cci-role-{{ h.group }}</v-icon>
                 {{ h.group.toUpperCase() }}
               </span>
             </div>

--- a/src/ui/components/cards/npc/cards/_ReactionCard.vue
+++ b/src/ui/components/cards/npc/cards/_ReactionCard.vue
@@ -18,6 +18,7 @@
         </v-btn>
       </cc-tooltip>
     </v-col>
+    <cc-tags :tags="item.Feature.Tags" small />
   </card-base>
 </template>
 

--- a/src/ui/components/cards/npc/cards/_ReactionCard.vue
+++ b/src/ui/components/cards/npc/cards/_ReactionCard.vue
@@ -18,7 +18,7 @@
         </v-btn>
       </cc-tooltip>
     </v-col>
-    <cc-tags :tags="item.Feature.Tags" small />
+    <cc-tags v-if="item.Feature.Tags" :tags="item.Feature.Tags" small />
   </card-base>
 </template>
 

--- a/src/ui/components/cards/npc/cards/_SystemCard.vue
+++ b/src/ui/components/cards/npc/cards/_SystemCard.vue
@@ -8,7 +8,7 @@
     <span class="overline">EFFECT</span>
     <p v-if="item.Tier" class="body-1 mb-0" v-html="item.Feature.EffectByTier(item.Tier)" />
     <p v-else class="body-1 mb-0" v-html="item.Feature.Effect" />
-    <cc-tags :tags="item.Feature.Tags" small />
+    <cc-tags v-if="item.Feature.Tags" :tags="item.Feature.Tags" small />
   </card-base>
 </template>
 

--- a/src/ui/components/cards/npc/cards/_TraitCard.vue
+++ b/src/ui/components/cards/npc/cards/_TraitCard.vue
@@ -8,7 +8,7 @@
     <span class="overline">EFFECT</span>
     <p v-if="item.Tier" class="body-1 mb-0" v-html="item.Feature.EffectByTier(item.Tier)" />
     <p v-else class="body-1 mb-0" v-html="item.Feature.Effect" />
-    <cc-tags :tags="item.Feature.Tags" small />
+    <cc-tags v-if="item.Feature.Tags" :tags="item.Feature.Tags" small />
   </card-base>
 </template>
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -65,12 +65,12 @@ const themeDefaults = {
   'role--artillery': '#a64d79',
   'role--biological': '#7e52a3',
 
-  'npc-feature': '#cc0000',
-  'npc-trait': '#cc0000',
-  'npc-system': '#58b434',
-  'npc-weapon': '#212121',
-  'npc-tech': '#007674',
-  'npc-reaction': '#512DA8',
+  'npc--feature': '#991E2A',
+  'npc--trait': '#991E2A',
+  'npc--system': '#58b434',
+  'npc--weapon': '#212121',
+  'npc--tech': '#007674',
+  'npc--reaction': '#512DA8',
 
   enemy: '#C62828',
   ally: '#1661b8',


### PR DESCRIPTION
# Description

Implements functionality for the new optional "overrides" prop of NPC features. Overridden stats are still able to be manually modified when custom tier is selected.

## Issue Number
Closes #631 

## Type of change
Bug fix. Should be self-contained.
