### PR TITLE
Fixed image uploader not being awaited

### DIFF
--- a/src/ui/components/selectors/CCImageSelector.vue
+++ b/src/ui/components/selectors/CCImageSelector.vue
@@ -177,7 +177,7 @@ export default Vue.extend({
     },
     async importImage() {
       const { dialog } = require('electron').remote
-      const path = dialog.showOpenDialog({
+      const dialogResult = await dialog.showOpenDialog({
         title: 'Load Image',
         buttonLabel: 'Load',
         properties: ['openFile'],
@@ -188,8 +188,8 @@ export default Vue.extend({
           },
         ],
       })
-      if (!path) return
-      await addImage(this.type, path[0])
+      if (!dialogResult.filePaths[0]) return
+      await addImage(this.type, dialogResult.filePaths[0])
       await this.importAll()
       this.$forceUpdate()
     },


### PR DESCRIPTION
# Description
Image uploader on Electron was erroring when opening the native dialog.
This was because the `electron.remote.showOpenDialog()` function is Async, and was not being awaited.
So electron would open the dialog and continue executing. resulting in the path being undefined.

awaiting the function fixes the issue.

## Issue Number
`#950`

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)
