### PR TITLE
Add active mode check for overkill granted by a mod

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
@@ -633,7 +633,9 @@ export default Vue.extend({
       }
     },
     overkill() {
-      return this.item.Tags.some(x => x.IsOverkill)
+      if (this.item.Tags.some(x => x.IsOverkill)) return true
+      if (this.item.Mod && this.item.Mod.AddedTags.some(x => x.IsOverkill)) return true
+      return false
     },
     crit() {
       return this.attackRoll && this.attackRoll >= 20


### PR DESCRIPTION
# Description
This fixes a blanket issue where mods that grant the overkill tag are not counted for automatic overkill tracking in active mode.
This is the generic half of the fix for #1424 the specific fix to apply the overkill tag on the paracausal mod can be found [in the lancer-data PRs](https://github.com/massif-press/lancer-data/pull/149)

## Issue Number
`#1424`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
