### PR TITLE
Add tooltips for weapon mounts

### DIFF
--- a/src/classes/mech/Mount.ts
+++ b/src/classes/mech/Mount.ts
@@ -78,6 +78,36 @@ abstract class Mount {
     this.slots = slots
   }
 
+  public get AvailableFittings(): string {
+    let result = ''
+
+    switch (this.Type) {
+      case MountType.Aux:
+        result = 'Auxiliary'
+        break
+      case MountType.AuxAux:
+        result = 'Auxiliary & Auxiliary'
+        break
+      case MountType.Flex:
+        result = 'Main | Auxiliary & Auxiliary'
+        break
+      case MountType.Heavy:
+        result = 'Superheavy | Heavy | Main | Aux'
+        break
+      case MountType.Integrated:
+        result = 'Integrated'
+        break
+      case MountType.Main:
+        result = 'Main | Auxiliary'
+        break
+      case MountType.MainAux:
+        result = 'Main & Auxiliary | Auxiliary & Auxiliary'
+        break
+    }
+
+    return result
+  }
+
   public get Weapons(): MechWeapon[] {
     return this.Slots.map(x => x.Weapon).filter(y => y !== null) as MechWeapon[]
   }

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/_MountBlock.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/_MountBlock.vue
@@ -4,10 +4,12 @@
     :cols="$vuetify.breakpoint.mdAndDown ? '12' : ''"
   >
     <fieldset class="ma-0 py-0" style="height: 100%">
-      <legend :style="`color: ${color}`" class="heading h3">
-        {{ mount.Name }}
-        <span v-if="impArm">(IMPROVED ARMAMENT)</span>
-      </legend>
+      <cc-tooltip title="Available Mount Fittings" :content="`${mount.AvailableFittings}`">
+        <legend :style="`color: ${color}`" class="heading h3">
+          {{ mount.Name }}
+          <span v-if="impArm">(IMPROVED ARMAMENT)</span>
+        </legend>
+      </cc-tooltip>
       <cb-mount-menu
         v-if="!intWeapon && !integrated && !readonly"
         :key="mech.AvailableBonuses.length"


### PR DESCRIPTION
# Description

These changes add tooltips for weapon mounts that display the available mount fittings for the mount type.

I went with a "hardcoded" implementation after trying to implement this using `Rules.MountFittings` and `Mount.slots` and `Mount.extra`, but I don't think it's possible to use the existing data to handle cases like Main/Aux or Flexible mounts correctly. IMO the easiest way to represent this is to just hard-code string representations of the mount fittings, but I'm open to reworking this if a more flexible implementation is desired.

![weapon-mount-tooltips-demo](https://user-images.githubusercontent.com/2609819/126858659-0168f91c-c5f0-49b9-9716-e35b40aa227a.png)

## Issue Number
#1541 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
