### PR TITLE
fix(Pilot Sheet): goTo Background description on click fixed

### DIFF
--- a/src/ui/components/selectors/CCBackgroundSelector.vue
+++ b/src/ui/components/selectors/CCBackgroundSelector.vue
@@ -9,7 +9,7 @@
           slot="sidebar"
           link
           @click="
-            $vuetify.goTo(`#e_${e.id}`, {
+            $vuetify.goTo(`#e_${e.ID}`, {
               duration: 250,
               easing: 'easeInOutQuad',
               offset: 25,
@@ -20,7 +20,7 @@
           <v-list-item-title class="heading h3 ml-2">{{ e.Name }}</v-list-item-title>
         </v-list-item>
         <br />
-        <v-row v-for="(e, i) in backgrounds" :id="`e_${e.id}`" :key="`${e.id}_${i}`" dense>
+        <v-row v-for="(e, i) in backgrounds" :id="`e_${e.ID}`" :key="`${e.ID}_${i}`" dense>
           <v-col>
             <cc-titled-panel
               icon="cci-orbit"


### PR DESCRIPTION
# Description

A typo in the BackgroundSelector led to undefined Background IDs. This prevented the Vuetify GoTo function from scrolling on click. The amended HTML now properly pulls the Background IDs.

## Issue Number
Closes #1561 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)