### PR TITLE
Fix custom counter delete button not deleting correct counter

### DIFF
--- a/src/features/pilot_management/ActiveSheet/layout/CountersBlock.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/CountersBlock.vue
@@ -9,7 +9,7 @@
       class="row justify-start pr-4"
     >
       <v-col v-for="cd in counterData" :key="cd.id" cols="auto" style="min-height: 170px">
-        <counter-component :counter-data="cd" @delete="deleteCustom" />
+        <counter-component :counter-data="cd" @delete="deleteCustom(cd.id)" />
       </v-col>
       <v-col key="NewCounter" cols="auto">
         <new-counter @create="onCustomCounterCreate" />


### PR DESCRIPTION
# Description

The Custom Counter delete button was not properly pointing at the ID of the counter to be deleted in its code, so the function defaulted to deleting the latest counter created.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
