### PR TITLE
fix(NPC Roster): fix editing NPC Feature Names & Descriptions

### DIFF
--- a/src/ui/components/cards/npc/cards/_ItemMenu.vue
+++ b/src/ui/components/cards/npc/cards/_ItemMenu.vue
@@ -52,14 +52,14 @@
     </v-menu>
     <cc-string-edit-dialog
       ref="cName"
-      :placeholder="item.Feature.Name"
+      :placeholder="item.Name"
       label="Custom Item Name"
       @save="save('Name', $event)"
       @reset="save('Name', '')"
     />
     <cc-string-edit-dialog
       ref="cDesc"
-      :placeholder="item.Feature.Description"
+      :placeholder="item.Description"
       label="Custom Item Description"
       @save="save('Description', $event)"
       @reset="save('Description', '')"
@@ -84,7 +84,7 @@ export default Vue.extend({
       this.$emit('recalc')
     },
     save(prop, newName) {
-      this.$set(this.item.Feature, prop, newName)
+      this.$set(this.item, prop, newName)
     },
   },
 })


### PR DESCRIPTION
# Description

This fix points the getter/setter of an NPC Item to the correct location to properly edit the item's Name and Description & save them.  Found that the `cc-string-edit-dialog` was pointed at an NpcFeature object, which a) lacks a Name setter and b) lacks a Description field.  This change should point the dialog box to the correct object.

## Issue Number
`#1505`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
