### PR TITLE
fix(Pilot Sheet): top Offset-Y Talent card popup in pilot Tac Profile

### DIFF
--- a/src/ui/components/Talent/components/_TalentSmall.vue
+++ b/src/ui/components/Talent/components/_TalentSmall.vue
@@ -3,9 +3,11 @@
     <v-menu
       open-on-hover
       :close-on-content-click="false"
-      bottom
+      top
+      nudge-top="10px"
       offset-y
       open-delay="100"
+      close-delay="50"
       max-width="80vw"
       min-width="50vw"
     >

--- a/src/ui/components/Talent/components/_TalentTerse.vue
+++ b/src/ui/components/Talent/components/_TalentTerse.vue
@@ -34,7 +34,7 @@
             v-show="showFull || (!showFull && rank && parseInt(rank) >= n)"
             :key="`rank-btn-${n}`"
           >
-            <v-menu open-on-hover bottom offset-y open-delay="100">
+            <v-menu open-on-hover top offset-y open-delay="100">
               <template v-slot:activator="{ on }">
                 <v-btn :block="$vuetify.breakpoint.smAndDown" tile :color="rankColor(n)" v-on="on">
                   <v-icon v-if="!rank || (rank && parseInt(rank) >= n)" left>


### PR DESCRIPTION
# Description

Reorients the _TalentSmall.vue and _TalentTerse.vue components so the hoverable talent tooltip is offset above the talent icon.
Previously oriented to bottom, leading to overlap with the Pilot navbar.

## Issue Number
Closes #1560 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)