### PR TITLE
Correct Critical Reactor behavior at 1 and 0 Stress

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -615,6 +615,7 @@ class Mech implements IActor {
     if (stress > this.MaxStress) this._current_stress = this.MaxStress
     else if (stress < 0) this._current_stress = 0
     else this._current_stress = stress
+    if (this._current_stress === 0 ) this._pilot.State.ReactorCriticalDestruct()
     this.save()
   }
 

--- a/src/ui/components/tables/CCStressTable.vue
+++ b/src/ui/components/tables/CCStressTable.vue
@@ -219,7 +219,7 @@ export default class CCStressTable extends Vue {
       case 2:
         return 2
       case 1:
-        return 3
+        return this.mech.CurrentStress <= 1 ? 4 : 3
     }
     return 4
   }

--- a/src/ui/components/tables/CCStressTable.vue
+++ b/src/ui/components/tables/CCStressTable.vue
@@ -182,7 +182,6 @@ export default class CCStressTable extends Vue {
   dialog = false
   show(): void {
     this.dialog = true
-    if (this.mech.CurrentStress === 0) this.window = 4
   }
   close(): void {
     this.window = 0


### PR DESCRIPTION
# Description

These changes fix issue #1412 such that rolling a "Meltdown" with only 1 stress remaining now causes an immediate "Critical Reactor" state.
This also fixes an unlisted issue where going down to 0 stress did not cause an immediate "Critical Reactor" state at all. Please see comments for more information.

## Issue Number
`#1412`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
