### PR TITLE
fix(Mission Runner): Restore scrolling in NPC selector for reinforcements

### DIFF
--- a/src/features/encounters/encounter/components/NpcSelector.vue
+++ b/src/features/encounters/encounter/components/NpcSelector.vue
@@ -48,7 +48,7 @@
                 duration: 150,
                 easing: 'easeInOutQuad',
                 offset: 25,
-                container: '.v-dialog--active',
+                container: $el.closest('.v-dialog--active'),
               })
             "
           >


### PR DESCRIPTION
# Description

Scrolling was broken when clicking the name of an NPC selector, but only in the Mission Runner and not encounter builder.  Turns out in the Mission Runner, there were TWO open/active dialogs ([`NpcSelector` was in a `CcSoloDialog` inside of `ReinforcementsModal`](https://github.com/massif-press/compcon/blob/master/src/features/encounters/mission/runner/components/ReinforcementsModal.vue#L98-L100), but [`ReinforcementsModal` was in a `CcSoloDialog` inside of `EncounterNav`](https://github.com/massif-press/compcon/blob/master/src/features/encounters/mission/runner/components/EncounterNav.vue#L116-L124)!) and when passing a selector instead of an element to `$vuetify.goTo`'s options object it uses the first one found in the document, which was NOT the one we intended.

I updated this to utilize [Element.closest()](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) to find the nearest parent that matched our selector.

I'm still green with Vue and couldn't work out how to pass down the parent dialog as a ref to the child.  If there's a more Vue-centric way of doing things please let me know, I had trouble following [StackOverflow's suggestions](https://stackoverflow.com/questions/51668630/vue-how-to-pass-parent-ref-to-child-as-a-prop)

## Issue Number
#637

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)