### PR TITLE
fix(Mission Runner): Ensure remaining HP is calculated correctly after structure roll

### DIFF
--- a/src/classes/npc/Npc.ts
+++ b/src/classes/npc/Npc.ts
@@ -377,7 +377,7 @@ export class Npc implements IActor {
   public set CurrentHP(val: number) {
     if (val > this.MaxHP) this.CurrentStats.HP = this.MaxHP
     else if (val <= 0) {
-      this.CurrentStats.HP = this.MaxHP - val
+      this.CurrentStats.HP = this.MaxHP + val
       this.CurrentStructure -= 1
     } else this.CurrentStats.HP = val
   }


### PR DESCRIPTION
# Description

If an NPC mech takes HP damage then they have available HP, the amount HP remaining after the structure roll was being improperly calculated.  Thanks to @aritsune for [pointing out exactly where to fix](https://github.com/massif-press/compcon/issues/803#issuecomment-618584004).  I also went and [verified that this is being properly set for PC mechs](https://github.com/massif-press/compcon/blob/master/src/classes/mech/Mech.ts#L401).

## Issue Number
#803

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
