### PR TITLE
Changed Gear uses on Compendium to show MaxUses

### DIFF
--- a/src/features/compendium/Views/PilotGear.vue
+++ b/src/features/compendium/Views/PilotGear.vue
@@ -51,7 +51,7 @@ export default class PilotGear extends Vue {
   ]
   public gear_headers = [
     { text: 'Item', align: 'left', value: 'Name' },
-    { text: 'Uses', align: 'center', value: 'Uses' },
+    { text: 'Uses', align: 'center', value: 'MaxUses' },
   ]
 
   // typing on these is wrong... look into fixing it


### PR DESCRIPTION
# Description
Pilot Gear compendium was not showing Uses.
Uses is a state variable, and is not set if the object isn't instantiated.
however, MaxUses is Constant, and is the data we need to show anyway.

## Issue Number
`#938`

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)