### PR TITLE
fix(Pilot Sheet): fix missing pilot weapon equip button in list mode

### DIFF
--- a/src/ui/components/panels/loadout/pilot_loadout/_PLWeaponCard.vue
+++ b/src/ui/components/panels/loadout/pilot_loadout/_PLWeaponCard.vue
@@ -110,6 +110,7 @@ export default Vue.extend({
       { text: 'Range', align: 'left', value: 'Range[0].Max' },
       { text: 'Damage', align: 'left', value: 'Damage[0].Max' },
       { text: 'Detail', align: 'center', value: 'Detail' },
+      { text: '', align: 'center', value: 'Equip' },
     ],
   }),
   methods: {


### PR DESCRIPTION
# Description

Fixes missing equip button for Pilot Weapon list view using the same fix as the pilot gear list for issue #1495.

## Issue Number
`#1529`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
