### PR TITLE
Fixed the `ExportDialog` to print the real vault ShareCode

### DIFF
--- a/src/features/pilot_management/PilotSheet/components/ExportDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/ExportDialog.vue
@@ -10,8 +10,7 @@
       <div v-if="pilot.CloudID" class="flavor-text">
         <span class="font-weight-bold accent--text">Pilot Share Code:&nbsp;</span>
         <span>
-          {{ pilot.CloudID }}
-          {{ pilot.CloudOwner }}
+          {{ pilot.ShareCode }}
           <cc-tooltip simple inline content="Copy Share Code to clipboard">
             <v-icon :color="copyConfirm ? 'success' : 'grey'" @click="copyCode()">
               {{ copyConfirm ? 'mdi-check-outline' : 'mdi-clipboard-text-outline' }}
@@ -101,7 +100,7 @@ export default Vue.extend({
     },
     async copyCode() {
       this.copyConfirm = true
-      navigator.clipboard.writeText(this.pilot.CloudID).then(
+      navigator.clipboard.writeText(this.pilot.ShareCode).then(
         function() {
           Vue.prototype.$notify('Cloud ID copied to clipboard.', 'confirmation')
         },


### PR DESCRIPTION
# Description

* The `ExportDialog` was not using the `ShareCode` getter from the `ICloudSyncable` `Pilot` which was preventing users from getting a usable share code string -- instead all they'd get is the uid for their pilot.
* Note that in the "Sheet View" for the actual pilot page does seem to use the `ShareCode` so there is currently a workaround for obtaining a usable vault code.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)