### PR TITLE
fix(Pilot Sheet): show Overpower Caliber and other bonuses in the com…

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -143,6 +143,11 @@ class Statblock {
               if (idx + 1 < mount.Weapons.length) output += ' / '
             })
           }
+
+          if (mount.Bonuses.length > 0) {
+            output += ' // ' + mount.Bonuses.map(bonus => bonus.Name).join(', ')
+          }
+
           output += '\n'
         }
 


### PR DESCRIPTION
…pact statblock

Closes #1483

# Description

Update generation of the standard pilot statblock to display weapon mount bonuses just as the compact statblock.

## Issue Number
`#1483`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
