### PR TITLE
fix(Pilot Sheet): fix Talent scroll on click for new pilots

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -543,7 +543,14 @@ class Pilot implements ICloudSyncable {
 
   public set Skills(skills: PilotSkill[]) {
     this._skills = skills
+    this.skillSort()
     this.save()
+  }
+
+  private skillSort(): void {
+    this._skills = this._skills.sort(function (a, b) {
+      return a.Title > b.Title ? 1 : -1
+    })
   }
 
   public get CurrentSkillPoints(): number {
@@ -584,6 +591,7 @@ class Pilot implements ICloudSyncable {
     } else {
       this._skills[index].Increment()
     }
+    this.skillSort()
     this.save()
   }
 
@@ -606,6 +614,7 @@ class Pilot implements ICloudSyncable {
         this._skills.splice(index, 1)
       }
     }
+    this.skillSort()
     this.save()
   }
 
@@ -624,6 +633,7 @@ class Pilot implements ICloudSyncable {
 
   public set Talents(talents: PilotTalent[]) {
     this._talents = talents
+    this.talentSort()
     this.save()
   }
 

--- a/src/ui/components/selectors/CCSkillSelector.vue
+++ b/src/ui/components/selectors/CCSkillSelector.vue
@@ -5,7 +5,11 @@
     :success="!pilot.IsMissingSkills && enoughSelections"
   >
     <template v-slot:left-column>
-      <div v-for="(pSkill, i) in pilot.Skills" :key="`summary_${pSkill.Skill.ID}_${i}`">
+      <div 
+        v-for="(pSkill, i) in pilot.Skills" 
+        :key="`summary_${pSkill.Skill.ID}_${i}`"
+        @click="scroll(pSkill.Skill.ID)"
+      >
         <missing-item v-if="pSkill.Skill.err" @remove="pilot.RemoveSkill(pSkill)" />
         <v-chip v-else label color="panel" style="width: 100%" class="my-1 pa-1">
           <v-chip dark color="accent" small>
@@ -72,6 +76,7 @@
         </div>
         <skill-select-item
           v-for="(s, i) in skills[h.attr]"
+          :id="`skill_${s.ID}`"
           :key="`skill_${h.attr}_${i}`"
           :skill="s"
           :can-add="pilot.CanAddSkill(s)"
@@ -135,6 +140,23 @@ export default Vue.extend({
     const compendium = getModule(CompendiumStore, this.$store)
     this.staticSkills = this.$_.groupBy(compendium.Skills, 'Family')
     this.headers = rules.skill_headers
+  },
+  methods: {
+    scroll(id) {
+      if (this.newPilot || this.levelUp)
+        this.$vuetify.goTo(`#skill_${id}`, {
+          duration: 150,
+          easing: 'easeInOutQuad',
+          offset: 25,
+        })
+      else
+        this.$vuetify.goTo(`#skill_${id}`, {
+          duration: 150,
+          easing: 'easeInOutQuad',
+          offset: 25,
+          container: '.v-dialog--active',
+        })
+    }
   },
 })
 </script>

--- a/src/ui/components/selectors/CCTalentSelector.vue
+++ b/src/ui/components/selectors/CCTalentSelector.vue
@@ -164,7 +164,7 @@ export default Vue.extend({
       return this.pilot.IsMissingTalents
     },
     scroll(id) {
-      if (this.levelUp)
+      if (this.newPilot || this.levelUp)
         this.$vuetify.goTo(`#e_${id}`, {
           duration: 150,
           easing: 'easeInOutQuad',


### PR DESCRIPTION
# Description

This PR fixes the Talent scrolling on click during new pilot creation, and also applies the same scrolling to skill trigger selection.  Additional sorting of skills was also included.

To be honest, this PR started with an attempt at sorting a Pilot's skills upon addition/removal/setting, and evolved into applying a `$vuetify.goTo` to the skill trigger selections, which evolved into finding and fixing issue #1566.

## Issue Number
Closes #1566, addresses one part of #917 within the scope of Pilot Management

## Type of change

- [x] Bug fix
- [x] New feature
