### PR TITLE
feat(Compendium): add License Level column to Systems table

### DIFF
--- a/src/features/compendium/Views/Systems.vue
+++ b/src/features/compendium/Views/Systems.vue
@@ -16,11 +16,12 @@ import { MechEquipment } from '@/class'
 @Component({
   components: { CompendiumBrowser },
 })
-export default class Weapons extends Vue {
+export default class Systems extends Vue {
   public headers = [
     { text: 'Source', align: 'left', value: 'Source' },
     { text: 'System', align: 'left', value: 'Name' },
     { text: 'License', align: 'left', value: 'LicenseString' },
+    { text: 'License Level', align: 'left', value: 'LicenseLevel' },
     { text: 'SP Cost', align: 'left', value: 'SP' },
   ]
 


### PR DESCRIPTION
# Description
Added the ability to sort Systems by License Level, by adding a License Level column.
This may not be the best way to do this?
its possible this sorting functionality could be added to the existing License column? please advise

Also, renamed the component class from `Weapons` to `Systems`
Suspect this was a copy paste error, didn't break anything, as all imports were using the default import 

## Issue Number
#929 

## Type of change
- [X] New feature (non-breaking change which adds functionality)