### PR TITLE
TRIGGER label will only appear if reaction actually has a trigger

### DIFF
--- a/src/ui/components/cards/npc/cards/_ReactionCard.vue
+++ b/src/ui/components/cards/npc/cards/_ReactionCard.vue
@@ -6,7 +6,7 @@
     @remove-feature="$emit('remove-feature', $event)"
     @recalc="$emit('recalc')"
   >
-    <span class="overline">TRIGGER</span>
+    <span v-if="item.Feature.Trigger" class="overline">TRIGGER</span>
     <p class="panel body-1 mb-0" v-html="item.Feature.Trigger" />
     <span class="overline">EFFECT</span>
     <p v-if="item.Tier" class="body-1 mb-0" v-html="item.Feature.EffectByTier(item.Tier)" />


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Simple change, only display 'TRIGGER' label on NPC reactions that actually have triggers, in response to Issue #915 

## Issue Number
`#915`

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)