### PR TITLE
Tag display on alternate weapon profiles

### DIFF
--- a/src/classes/effects/ItemEffect.ts
+++ b/src/classes/effects/ItemEffect.ts
@@ -44,14 +44,14 @@ interface IEffectData {
   effect_type: EffectType
   name?: string
   activation?: ActivationType
-  tags?: ITagCompendiumData[]
+  tags?: ITagData[]
 }
 
 abstract class ItemEffect {
   private _err: boolean
   protected effectType: EffectType
   protected activation: ActivationType
-  protected tags: ITagCompendiumData[]
+  protected tags: ITagData[]
 
   public constructor(err?: boolean) {
     this._err = err
@@ -66,7 +66,7 @@ abstract class ItemEffect {
   }
 
   public get Tags(): Tag[] {
-    return this.tags ? this.tags.map(x => new Tag(x)) : []
+    return Tag.Deserialize(this.tags)
   }
 
   public static Generate(data: any): ItemEffect | null {

--- a/src/classes/effects/ProfileEffect.ts
+++ b/src/classes/effects/ProfileEffect.ts
@@ -1,6 +1,6 @@
 import { IRangeData, IDamageData } from '@/interface'
 import { ItemEffect, IEffectData } from './ItemEffect'
-import { ActivationType, EffectType, Damage, Range } from '@/class'
+import { ActivationType, EffectType, Damage, Range, Tag } from '@/class'
 
 interface IProfileEffectData extends IEffectData {
   name: string
@@ -20,6 +20,7 @@ class ProfileEffect extends ItemEffect {
     this.Name = data.name
     this.Damage = data.damage ? data.damage.map(x => new Damage(x)) : []
     this.Range = data.range ? data.range.map(x => new Range(x)) : []
+    this.tags = data.tags ? data.tags : []
     this.Detail = data.detail
     this.activation = ActivationType.None
     this.effectType = EffectType.Profile

--- a/src/classes/effects/ProfileEffect.ts
+++ b/src/classes/effects/ProfileEffect.ts
@@ -1,6 +1,6 @@
 import { IRangeData, IDamageData } from '@/interface'
 import { ItemEffect, IEffectData } from './ItemEffect'
-import { ActivationType, EffectType, Damage, Range, Tag } from '@/class'
+import { ActivationType, EffectType, Damage, Range } from '@/class'
 
 interface IProfileEffectData extends IEffectData {
   name: string


### PR DESCRIPTION
# Description

Fixes a few small issues which prevented tags from displaying on alternate weapon profiles. 

## Issue Number
Closes #691.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
