### PR TITLE
Correction to Building instructions for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ COMP/CON is built with [Vue.js](https://vuejs.org/) and can build to either web 
 # Build for web
   yarn build
 # Build for Electron
-  yarn build:electron
+  yarn electron:build
 ```
 
 ## Got a problem?


### PR DESCRIPTION
# Description

Instructions for building electron target incorrect. Changed target to electron:build from build:electron.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)