### PR TITLE
Fixed Npc image being massive and pushing controls really far down

### DIFF
--- a/src/features/encounters/mission/runner/components/NpcCard.vue
+++ b/src/features/encounters/mission/runner/components/NpcCard.vue
@@ -271,7 +271,7 @@
       <v-col v-if="npc.HasImage">
         <v-card flat outlined>
           <v-card-text class="pa-1">
-            <v-img v-if="npc.Image" :key="npc.Image" :src="npc.Image" aspect-ratio="1" />
+            <v-img v-if="npc.Image" :key="npc.Image" :src="npc.Image" max-width="50vw" max-height="50vh" aspect-ratio="1" />
           </v-card-text>
         </v-card>
       </v-col>


### PR DESCRIPTION
# Description
When a large Image is added to an NPC, when that npc is viewed on the Mission runner, it expands to its original size, taking up huge amounts of space and pushing the other controls down the page.

I have added a limit of the size the image can take on the Encounter screen to 50% Viewport size,


## Issue Number
bug mentioned on discord

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

