### PR TITLE
fix(NPC Roster): Align NPC statblock format with PC Mech statblock format

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -72,7 +72,7 @@ class Statblock {
         output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
       output += `  STRUCTURE:${mech.CurrentStructure}${
         mech.IsActive ? '/' + mech.MaxStructure : ''
-      }`
+        }`
       output += ` HP:${mech.CurrentHP}${mech.IsActive ? '/' + mech.MaxHP : ''}`
       output += ` ARMOR:${mech.Armor}\n`
       output += `  STRESS:${mech.CurrentStress}${mech.IsActive ? '/' + mech.MaxStress : ''}`
@@ -120,10 +120,10 @@ class Statblock {
     return `-- ${mech.Frame.Source} ${mech.Frame.Name} @ LL${pilot.Level} --
 [ LICENSES ]
   ${
-    pilot.Licenses.length
-      ? `${pilot.Licenses.map(l => `${l.License.Source} ${l.License.Name} ${l.Rank}`).join(', ')}`
-      : 'N/A'
-  }
+      pilot.Licenses.length
+        ? `${pilot.Licenses.map(l => `${l.License.Source} ${l.License.Name} ${l.Rank}`).join(', ')}`
+        : 'N/A'
+      }
 [ CORE BONUSES ]
   ${pilot.CoreBonuses.length ? `${pilot.CoreBonuses.map(cb => cb.Name).join(', ')}` : 'N/A'}
 [ TALENTS ]
@@ -131,42 +131,42 @@ class Statblock {
 [ STATS ]
   HULL:${pilot.MechSkills.Hull} AGI:${pilot.MechSkills.Agi} SYS:${pilot.MechSkills.Sys} ENGI:${
       pilot.MechSkills.Eng
-    }
+      }
   STRUCTURE:${mech.MaxStructure} HP:${mech.MaxHP} ARMOR:${mech.Armor}
   STRESS:${mech.MaxStress} HEATCAP:${mech.HeatCapacity} REPAIR:${mech.RepairCapacity}
   TECH ATK:${mech.TechAttack > 0 ? `+${mech.TechAttack}` : mech.TechAttack} LIMITED:+${
       mech.LimitedBonus
-    }
+      }
   SPD:${mech.Speed} EVA:${mech.Evasion} EDEF:${mech.EDefense} SENSE:${mech.SensorRange} SAVE:${
       mech.SaveTarget
-    }
+      }
 [ WEAPONS ]
   ${mech.IntegratedMounts.map(mount => `Integrated: ${mount.Weapon ? mount.Weapon.Name : 'N/A'}`)}
   ${mechLoadout
-    .AllEquippableMounts(
-      pilot.has('CoreBonus', 'cb_improved_armament'),
-      pilot.has('CoreBonus', 'cb_integrated_weapon')
-    )
-    .map(mount => {
-      let out = `${mount.Name}: `
-      if (mount.IsLocked) out += 'SUPERHEAVY WEAPON BRACING'
-      else
-        out += mount.Weapons.filter(Boolean)
-          .map(weapon => `${weapon.Name}${weapon.Mod ? ` (${weapon.Mod.Name})` : ''}`)
-          .join(' / ')
+        .AllEquippableMounts(
+          pilot.has('CoreBonus', 'cb_improved_armament'),
+          pilot.has('CoreBonus', 'cb_integrated_weapon')
+        )
+        .map(mount => {
+          let out = `${mount.Name}: `
+          if (mount.IsLocked) out += 'SUPERHEAVY WEAPON BRACING'
+          else
+            out += mount.Weapons.filter(Boolean)
+              .map(weapon => `${weapon.Name}${weapon.Mod ? ` (${weapon.Mod.Name})` : ''}`)
+              .join(' / ')
 
-      if (mount.Bonuses.length > 0)
-        out += ' // ' + mount.Bonuses.map(bonus => bonus.Name).join(', ')
+          if (mount.Bonuses.length > 0)
+            out += ' // ' + mount.Bonuses.map(bonus => bonus.Name).join(', ')
 
-      return out
-    })
-    .join('\n  ')}
+          return out
+        })
+        .join('\n  ')}
 [ SYSTEMS ]
   ${mechLoadout.Systems.map(sys => {
-    let out = sys.Name
-    if (sys.IsLimited) out += ` x${sys.MaxUses + mech.LimitedBonus}`
-    return out
-  }).join(', ')}`
+          let out = sys.Name
+          if (sys.IsLimited) out += ` x${sys.MaxUses + mech.LimitedBonus}`
+          return out
+        }).join(', ')}`
   }
 
   public static GenerateNPC(npc: Npc): string {

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -1,17 +1,17 @@
 import { Pilot, Mech, Npc } from '@/class'
 
+function linebreak(i: number, length: number): string {
+  if (i > 0 && (i + 1) % 2 === 0 && i + 1 !== length) {
+    return '\n  '
+  } else if (i + 1 < length) {
+    return ', '
+  } else {
+    return '\n'
+  }
+}
+
 class Statblock {
   public static Generate(pilot?: Pilot, mech?: Mech): string {
-    function linebreak(i: number, length: number): string {
-      if (i > 0 && (i + 1) % 2 === 0 && i + 1 !== length) {
-        return '\n  '
-      } else if (i + 1 < length) {
-        return ', '
-      } else {
-        return '\n'
-      }
-    }
-
     let output = ''
     if (pilot) {
       output += `» ${pilot.Callsign.toUpperCase()} «\n`
@@ -172,21 +172,18 @@ class Statblock {
   public static GenerateNPC(npc: Npc): string {
     let output = `// ${npc.Name} //\n`
     output += `${npc.Class.Name.toUpperCase()}`
-    if (npc.Templates) output += `${npc.Templates.map(t => t.Name).join(' ')}`
+    if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`
     output += typeof npc.Tier === 'number' ? `, Tier ${npc.Tier} ` : ', Custom '
-    output += npc.Tag
-    output += '\n[ STATS ]'
-    output += `\nH: ${npc.Stats.Hull} | A: ${npc.Stats.Agility} | S: ${npc.Stats.Systems} | E: ${npc.Stats.Engineering}`
-    output += `\nSTRUCT: ${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.Stats.HP}`
-    output += `\nSTRESS: ${npc.Stats.Stress} | HEATCAP: ${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}`
-    output += `\nSAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}`
-    output += `\nSENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}`
-    output += '\n[ FEATURES ]\n'
-    npc.Items.forEach((e, idx) => {
-      output += `${e.Name} (${'I'.repeat(e.Tier)})`
-      if (idx % 3 === 0) output += '\n'
-    })
-
+    output += `${npc.Tag}\n`
+    output += '[ STATS ]\n'
+    output += `  H: ${npc.Stats.Hull} | A: ${npc.Stats.Agility} | S: ${npc.Stats.Systems} | E: ${npc.Stats.Engineering}\n`
+    output += `  STRUCT: ${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.Stats.HP}\n`
+    output += `  STRESS: ${npc.Stats.Stress} | HEATCAP: ${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
+    output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
+    output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
+    output += '[ FEATURES ]\n  '
+    output += npc.Items.map((item, index) => `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`).join("")
+    console.log(npc.Items.map((item, index) => `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`).join(""))
     return output
   }
 }


### PR DESCRIPTION
# Description

The NPC statblocks we generated had some issues in formatting, specifically around NPC templates and features.  I touched up the whitespace and applied the `linebreak()` function we're using on PC statblocks for NPC features.

## Before:
```
// New ACE //
ACEVETERAN ELITE, Tier 1 Mech
[ STATS ]
H: -2 | A: 3 | S: 1 | E: 0
STRUCT: 3 | ARMOR: 0 | HP: 10
STRESS: 3 | HEATCAP: 8 | SPD: 5
SAVE: 10 | EVADE: 12 | EDEF: 8
SENS: 10 | SIZE: 1 | ACT: 2
[ FEATURES ]
SSC FLIGHT SYSTEM (I)
MISSILE LAUNCHER (I)BARREL ROLL (I)BOMBING BAY (I)
CHAFF LAUNCHERS (I)RAPID RESPONSE (I)STRAFE (I)
MISSILE SWARM (I)REINFORCED (I)VETERANCY (I)
VETERAN TRAITS (I)HACKER (I)PARTING GIFT (I)
SHOCK ARMOR (I)SELF REPAIR (I)INSULATED (I)
REINFORCED (I)READY AND WAITING (I)CAREER SOLDIER (I)
SPECIALIST KIT (I)
```

## After:
```
// New ACE //
ACE VETERAN ELITE, Tier 1 Mech
[ STATS ]
  H: -2 | A: 3 | S: 1 | E: 0
  STRUCT: 3 | ARMOR: 0 | HP: 10
  STRESS: 3 | HEATCAP: 8 | SPD: 5
  SAVE: 10 | EVADE: 12 | EDEF: 8
  SENS: 10 | SIZE: 1 | ACT: 2
[ FEATURES ]
  SSC FLIGHT SYSTEM (I), MISSILE LAUNCHER (I)
  BARREL ROLL (I), BOMBING BAY (I)
  CHAFF LAUNCHERS (I), RAPID RESPONSE (I)
  STRAFE (I), MISSILE SWARM (I)
  REINFORCED (I), VETERANCY (I)
  VETERAN TRAITS (I), HACKER (I)
  PARTING GIFT (I), SHOCK ARMOR (I)
  SELF REPAIR (I), INSULATED (I)
  REINFORCED (I), READY AND WAITING (I)
  CAREER SOLDIER (I), SPECIALIST KIT (I)

```
