### PR TITLE
fix(Item Card): Make sure item card re-imports correct component when this.item updates

### DIFF
--- a/src/ui/components/cards/CCItemCard.vue
+++ b/src/ui/components/cards/CCItemCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="component" v-if="component" :item="item" />
+  <component :is="componentLoader" v-if="componentLoader" :item="item" />
 </template>
 
 <script>
@@ -17,23 +17,19 @@ export default {
     }
   },
   computed: {
-    loader() {
+    componentLoader() {
       if (!this.item) {
         return null
       }
-      return () => import(`./_${this.item.ItemType}Card.vue`)
-    },
-  },
-  mounted() {
-    if (this.item) {
-      this.loader()
-        .then(() => {
-          this.component = () => this.loader()
-        })
-        .catch(() => {
+      return () => {
+        try {
+          return import(`./_${this.item.ItemType}Card.vue`)
+        } catch (error) {
           console.error(`Unable to load component ${this.item.ItemType}`)
-        })
-    }
+          return null
+        }
+      }
+    },
   },
 }
 </script>


### PR DESCRIPTION
# Description

I ran into an error in the NPC builder when adding features in using the selector split view, encountering sporadic `t.item.Damage is not a function` error toasts when selecting features in the left column of the selector.  I managed to narrow it down to a repro:

### Repro
1) Create a new NPC (I went with Berserker, where I knew I had run into this error before)
2) Select that new NPC in the NPC Roster
3) Click the `Add Feature` button
4) Click on a weapon feature (For the Berserker, `Nail Gun` and `Harpoon Cannon` fit his criteria)
5) Observe a correctly rendered NpcWeapon card with the weapon's stats
6) Click on an item feature (For the Berserker, `Juggernaut`, `Retribution`, and `Superhot` fit this criteria)

### Expected
7) Observe a correctly rendered NpcItem card with the system's stats
8) No error toast appears

### Actual
7) An NpcWeapon item card is rendered with the systems stats
8) An error toast containing "t.item.Damage is not a function" appears

This also works in reverse.  If instead you select an item feature, and the click a weapon feature, it will attempt to render the weapons states using an NpcItem card instead. 

I worked out that while we were using a computed `loader()` to import the correct component based on `this.item.itemType` we were only setting the `component` property used in the template on mount.  While I'm not super familiar with VueJS that lead me to believe that while we were updating the computer `loader()` correctly, `component` would never get updated if `this.item` or `this.item.itemType` changes, as the component has already been mounted.  

Happy to work through any changes this PR might need so that it can land!

## Issue Number
Sorry, I did not create an issue before starting this fix.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)