### PR TITLE
fix(Pilot Sheet): skill Focus reserve grants bonus skill triggers

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -551,7 +551,8 @@ class Pilot implements ICloudSyncable {
   }
 
   public get MaxSkillPoints(): number {
-    return Bonus.IntPilot(Rules.MinimumPilotSkills + this._level, 'skill_point', this)
+    const bonus = this.Reserves.filter(x => x.ID === 'reserve_skill').length
+    return Bonus.IntPilot(Rules.MinimumPilotSkills + this._level + bonus, 'skill_point', this)
   }
 
   public get IsMissingSkills(): boolean {


### PR DESCRIPTION
# Description

Followed pattern of bonus reserve License to increase the maximum number of skill trigger assignments available to a pilot.  Bonus skill point will be awarded for every instance of the 'Skill Focus' Reserve.

## Issue Number
Closes #1549

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)