### PR TITLE
feat(Pilot Sheet): adds the detail field to custom skill triggers

### DIFF
--- a/src/classes/Interfaces.d.ts
+++ b/src/classes/Interfaces.d.ts
@@ -55,6 +55,7 @@ declare interface IRankedData {
   rank: number
   custom?: boolean
   custom_desc?: string
+  custom_detail?: string
 }
 
 declare interface IEquipmentData {

--- a/src/classes/pilot/CustomSkill.ts
+++ b/src/classes/pilot/CustomSkill.ts
@@ -3,11 +3,13 @@ import { ItemType } from '@/class'
 class CustomSkill {
   private _name: string
   private _description: string
+  private _detail: string
   private _item_type: ItemType
 
-  public constructor(name: string, description: string) {
+  public constructor(name: string, description: string, detail: string) {
     this._name = name
     this._description = description
+    this._detail = detail
     this._item_type = ItemType.Skill
   }
 
@@ -40,7 +42,11 @@ class CustomSkill {
   }
 
   public get Detail(): string {
-    return ''
+    return this._detail
+  }
+
+  public set Detail(val: string) {
+    this._detail = val
   }
 
   public get Family(): string {

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -513,8 +513,8 @@ class Pilot {
     this.save()
   }
 
-  public AddCustomSkill(cs: { skill: string; description: string }): void {
-    this.AddSkill(new CustomSkill(cs.skill, cs.description))
+  public AddCustomSkill(cs: { skill: string; description: string, detail: string }): void {
+    this.AddSkill(new CustomSkill(cs.skill, cs.description, cs.detail))
   }
 
   public CanRemoveSkill(skill: Skill | CustomSkill): boolean {

--- a/src/classes/pilot/PilotSkill.ts
+++ b/src/classes/pilot/PilotSkill.ts
@@ -50,13 +50,14 @@ class PilotSkill {
         rank: item.Rank,
         custom: true,
         custom_desc: item.Skill.Description,
+        custom_detail: item.Skill.Detail,
       }
     return { id: item.Skill.ID, rank: item.Rank }
   }
 
   public static Deserialize(itemData: IRankedData): PilotSkill {
     if (itemData.custom)
-      return new PilotSkill(new CustomSkill(itemData.id, itemData.custom_desc), itemData.rank)
+      return new PilotSkill(new CustomSkill(itemData.id, itemData.custom_desc, itemData.custom_detail), itemData.rank)
     return new PilotSkill(Skill.Deserialize(itemData.id), itemData.rank)
   }
 }

--- a/src/ui/components/selectors/components/_AddCustomSkill.vue
+++ b/src/ui/components/selectors/components/_AddCustomSkill.vue
@@ -12,10 +12,20 @@
         outlined
         dense
         hide-details
-        rows="2"
+        rows="1"
         auto-grow
         class="pl-4 mt-1"
         label="Description"
+      />
+      <v-textarea
+        v-model="newDetail"
+        outlined
+        dense
+        hide-details
+        rows="3"
+        auto-grow
+        class="pl-4 mt-1"
+        label="Detail"
       />
     </v-col>
     <v-col cols="auto" class="text-center">
@@ -37,12 +47,14 @@ export default Vue.extend({
   data: () => ({
     newSkill: '',
     newDesc: '',
+    newDetail: '',
   }),
   methods: {
     addSkill() {
-      this.$emit('add-custom', { skill: this.newSkill, description: this.newDesc })
+      this.$emit('add-custom', { skill: this.newSkill, description: this.newDesc, detail: this.newDetail })
       this.newSkill = ''
       this.newDesc = ''
+      this.newDetail = ''
     },
   },
 })


### PR DESCRIPTION
Adds the detail field to custom skill triggers, bringing them in-line with built-in skill triggers.

This allows users to provide a terse description of their custom triggers, and a more detailed
explanation for the fold-out view in both the narrative profile and active mode views.

Closes #903