### PR TITLE
feat(Active Mode): add support for rolling Tech Attacks other than Invade

### DIFF
--- a/src/classes/Action.ts
+++ b/src/classes/Action.ts
@@ -25,6 +25,7 @@ interface IActionData {
   log?: string
   ignore_used?: boolean
   heat_cost?: number
+  tech_attack?: boolean
 }
 
 enum ActivePeriod {
@@ -106,6 +107,7 @@ class Action {
   public readonly IsItemAction: boolean
   public readonly IsDowntimeAction: boolean
   public readonly IsActiveHidden: boolean
+  public readonly IsTechAttack: boolean
   public readonly SynergyLocations: string[]
   public readonly Confirm: string[]
   public readonly Log: string
@@ -145,6 +147,7 @@ class Action {
     if (data.damage) this.Damage = data.damage.map(x => new Damage(x))
     if (data.range) this.Range = data.range.map(x => new Range(x))
     this.IsPilotAction = data.pilot
+    this.IsTechAttack = data.tech_attack
     this.IsMechAction = data.mech || !data.pilot
     this.IsActiveHidden = data.hide_active
     this.IsDowntimeAction = data.activation && data.activation.toString() === 'Downtime'

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -31,7 +31,7 @@
         :used="techAttack"
         :action="action"
         :mech="mech"
-        @log="log($event)"
+        @techAttackComplete="techAttackComplete($event)"
       />
       <action-confirm-log
         ref="log"
@@ -131,9 +131,14 @@ export default Vue.extend({
       const self = this
       Vue.nextTick().then(() => self.$forceUpdate())
     },
-    log(logOverride) {
-      this.logOverride = logOverride
+    techAttackComplete(success) {
+      this.logOverride = ['UPLINK ESTABLISHED. ATTEMPTING REMOTE ACCESS.']
+      if (success) {
+        this.logOverride.push('SYSTEM ACCESS OBTAINED.')
+        this.logOverride = this.logOverride.concat(this.action.Confirm)
+      } else this.logOverride.push('ACCESS DENIED. SYSTEM FAILURE.')
       this.displayLog = true
+
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
       this.$emit('use')

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
   },
   methods: {
     use(free) {
-      this.mech.Pilot.State.CommitAction(this.action, free)
+      if (!this.fulltech) this.mech.Pilot.State.CommitAction(this.action, free)
       if (this.action.IsTechAttack) {
           this.techAttack = true
       } else {

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -170,5 +170,3 @@ export default Vue.extend({
   },
 })
 </script>
-        this.techAttack = false
-        this.displayLog = false

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -19,6 +19,7 @@
           :is="component"
           v-if="component"
           ref="c"
+          :fulltech="fulltech"
           :used="action.Used"
           :mech="mech"
           :action="action"
@@ -74,6 +75,7 @@ export default Vue.extend({
       required: true,
     },
     noAction: { type: Boolean },
+    fulltech: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -132,12 +134,21 @@ export default Vue.extend({
       Vue.nextTick().then(() => self.$forceUpdate())
     },
     techAttackComplete(success) {
-      this.logOverride = ['UPLINK ESTABLISHED. ATTEMPTING REMOTE ACCESS.']
-      if (success) {
-        this.logOverride.push('SYSTEM ACCESS OBTAINED.')
-        this.logOverride = this.logOverride.concat(this.action.Confirm)
-      } else this.logOverride.push('ACCESS DENIED. SYSTEM FAILURE.')
-      this.displayLog = true
+      if ( this.fulltech ) {
+        this.techAttack = false
+
+        if ( success ) this.$emit('add-invade', this.action)
+        else this.$emit('add-fail', this.action.Name)
+
+        this.hide()
+      } else {
+        this.logOverride = ['UPLINK ESTABLISHED. ATTEMPTING REMOTE ACCESS.']
+        if (success) {
+          this.logOverride.push('SYSTEM ACCESS OBTAINED.')
+          this.logOverride = this.logOverride.concat(this.action.Confirm)
+        } else this.logOverride.push('ACCESS DENIED. SYSTEM FAILURE.')
+        this.displayLog = true
+      }
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
@@ -159,3 +170,5 @@ export default Vue.extend({
   },
 })
 </script>
+        this.techAttack = false
+        this.displayLog = false

--- a/src/ui/components/panels/loadout/active_loadout/components/_ActionActivationButtons.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_ActionActivationButtons.vue
@@ -13,7 +13,7 @@
       {{ action.Name }}
     </v-btn>
     <v-btn
-      v-if="action.Activation !== 'Free' && action.Activation !== 'Protocol'"
+      v-if="!fulltech && action.Activation !== 'Free' && action.Activation !== 'Protocol'"
       small
       tile
       block
@@ -45,6 +45,7 @@ export default Vue.extend({
   name: 'action-activation-buttons',
   props: {
     used: { type: Boolean },
+    fulltech: { type: Boolean, default: false },
     action: {
       type: Object,
       required: true,
@@ -56,7 +57,7 @@ export default Vue.extend({
   },
   computed: {
     disableCostActivate() {
-      if (this.used) return true
+      if (this.used && !this.fulltech) return true
       if (this.action.Activation === ActivationType.Protocol)
         return !this.mech.Pilot.State.IsProtocolAvailable
       let activationCost = 0

--- a/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
       this.freeAction = false
       this.succeeded = false
       this.failed = false
-      this.attackRoll = 0
+      this.attackRoll = ''
     },
     registerTechRoll(roll) {
       Vue.set(this, 'attackRoll', roll)
@@ -163,14 +163,7 @@ export default Vue.extend({
     complete(success) {
         this.succeeded = success
         this.failed = !success
-
-        let l = ['UPLINK ESTABLISHED. ATTEMPTING REMOTE ACCESS.']
-        if (this.succeeded) {
-          l.push('SYSTEM ACCESS OBTAINED.')
-          l = l.concat(this.action.Confirm)
-        } else l.push('ACCESS DENIED. SYSTEM FAILURE.')
-
-        this.$emit('log', l )
+        this.$emit('techAttackComplete', this.succeeded )
     },
   }
 })

--- a/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
@@ -1,0 +1,177 @@
+<template>
+  <div>
+    <v-slide-x-reverse-transition>
+      <v-row v-if="used" justify="center" align="center">
+        <v-col lg="auto" md="12" class="mt-n5">
+          <v-row dense class="text-center mb-n3" justify="start" align="start">
+            <v-col cols="auto" class="mx-8">
+              <div class="overline">Tech Attack Roll</div>
+              <div class="heading text--text" style="font-size: 24pt">
+                <v-icon x-large class="mr-n1">mdi-dice-d20-outline</v-icon>
+                {{ `${mech.TechAttack >= 0 ? '+' : ''}${mech.TechAttack}` }}
+              </div>
+            </v-col>
+            <v-col cols="auto" class="mx-8">
+              <div class="overline">vs. Target</div>
+              <v-icon x-large v-html="'cci-edef'" />
+              <div class="overline font-weight-bold mt-n2" v-html="'E-Defense'" />
+            </v-col>
+          </v-row>
+        </v-col>
+        <v-col cols="auto" class="ml-auto">
+          <v-row dense justify="end">
+            <v-col
+              cols="auto"
+              class="ml-auto px-12 mr-n10 panel dual-sliced"
+              style="height: 70px"
+            >
+              <div class="overline pl-1">Accuracy</div>
+              <v-text-field
+                v-model="accuracy"
+                type="number"
+                append-outer-icon="mdi-plus-circle-outline"
+                append-icon="cci-accuracy"
+                prepend-icon="mdi-minus-circle-outline"
+                style="width: 115px"
+                class="hide-input-spinners"
+                color="accent"
+                dense
+                hide-details
+                @click:append-outer="accuracy += 1"
+                @click:prepend="accuracy > 0 ? (accuracy -= 1) : ''"
+                @change="accuracy = parseInt($event)"
+              />
+            </v-col>
+            <v-col cols="auto" class="px-12 mr-n10 panel dual-sliced" style="height: 70px">
+              <div class="overline pl-1">Difficulty</div>
+              <v-text-field
+                v-model="difficulty"
+                type="number"
+                append-outer-icon="mdi-plus-circle-outline"
+                append-icon="cci-difficulty"
+                prepend-icon="mdi-minus-circle-outline"
+                style="width: 115px"
+                class="hide-input-spinners"
+                color="accent"
+                dense
+                hide-details
+                @click:append-outer="difficulty += 1"
+                @click:prepend="difficulty > 0 ? (difficulty -= 1) : ''"
+                @change="difficulty = parseInt($event)"
+              />
+            </v-col>
+            <v-col cols="auto" class="px-12 panel dual-sliced" style="height: 70px">
+              <div class="overline mr-n6 pl-3">Tech Attack Roll</div>
+              <v-row no-gutters>
+                <v-col class="mr-n2 ml-n2">
+                  <cc-dice-menu
+                    :preset="`1d20+${mech.TechAttack}`"
+                    :preset-accuracy="accuracy - difficulty"
+                    title="Tech Attack"
+                    @commit="registerTechRoll($event.total)"
+                  />
+                </v-col>
+                <v-col>
+                  <v-text-field
+                    v-model="attackRoll"
+                    type="number"
+                    class="hide-input-spinners ml-n3"
+                    style="max-width: 60px; margin-top: -0.5px"
+                    color="accent"
+                    dense
+                    hide-details
+                  />
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+        </v-col>
+      </v-row>
+    </v-slide-x-reverse-transition>
+
+    <v-slide-x-reverse-transition>
+      <v-row v-if="!!attackRoll" dense class="mt-n2">
+        <v-col md="6" lg="3" xl="2" class="ml-auto">
+          <v-btn
+            tile
+            block
+            class="primary"
+            :color="`primary ${succeeded ? 'lighten-1' : ''}`"
+            :disabled="failed"
+            @click="complete(true)"
+          >
+            SUCCESS
+          </v-btn>
+        </v-col>
+        <v-col md="6" lg="3" xl="2">
+          <v-btn
+            tile
+            block
+            :disabled="succeeded"
+            :color="failed ? 'error' : ''"
+            @click="complete(false)"
+          >
+            FAILURE
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-slide-x-reverse-transition>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { DiceRoller } from '@/class'
+
+export default Vue.extend({
+  name: 'tech-attack',
+  props: {
+    used: { type: Boolean },
+    mech: { type: Object, required: true },
+    action: { type: Object, required: true },
+  },
+  data: () => ({
+    accuracy: 0,
+    difficulty: 0,
+    attackRoll: '',
+    succeeded: false,
+    failed: false
+  }),
+  watch: {
+    used: {
+      immediate: true,
+      deep: true,
+      handler: function() {
+        this.init()
+      },
+    }
+  },
+  methods: {
+    init() {
+      this.activated = false
+      this.accuracy = 0
+      this.difficulty = 0
+      this.freeAction = false
+      this.succeeded = false
+      this.failed = false
+      this.attackRoll = 0
+    },
+    registerTechRoll(roll) {
+      Vue.set(this, 'attackRoll', roll)
+      Vue.nextTick().then(() => this.$forceUpdate())
+    },
+    complete(success) {
+        this.succeeded = success
+        this.failed = !success
+
+        let l = ['UPLINK ESTABLISHED. ATTEMPTING REMOTE ACCESS.']
+        if (this.succeeded) {
+          l.push('SYSTEM ACCESS OBTAINED.')
+          l = l.concat(this.action.Confirm)
+        } else l.push('ACCESS DENIED. SYSTEM FAILURE.')
+
+        this.$emit('log', l )
+    },
+  }
+})
+</script>

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ActionDialogBase.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ActionDialogBase.vue
@@ -4,6 +4,7 @@
       <action-detail-expander :action="action" />
     </v-col>
     <action-activation-buttons
+      :fulltech="fulltech"
       :used="used"
       :action="action"
       :mech="mech"
@@ -22,6 +23,7 @@ export default Vue.extend({
   components: { ActionDetailExpander, ActionActivationButtons },
   props: {
     used: { type: Boolean },
+    fulltech: { type: Boolean, default: false },
     mech: {
       type: Object,
       required: true,

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
@@ -12,6 +12,17 @@
           :disabled="quick.length === 2"
           @click="addQuick(a)"
         />
+        <cc-combat-dialog
+          v-for="(a, j) in quickActions[k]"
+          v-if="a.IsTechAttack"
+          fulltech
+          :key="`action_dialog_${j}`"
+          :ref="`dialog_${a.ID}`"
+          :action="a"
+          :mech="mech"
+          @add-invade="quick.push($event)"
+          @add-fail="quick.push('attack-fail-'+$event)"
+        />
         <item-selector-row
           v-if="i === 0"
           :item="invadeAction"
@@ -53,6 +64,9 @@
           <v-col>
             <v-alert v-if="q === 'invade-fail'" dense outlined color="white" class="text-center">
               <span class="heading h3 text-disabled">INVASION ATTEMPT FAILED</span>
+            </v-alert>
+            <v-alert v-else-if="typeof(q) === 'string' && q.startsWith('attack-fail-')" dense outlined color="white" class="text-center">
+              <span class="heading h3 text-disabled">{{ systemFromFailure(q) }} FAILED</span>
             </v-alert>
             <cc-action v-else panel :action="q" />
           </v-col>
@@ -147,7 +161,8 @@ export default Vue.extend({
       this.quick = this.quick.splice(0, this.quick.length)
     },
     addQuick(action) {
-      if (this.quick.length < 2) this.quick.push(action)
+      if (action.IsTechAttack) this.fulltech(action)
+      else if (this.quick.length < 2) this.quick.push(action)
     },
     removeQuick(idx) {
       this.quick.splice(idx, 1)
@@ -155,6 +170,9 @@ export default Vue.extend({
     openInvade() {
       this.$refs.inv_dialog.init()
       this.$refs.inv_dialog.show()
+    },
+    systemFromFailure(failureString) {
+        return failureString.split('-')[2].toUpperCase()
     },
   },
 })

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_InvadeDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_InvadeDialog.vue
@@ -15,39 +15,13 @@
           <v-col>
             <action-detail-expander :action="action" />
           </v-col>
-          <v-col cols="auto">
-            <v-btn
-              large
-              tile
-              dark
-              block
-              :disabled="actionFree"
-              :color="`${action.Color} ${actionCost ? 'lighten-1' : ''}`"
-              @click="actionCost = !actionCost"
-            >
-              <v-icon left>{{ action.Icon }}</v-icon>
-              {{ action.Name }}
-            </v-btn>
-            <v-btn
-              v-if="!fulltech && action.Activation !== 'Free'"
-              small
-              tile
-              dark
-              block
-              :disabled="actionCost"
-              :color="`action--free ${actionFree ? 'lighten-1' : ''}`"
-              @click="actionFree = !actionFree"
-            >
-              <v-icon left small>cci-free-action</v-icon>
-              Free Action
-              <cc-tooltip
-                inline
-                :content="`Special rules or equipment may allow you to ${action.Name} as a Free Action. Using this button will commit the action without spending a Quick Action this turn`"
-              >
-                <v-icon right small class="fadeSelect">mdi-information-outline</v-icon>
-              </cc-tooltip>
-            </v-btn>
-          </v-col>
+          <action-activation-buttons
+            :fulltech="fulltech"
+            :used="action.Used"
+            :action="action"
+            :mech="mech"
+            @use="use($event)"
+          />
         </v-row>
         <tech-attack
           :used="actionFree || actionCost"
@@ -147,10 +121,11 @@ import Vue from 'vue'
 import ActionDetailExpander from '../../components/_ActionDetailExpander.vue'
 import ActionTitlebar from '../../components/_ActionTitlebar.vue'
 import TechAttack from '../../components/_TechAttack.vue'
+import ActionActivationButtons from '../../components/_ActionActivationButtons.vue'
 
 export default Vue.extend({
   name: 'invade-dialog',
-  components: { ActionDetailExpander, ActionTitlebar, TechAttack },
+  components: { ActionDetailExpander, ActionTitlebar, TechAttack, ActionActivationButtons },
   props: {
     mech: {
       type: Object,
@@ -202,6 +177,10 @@ export default Vue.extend({
     },
   },
   methods: {
+    use(free) {
+      this.actionFree = free
+      this.actionCost = !free
+    },
     runTimeout() {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_InvadeDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_InvadeDialog.vue
@@ -198,8 +198,9 @@ export default Vue.extend({
         this.$emit('add-invade', a)
         this.init()
         this.hide()
+      } else {
+        this.state.CommitAction(this.action, this.actionFree)
       }
-      this.state.CommitAction(this.action, this.actionFree)
       this.$emit('use')
       this.selected = a
       this.runTimeout()
@@ -212,9 +213,10 @@ export default Vue.extend({
           this.$emit('add-fail')
           this.init()
           this.hide()
+        } else {
+          this.state.CommitAction(this.action, this.actionFree)
         }
         this.failed = true
-        this.state.CommitAction(this.action, this.actionFree)
         this.$emit('use')
         this.runTimeout()
       }

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ItemActionDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ItemActionDialog.vue
@@ -4,6 +4,7 @@
     :used="used"
     :action="action"
     :mech="mech"
+    :fulltech="fulltech"
     @use="$emit('use', $event)"
     @undo="$emit('undo')"
   />
@@ -18,6 +19,7 @@ export default Vue.extend({
   components: { ActionDialogBase },
   props: {
     used: { type: Boolean },
+    fulltech: { type: Boolean, default: false },
     mech: {
       type: Object,
       required: true,


### PR DESCRIPTION
Closes #1317

# Description

These changes utilize a new field in the IActionData struct to bring up the roll menu when activating something ( system, talent, ....) that causes a tech attack.

## Issue Number
`#1317`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
