### PR TITLE
fix(Active Mode): allow counters provided by the mech to be displayed

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -996,8 +996,9 @@ class Mech implements IActor {
   }
 
   // -- Bonuses, Actions, Synergies, etc. ---------------------------------------------------------
-  private features<T>(p: string): T[] {
-    let output = this.Pilot[p]
+  private features<T>(p: string, i: boolean=true): T[] {
+    let output:T[] = []
+    if (i) output = this.Pilot[p] 
 
     if (this.ActiveLoadout) {
       const activeBonuses = this.ActiveLoadout.Equipment.filter(
@@ -1043,6 +1044,10 @@ class Mech implements IActor {
 
   public get Counters(): ICounterData[] {
     return this.features('Counters')
+  }
+
+  public get CountersOnlyMech(): ICounterData[] {
+    return this.features('Counters',false)
   }
 
   public get CounterData(): ICounterData[] {

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -1112,7 +1112,9 @@ class Pilot implements ICloudSyncable {
   }
 
   public get Counters(): ICounterData[] {
-    return this.features('Counters')
+    let counters:ICounterData[] = this.features('Counters')
+    if (this.ActiveMech) counters = counters.concat(this.ActiveMech.CountersOnlyMech)
+    return counters
   }
 
   public get IntegratedWeapons(): MechWeapon[] {


### PR DESCRIPTION
# Description

In looking at adding counters for Brutal LV3 and the Black ICE Module, I noticed that the ZF4 Solidcore counter was already present. In my testing neither the Solidcore or the Black ICE Module counters displayed. These changes fix that such that counters provided by equipment or frames are displayed in active mode.

## Issue Number
#1409 
#1410 
#1411

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
