### PR TITLE
build: allow public dev server to use SSL

### DIFF
--- a/webpack_config/webpack.dev-public.config.js
+++ b/webpack_config/webpack.dev-public.config.js
@@ -2,5 +2,6 @@ module.exports = {
    devServer: {
       host: '0.0.0.0',
       disableHostCheck: true,
+      https: true,
    },
 }


### PR DESCRIPTION
# Description

Previously, the dev-public target, which provides the dev server to addresses other than `localhost` was not providing an SSL connection. This was preventing LCP files from being uploaded to the dev-public site.

( This is working on the `dev` target currently because browsers currently treat 'localhost' addresses as trusted, just like SSL sites )


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
