### PR TITLE
fix(Encounter Builder): Restore scrolling when multiple NPC selectors have been active on page

### DIFF
--- a/src/features/encounters/encounter/components/NpcSelector.vue
+++ b/src/features/encounters/encounter/components/NpcSelector.vue
@@ -44,7 +44,7 @@
           <span
             class="accent--text heading clickable ml-n2"
             @click="
-              $vuetify.goTo(`#e_${item.ID}`, {
+              $vuetify.goTo(`#${generateNpcElementId(item)}`, {
                 duration: 150,
                 easing: 'easeInOutQuad',
                 offset: 25,
@@ -63,7 +63,7 @@
     <div v-if="!npcs.length" class="subtle--text heading h2 text-center">
       // NO NPCS AVAILABLE //
     </div>
-    <v-row v-for="(npc, i) in npcs" :id="`e_${npc.ID}`" :key="`${npc.ID}_${i}`">
+    <v-row v-for="(npc, i) in npcs" :id="generateNpcElementId(npc)" :key="`${npc.ID}_${i}`">
       <v-col class="pl-0 mb-2">
         <npc-panel :npc="npc">
           <div>
@@ -120,6 +120,11 @@ export default Vue.extend({
   created() {
     const compendium = getModule(NpcStore, this.$store)
     this.npcs = compendium.Npcs
+  },
+  methods: {
+    generateNpcElementId: function(npc) {
+      return `e_${this._uid}_${npc.ID}`
+    },
   },
 })
 </script>


### PR DESCRIPTION
# Description

Vuetify.goTo was running into issues when multiple `NpcSelector` components were rendered on a page at once.  We were giving a "unique" ID to each container element for the NPC list, but if there were multiple `NpcSelector` components on the page (such as in the Encounter Builder), these IDs were getting duplicated and the browser was getting them confused.  Adding the `NpcSelector` components auto-generated uid to the NPC element ID solved this.  I also went back and tested in the Mission Runner reinforcements modal and it still works there as well.

## Issue Number
#816

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
