### PR TITLE
Add pilot menu to roster items

### DIFF
--- a/src/features/pilot_management/PilotSheet/components/PilotEditMenu.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotEditMenu.vue
@@ -1,0 +1,130 @@
+<template>
+  <div>
+    <v-menu offset-y top>
+      <template v-slot:activator="{ on: menu }">
+        <v-btn class="ml-2" icon dark v-on="menu">
+          <v-icon>mdi-settings</v-icon>
+        </v-btn>
+      </template>
+      <v-list two-line subheader>
+        <v-subheader class="heading h2 white--text primary py-0 px-2">Pilot Options</v-subheader>
+        <v-list-item @click="$refs.printDialog.show()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon>mdi-printer</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Print</v-list-item-title>
+            <v-list-item-subtitle>
+              Print tabletop-ready character and mech sheets
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item @click="$refs.statblockDialog.show()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon>mdi-file-document-box</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Generate Statblock</v-list-item-title>
+            <v-list-item-subtitle>
+              Get a plaintext representation of this character's build
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item @click="$refs.exportDialog.show()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon>mdi-export-variant</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Export Pilot</v-list-item-title>
+            <v-list-item-subtitle>Open the pilot export menu</v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item @click="$refs.cloudDialog.show()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon>mdi-cloud</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Cloud Settings</v-list-item-title>
+            <v-list-item-subtitle>
+              Manage this pilot's cloud data and share codes
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item @click="$refs.cloud.sync()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon>mdi-cloud-sync</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>Quick Sync</v-list-item-title>
+            <v-list-item-subtitle v-if="!pilot.CloudID && !pilot.IsUserOwned">
+              Sync cloud with pilot (creates new cloud data)
+            </v-list-item-subtitle>
+            <v-list-item-subtitle v-else-if="!pilot.CloudID || pilot.IsUserOwned">
+              Sync cloud with pilot (overwrites cloud data)
+            </v-list-item-subtitle>
+            <v-list-item-subtitle v-else>
+              Sync pilot with cloud (overwrites local data)
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+        <v-divider />
+        <v-list-item @click="$refs.deleteDialog.show()">
+          <v-list-item-icon class="ma-0 mr-2 mt-3">
+            <v-icon color="error">mdi-delete</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title class="error--text">Delete Pilot</v-list-item-title>
+            <v-list-item-subtitle class="error--text">
+              Remove this pilot from the roster
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+    <print-dialog ref="printDialog" :pilot="pilot" />
+    <export-dialog ref="exportDialog" :pilot="pilot" />
+    <statblock-dialog ref="statblockDialog" :pilot="pilot" />
+    <cloud-dialog ref="cloudDialog" :pilot="pilot" />
+    <delete-dialog ref="deleteDialog" :pilot="pilot" @delete="deletePilot()" />
+    <cloud-manager ref="cloud" :pilot="pilot" />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import CloudManager from './CloudManager.vue'
+import CloudDialog from './CloudDialog.vue'
+import StatblockDialog from './StatblockDialog.vue'
+import ExportDialog from './ExportDialog.vue'
+import PrintDialog from './PrintDialog.vue'
+import DeleteDialog from './DeletePilotDialog.vue'
+
+import { getModule } from 'vuex-module-decorators'
+import { PilotManagementStore } from '@/store'
+
+export default Vue.extend({
+  name: 'edit-menu',
+  components: {
+    CloudManager,
+    CloudDialog,
+    StatblockDialog,
+    ExportDialog,
+    PrintDialog,
+    DeleteDialog,
+  },
+  props: {
+    pilot: {
+      type: Object,
+      required: true,
+    },
+  },
+  methods: {
+    deletePilot() {
+      this.$router.push('/pilot_management')
+      const store = getModule(PilotManagementStore, this.$store)
+      store.deletePilot(this.pilot)
+    },
+  },})
+
+</script>

--- a/src/features/pilot_management/PilotSheet/components/PilotNav.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotNav.vue
@@ -30,88 +30,7 @@
     </v-btn>
     <v-divider vertical class="mx-2" />
     <div id="divider" />
-    <v-menu offset-y top>
-      <template v-slot:activator="{ on: menu }">
-        <v-btn class="unskew ml-2" icon dark v-on="menu">
-          <v-icon>mdi-settings</v-icon>
-        </v-btn>
-      </template>
-      <v-list two-line subheader>
-        <v-subheader class="heading h2 white--text primary py-0 px-2">Pilot Options</v-subheader>
-        <v-list-item @click="$refs.printDialog.show()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon>mdi-printer</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>Print</v-list-item-title>
-            <v-list-item-subtitle>
-              Print tabletop-ready character and mech sheets
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-        <v-list-item @click="$refs.statblockDialog.show()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon>mdi-file-document-box</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>Generate Statblock</v-list-item-title>
-            <v-list-item-subtitle>
-              Get a plaintext representation of this character's build
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-        <v-list-item @click="$refs.exportDialog.show()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon>mdi-export-variant</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>Export Pilot</v-list-item-title>
-            <v-list-item-subtitle>Open the pilot export menu</v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-        <v-list-item @click="$refs.cloudDialog.show()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon>mdi-cloud</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>Cloud Settings</v-list-item-title>
-            <v-list-item-subtitle>
-              Manage this pilot's cloud data and share codes
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-        <v-list-item @click="$refs.cloud.sync()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon>mdi-cloud-sync</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>Quick Sync</v-list-item-title>
-            <v-list-item-subtitle v-if="!pilot.CloudID && !pilot.IsUserOwned">
-              Sync cloud with pilot (creates new cloud data)
-            </v-list-item-subtitle>
-            <v-list-item-subtitle v-else-if="!pilot.CloudID || pilot.IsUserOwned">
-              Sync cloud with pilot (overwrites cloud data)
-            </v-list-item-subtitle>
-            <v-list-item-subtitle v-else>
-              Sync pilot with cloud (overwrites local data)
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-        <v-divider />
-        <v-list-item @click="$refs.deleteDialog.show()">
-          <v-list-item-icon class="ma-0 mr-2 mt-3">
-            <v-icon color="error">mdi-delete</v-icon>
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title class="error--text">Delete Pilot</v-list-item-title>
-            <v-list-item-subtitle class="error--text">
-              Remove this pilot from the roster
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
-    </v-menu>
-
+    <edit-menu :pilot="pilot" class="unskew" style="display: inline-block" />
     <v-menu offset-y top>
       <template v-slot:activator="{ on: menu }">
         <v-btn class="unskew ml-2" icon dark v-on="menu">
@@ -151,37 +70,20 @@
         </v-list-item-group>
       </v-list>
     </v-menu>
-    <print-dialog ref="printDialog" class="unskew" :pilot="pilot" />
-    <export-dialog ref="exportDialog" class="unskew" :pilot="pilot" />
-    <statblock-dialog ref="statblockDialog" class="unskew" :pilot="pilot" />
-    <cloud-dialog ref="cloudDialog" class="unskew" :pilot="pilot" />
-    <delete-dialog ref="deleteDialog" class="unskew" :pilot="pilot" @delete="deletePilot()" />
-    <cloud-manager ref="cloud" class="unskew" :pilot="pilot" />
+    
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-
-import CloudManager from './CloudManager.vue'
-import CloudDialog from './CloudDialog.vue'
-import StatblockDialog from './StatblockDialog.vue'
-import ExportDialog from './ExportDialog.vue'
-import PrintDialog from './PrintDialog.vue'
-import DeleteDialog from './DeletePilotDialog.vue'
-
+import EditMenu from './PilotEditMenu.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 
 export default Vue.extend({
   name: 'pilot-nav',
   components: {
-    CloudManager,
-    CloudDialog,
-    StatblockDialog,
-    ExportDialog,
-    PrintDialog,
-    DeleteDialog,
+    EditMenu,
   },
   props: {
     pilot: {
@@ -199,8 +101,8 @@ export default Vue.extend({
       return this.pilot.Mechs.some(x => x.ID === store.LoadedMechID)
         ? store.LoadedMechID
         : this.pilot.ActiveMech
-        ? this.pilot.ActiveMech.ID
-        : null
+          ? this.pilot.ActiveMech.ID
+          : null
     },
   },
   methods: {

--- a/src/features/pilot_management/Roster/components/PilotListItem.vue
+++ b/src/features/pilot_management/Roster/components/PilotListItem.vue
@@ -13,8 +13,9 @@
       </div>
     </v-card>
     <div id="banner" style="width: 100%">
-      <div style="width: 100%" class="overlay primary sliced">
-        <h2 class="heading callsign" style="margin-left: 150px;">{{ pilot.Callsign }}</h2>
+      <div style="width: 100%;display: flex;justify-content: space-between;" class="overlay primary sliced">
+        <div class="heading callsign" style="margin-left: 150px; display: inline-block;">{{ pilot.Callsign }}</div>
+        <edit-menu style="display: inline-block; padding-right: 30px;" :pilot="pilot" />
       </div>
       <div style="margin-right: 30px; border-top: 0!important" class="light-panel clipped">
         <div style="margin-left: 150px; padding-left: 8px; min-height: 100px">
@@ -73,9 +74,13 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import EditMenu from '../../PilotSheet/components/PilotEditMenu.vue'
 
 export default Vue.extend({
-  name: 'cc-pilot-list-item',
+  name: 'pilot-list-item',
+  components: {
+    EditMenu,
+  },
   props: {
     pilot: {
       type: Object,

--- a/src/features/pilot_management/Roster/index.vue
+++ b/src/features/pilot_management/Roster/index.vue
@@ -14,7 +14,7 @@
       <v-container v-if="profile.RosterView === 'list'" fluid>
         <v-row>
           <v-col v-for="p in pilots" :key="p.ID" cols="12">
-            <cc-pilot-list-item :pilot="p" />
+            <pilot-list-item :pilot="p" />
           </v-col>
         </v-row>
         <add-pilot />
@@ -31,6 +31,7 @@
 import Vue from 'vue'
 import RosterSort from './components/RosterSort.vue'
 import PilotTable from './components/PilotTable.vue'
+import PilotListItem from './components/PilotListItem.vue'
 import AddPilot from './components/AddPilot.vue'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore, PilotManagementStore } from '@/store'
@@ -38,7 +39,7 @@ import { UserProfile } from '@/io/User'
 
 export default Vue.extend({
   name: 'roster-view',
-  components: { RosterSort, PilotTable, AddPilot },
+  components: { RosterSort, PilotTable, AddPilot, PilotListItem },
   data: () => ({
     sortParams: null,
   }),


### PR DESCRIPTION
# Description

Pulled out the function menu (gear icon) on the pilot sheet so it could be reused in the list items for the roster. Used there.

## Notes
removed the `unskew` class from many of the menu items and just applied it to the entire menu in `PilotNav.vue` This was done because the gear menu is now shared with two types of menus, one that uses `skew` to achieve the clipped effect, and one that uses `clip-path` to achieve a similar affect. I attempted to make them use the same method, but it proved to be too difficult.

## Issue Number
#533 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

