### PR TITLE
Add error notifications and logging

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,7 @@ export default Vue.extend({
 
     Vue.prototype.$confirm = this.$refs.confirm.open
     Vue.prototype.$notify = this.$refs.notifier.notify.bind(this.$refs.notifier)
+
   },
 })
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@ export default Vue.extend({
 
     Vue.prototype.$confirm = this.$refs.confirm.open
     Vue.prototype.$notify = this.$refs.notifier.notify.bind(this.$refs.notifier)
-
+    Vue.prototype.$notifyError = this.$refs.notifier.notifyError.bind(this.$refs.notifier)
   },
 })
 </script>

--- a/src/classes/Interfaces.d.ts
+++ b/src/classes/Interfaces.d.ts
@@ -18,6 +18,13 @@ interface INotification {
   onClick?: () => void
 }
 
+declare interface IErrorReport {
+  time: Date
+  message: string
+  component?: string
+  stack: string
+}
+
 declare interface IDiceStats {
   min: number
   max: number

--- a/src/features/main_menu/index.vue
+++ b/src/features/main_menu/index.vue
@@ -54,7 +54,14 @@
         Support This Project
       </v-btn>
     </v-footer>
-    <cc-solo-dialog ref="optionsModal" large no-confirm title="Options & User Profile">
+    <cc-solo-dialog
+      ref="optionsModal"
+      large
+      no-confirm
+      no-pad
+      no-title-clip
+      title="Options & User Profile"
+    >
       <options-page />
     </cc-solo-dialog>
     <cc-solo-dialog ref="aboutModal" large no-confirm title="About"><about-page /></cc-solo-dialog>
@@ -80,7 +87,7 @@ import CCLog from './_components/CCLog.vue'
 import ContentPage from '../nav/pages/ExtraContent/index.vue'
 import AboutPage from '../nav/pages/About.vue'
 import HelpPage from '../nav/pages/Help.vue'
-import OptionsPage from '../nav/pages/Options.vue'
+import OptionsPage from '../nav/pages/Options/index.vue'
 import { getModule } from 'vuex-module-decorators'
 import { NavStore } from '@/store'
 

--- a/src/features/nav/index.vue
+++ b/src/features/nav/index.vue
@@ -95,7 +95,14 @@
       <content-page />
     </cc-solo-dialog>
 
-    <cc-solo-dialog ref="optionsModal" large no-confirm title="Options & User Profile">
+    <cc-solo-dialog
+      ref="optionsModal"
+      large
+      no-confirm
+      no-pad
+      no-title-clip
+      title="Options & User Profile"
+    >
       <options-page />
     </cc-solo-dialog>
     <cc-solo-dialog ref="aboutModal" large no-confirm title="About"><about-page /></cc-solo-dialog>
@@ -106,7 +113,7 @@
 <script lang="ts">
 import HelpPage from './pages/Help.vue'
 import AboutPage from './pages/About.vue'
-import OptionsPage from './pages/Options.vue'
+import OptionsPage from './pages/Options/index.vue'
 import ContentPage from './pages/ExtraContent/index.vue'
 import activePilot from '../pilot_management/mixins/activePilot'
 

--- a/src/features/nav/pages/Options/Log.vue
+++ b/src/features/nav/pages/Options/Log.vue
@@ -1,0 +1,67 @@
+<template>
+  <div style="max-height: 550px; overflow-y: scroll">
+    <h2 class="heading accent--text mb-3">Recent Errors</h2>
+    <v-expansion-panels>
+      <v-expansion-panel v-for="(error, i) in errors" :key="i">
+        <v-expansion-panel-header>
+          <div class="flavor-text font-small text--text">
+            <span class="flavor-text error--text font-big">{{ error.message }}</span>
+            - {{ dateFormat(error.time) }}
+            <span v-if="error.component">
+              at
+              <span class="secondary--text">[{{ error.component }}]</span>
+            </span>
+          </div>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <h5 class="error--text">STACK TRACE</h5>
+          <pre class="flavor-text error--text stack" @copy="onCopy($event, error)">{{
+            error.stack
+          }}</pre>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { getModule } from 'vuex-module-decorators'
+import { NavStore } from '@/store'
+
+@Component
+export default class OptionsLog extends Vue {
+  get errors() {
+    return getModule(NavStore, this.$store).Errors
+  }
+
+  dateFormat(date: Date) {
+    return `${date.getFullYear()}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}`
+  }
+
+  onCopy(e, error) {
+    console.log('oncopy fired');
+    const text = '```\n' + (error.component ? `Vue error at [${error.component}]\n` : '') + window.getSelection().toString() + '```'
+    e.clipboardData.setData('text/plain', text);
+    e.preventDefault();
+  }
+
+
+}
+</script>
+
+<style scoped>
+.font-small {
+  font-size: 12px;
+}
+
+.stack {
+  font-size: 14px;
+  user-select: all;
+  border: 1px solid var(--v-subtle-darken2);
+  border-radius: 4px;
+  padding: 10px;
+  margin: 3px 0;
+}
+</style>

--- a/src/features/nav/pages/Options/Settings.vue
+++ b/src/features/nav/pages/Options/Settings.vue
@@ -145,7 +145,7 @@ import { exportAll, importAll, exportV1Pilots, clearAllData } from '@/io/BulkDat
 import { saveFile } from '@/io/Dialog'
 
 export default Vue.extend({
-  name: 'options',
+  name: 'options-settings',
   data: () => ({
     theme: 'light',
     themes: [
@@ -164,7 +164,7 @@ export default Vue.extend({
     userTheme() {
       const store = getModule(CompendiumStore, this.$store)
       return store.UserProfile.Theme
-    },
+    }
   },
   created() {
     this.theme = this.userTheme

--- a/src/features/nav/pages/Options/index.vue
+++ b/src/features/nav/pages/Options/index.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-tabs dark background-color="primary" v-model="tab" style="min-height: 640px;">
+    <v-tab>Settings</v-tab>
+    <v-tab>Log</v-tab>
+    <v-tab-item>
+      <v-card-text><Settings /></v-card-text>
+    </v-tab-item>
+    <v-tab-item>
+      <v-card-text><Log /></v-card-text>
+    </v-tab-item>
+  </v-tabs>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Settings from './Settings.vue'
+import Log from './Log.vue'
+
+export default Vue.extend({
+  name: 'options',
+  components: { Settings, Log },
+  data: () => ({
+    tab: 1
+  })
+})
+</script>

--- a/src/features/nav/store/index.ts
+++ b/src/features/nav/store/index.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { Module, VuexModule, Action, Mutation } from 'vuex-module-decorators'
+import { Module, VuexModule, Action, Mutation, MutationAction } from 'vuex-module-decorators'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore, store } from '@/store'
 
 export const SET_NAV_MODE = 'SET_NAV_MODE'
 export const SET_DARK_MODE = 'SET_DARK_MODE'
+export const LOG_ERROR = 'LOG_ERROR'
 
 @Module({
   name: 'nav',
@@ -44,4 +45,17 @@ export class NavStore extends VuexModule {
       : 'light'
     this.context.commit(SET_DARK_MODE, mode)
   }
+
+  public Errors: IErrorReport[] = []
+
+  @Mutation
+  public [LOG_ERROR](error: IErrorReport) {
+    this.Errors = [error, ...this.Errors]
+  }
+
+  @Action({ commit: LOG_ERROR })
+  public logError(error: IErrorReport) {
+    return error
+  }
+
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,8 +54,8 @@ mixins.forEach(m => {
 Vue.directive('extlink', externalLinkDirective)
 
 
-Vue.config.errorHandler = (error, vm) => vm.$notify(error.message, 'error')
-window.onerror = (error) => Vue.prototype.$notify(error, 'error')
+Vue.config.errorHandler = (error, vm) => Vue.prototype.$notifyError(error, vm)
+window.onerror = (error) => Vue.prototype.$notifyError(error)
 
 new Vue({
   components: { App },

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,10 @@ mixins.forEach(m => {
 
 Vue.directive('extlink', externalLinkDirective)
 
+
+Vue.config.errorHandler = (error, vm) => vm.$notify(error.message, 'error')
+window.onerror = (error) => Vue.prototype.$notify(error, 'error')
+
 new Vue({
   components: { App },
   vuetify,

--- a/src/ui/GlobalNotifier.vue
+++ b/src/ui/GlobalNotifier.vue
@@ -24,6 +24,8 @@ import Component from 'vue-class-component'
 import uuid from 'uuid/v4'
 
 import NotificationSnackbar from './NotificationSnackbar.vue'
+import { getModule } from 'vuex-module-decorators'
+import { NavStore } from '@/store'
 
 @Component({
   components: { NotificationSnackbar }
@@ -42,6 +44,17 @@ export default class GlobalNotifier extends Vue {
     this.notifications = [...this.notifications, notification]
     this.shownNotifications = [...this.shownNotifications, notification]
     this.$forceUpdate()
+  }
+
+  public notifyError(error: Error, vm?: Vue) {
+    const nm = getModule(NavStore, this.$store)
+    nm.logError({
+      time: new Date(),
+      message: error.message,
+      component: vm?.$options?.name ?? undefined,
+      stack: error.stack
+    })
+    this.notify(error.message, 'error')
   }
 
   private hideNotification(id: string) {


### PR DESCRIPTION
Adds error notifications using the global notifier. Adds a new tab under Options that keeps logged errors (lost on refresh for now).

It will catch everything both inside and outside Vue - unfortunately vuex-module-decorator catches all errors and doesn't give a way to add a custom error handler - the only way to get around it is to manually add a `rawError` prop to every action decorator. They might fix this in the future, if not we might want to do this as tedious and ugly as it would be, since store errors are pretty important.

Would like it so that clicking on the notification sends you to the error logging page, but for that I'll need to globalize the options dialog.