### PR TITLE
Critical Hit / Overkill damage overhaul

### DIFF
--- a/src/ui/components/CCDiceMenu.vue
+++ b/src/ui/components/CCDiceMenu.vue
@@ -155,16 +155,13 @@
               <div class="caption">ROLLING {{ r.rolls.length }}D{{ r.sides }}</div>
               <v-row no-gutters>
                 <v-col v-for="(val, i) in r.rolls" :key="`roll_${r.sides}_${i}_${val}`" cols="auto">
-                  <v-chip v-if="r.lowRolls[i]" x-small label style="opacity: 0.4">
-                    {{ r.lowRolls[i] }}
-                  </v-chip>
-                  <v-chip x-small label :color="overkill && val === 1 ? 'heat' : ''">
+                  <v-chip x-small label :style="r.class[i] === 'low' ? 'opacity: 0.4' : ''" :color="r.class[i] === 'overkill' ? 'heat' : ''">
                     {{ val }}
                   </v-chip>
                   <v-icon v-if="i + 1 < r.rolls.length" small>mdi-plus</v-icon>
                 </v-col>
                 <v-col cols="auto" class="ml-auto stark--text">
-                  <b>= {{ r.rolls.reduce((a, b) => a + b, 0) - overkillRolls }}</b>
+                  <b>= {{ r.rolls.map((x,i) => { return r.class[i] === 'high' ? x : 0 }).reduce((a, b) => a + b, 0)}}</b>
                 </v-col>
               </v-row>
             </div>
@@ -278,10 +275,9 @@ export default Vue.extend({
     },
     total() {
       return (
-        this.result.flatMap(x => x.rolls).reduce((a, b) => a + b, 0) +
+        this.result.flatMap(x => x.rolls.map((y,i) => { return x.class[i] === 'high' ? y : 0 })).reduce((a, b) => a + b, 0) +
         parseInt(this.flat) +
-        parseInt(this.accTotal) -
-        this.overkillRolls
+        parseInt(this.accTotal)
       )
     },
   },
@@ -309,7 +305,7 @@ export default Vue.extend({
         return {
           sides: x.sides,
           rolls: dRoll.rawDieRolls,
-          lowRolls: dRoll.lowDieRolls,
+          class: dRoll.rollClassifications,
           overkill: dRoll.overkillRerolls,
         }
       })

--- a/src/ui/components/panels/loadout/active_loadout/components/_PilotAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_PilotAttack.vue
@@ -323,8 +323,9 @@ each source of damage is used.`"
                 <v-col cols="auto">
                   <cc-dice-menu
                     title="BONUS DAMAGE"
+                    :overkill="overkill"
                     :critical="crit"
-                    @commit="bonusDamage = $event.total"
+                    @commit="setBonusDamage($event)"
                   />
                 </v-col>
                 <v-col cols="auto" class="ml-n2">
@@ -635,6 +636,10 @@ export default Vue.extend({
     setDamage(index, damage) {
       Vue.set(this.damageRolls, index, damage.total)
       this.overkillHeat = damage.overkill
+    },
+    setBonusDamage(damage) {
+      this.bonusDamage = damage.total
+      this.overkillHeat += damage.overkill
     },
     confirm(): void {
       this.confirmed = true

--- a/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
@@ -369,8 +369,9 @@ each source of damage is used.`"
                 <v-col cols="auto">
                   <cc-dice-menu
                     title="BONUS DAMAGE"
+                    :overkill="overkill"
                     :critical="crit"
-                    @commit="bonusDamage = $event.total"
+                    @commit="setBonusDamage($event)"
                   />
                 </v-col>
                 <v-col cols="auto" class="ml-n2">
@@ -726,6 +727,10 @@ export default Vue.extend({
     setDamage(index, damage) {
       Vue.set(this.damageRolls, index, damage.total)
       this.overkillHeat = damage.overkill
+    },
+    setBonusDamage(damage) {
+      this.bonusDamage = damage.total
+      this.overkillHeat += damage.overkill
     },
     confirm(): void {
       this.confirmed = true


### PR DESCRIPTION
# Description

These changes overhaul how critical hits and overkill heat is calculated and displayed. The new method is more accurate for critical hit damage, and ( subjectively ) displays roll output more clearly. I will provide a summary of the algorithm changes, with screenshots, in the comments.

It also now accounts for overkill with bonus damage as well.

## Issue Number
`#1404`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
