### PR TITLE
Dev builds visible on LAN

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,14 @@ yarn dev
 
 Which will open a browser window pointed to `localhost:8080`. Hot Module Reload is enabled, which means that the app should refresh as you save code. Occasionally (especially after certain syntax errors) this can start to fall off, in part or completely. If this is the case, a refresh will either get HMR working again or find your error.
 
+If you need access to your development output on a different machine than you are building on ( a headless server, for example ), there is another target that you can use:
+
+```bash
+yarn dev-public
+```
+
+Please note that this allows access to any computer that can reach the build machine, so this is less safe than your standard development build.
+
 ## App Conventions
 
 WIP

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "webpack --env.platform=web --env.prod",
     "dev": "webpack-dev-server --progress --env.platform=web",
+    "dev-public": "webpack-dev-server --progress --env.platform=web --env.public_dev",
     "gen-schema": "node ./build_scripts/build-content-schema.js",
     "int-test": "jest int",
     "unit-test": "jest unit",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,12 +62,10 @@ const baseConfig = {
     publicPath: '',
   },
   devServer: {
-    host: '0.0.0.0',
     port: 8080,
     hot: true,
     open: true,
     historyApiFallback: true,
-    disableHostCheck: true,
   },
   module: {
     rules: [
@@ -221,6 +219,12 @@ module.exports = function(env, argv) {
     requireIfExists(`./webpack_config/webpack.${env.platform}.${target}.config`),
     { mode: env.prod ? 'production' : 'development' }
   )
+
+  if (target == 'dev' && env.public_dev) {
+    out = merge(out,
+      requireIfExists(`./webpack_config/webpack.${target}-public.config`),
+    )
+  }
 
   if (argv['analyze']) {
     out = merge(out, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,10 +62,12 @@ const baseConfig = {
     publicPath: '',
   },
   devServer: {
+    host: '0.0.0.0',
     port: 8080,
     hot: true,
     open: true,
     historyApiFallback: true,
+    disableHostCheck: true,
   },
   module: {
     rules: [

--- a/webpack_config/webpack.dev-public.config.js
+++ b/webpack_config/webpack.dev-public.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+   devServer: {
+      host: '0.0.0.0',
+      disableHostCheck: true,
+   },
+}


### PR DESCRIPTION
# Description

Adds a new yarn build target to allow dev builds to be visible outside of localhost of the building machine. This is useful for situations where the machine building cannot be used to view the site. ex. Headless build servers.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
