### PR TITLE
fix(Pilot Sheet/Mech Sheet): initializes Pilot, Mech, & Deployable HPs to final Max

### DIFF
--- a/src/classes/Deployable.ts
+++ b/src/classes/Deployable.ts
@@ -66,7 +66,7 @@ class Deployable extends CompendiumItem {
   public readonly Recall: ActivationType | null
   public readonly Redeploy: ActivationType | null
   public readonly Instances: number
-  private _current_hp: number
+  private _missing_hp: number
   private _current_heat: number
   private _current_repairs: number
   private _overshield: number
@@ -86,7 +86,7 @@ class Deployable extends CompendiumItem {
     this.Redeploy = data.redeploy || null
     this.Size = this.collect(data.size, owner, 'size')
     this.MaxHP = this.collect(data.hp, owner, 'hp')
-    this._current_hp = this.MaxHP
+    this._missing_hp = 0
     this.Armor = this.collect(data.armor, owner, 'armor')
     this.Evasion = this.collect(
       data.evasion,
@@ -136,15 +136,15 @@ class Deployable extends CompendiumItem {
   }
 
   public get CurrentHP(): number {
-    if (this._current_hp > this.MaxHP) this.CurrentHP = this.MaxHP
-    return this._current_hp
+    if (this._missing_hp < 0) this.CurrentHP = this.MaxHP
+    return this.MaxHP - this._missing_hp
   }
 
   public set CurrentHP(hp: number) {
-    if (hp > this.MaxHP) this._current_hp = this.MaxHP
+    if (hp > this.MaxHP) this._missing_hp = 0
     else if (hp <= 0) {
       this.Destroyed = true
-    } else this._current_hp = hp
+    } else this._missing_hp = this.MaxHP - hp
     this.save()
   }
 

--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -66,7 +66,7 @@ class Mech implements IActor {
   private _loadouts: MechLoadout[]
   private _active_loadout: MechLoadout
   private _current_structure: number
-  private _current_hp: number
+  private _missing_hp: number
   private _overshield: number
   private _current_stress: number
   private _current_heat: number
@@ -117,7 +117,7 @@ class Mech implements IActor {
     this._loadouts = [new MechLoadout(this)]
     this._active_loadout = this._loadouts[0]
     this._current_structure = frame.Structure
-    this._current_hp = frame.HP
+    this._missing_hp = 0
     this._current_stress = frame.HeatStress
     this._current_repairs = frame.RepCap
     this._currentMove = frame.Speed
@@ -494,16 +494,16 @@ class Mech implements IActor {
   }
 
   public get CurrentHP(): number {
-    if (this._current_hp > this.MaxHP) this.CurrentHP = this.MaxHP
-    return this._current_hp
+    if (this._missing_hp < 0) this.CurrentHP = this.MaxHP
+    return this.MaxHP - this._missing_hp
   }
 
   public set CurrentHP(hp: number) {
-    if (hp > this.MaxHP) this._current_hp = this.MaxHP
+    if (hp > this.MaxHP) this._missing_hp = 0
     else if (hp <= 0) {
       this.CurrentStructure -= 1
       this.CurrentHP = this.MaxHP + hp
-    } else this._current_hp = hp
+    } else this._missing_hp = this.MaxHP - hp
     this.save()
   }
 
@@ -1091,7 +1091,7 @@ class Mech implements IActor {
       current_structure: m._current_structure,
       current_move: m._currentMove,
       boost: m._boost,
-      current_hp: m._current_hp,
+      current_hp: m.CurrentHP,
       overshield: m._overshield,
       current_stress: m._current_stress,
       current_heat: m._current_heat,
@@ -1141,7 +1141,7 @@ class Mech implements IActor {
     m._current_structure = data.current_structure
     m._currentMove = data.current_move || 0
     m._boost = data.boost || 0
-    m._current_hp = data.current_hp
+    m.CurrentHP = data.current_hp
     m._overshield = data.overshield || 0
     m._current_stress = data.current_stress
     m._current_heat = data.current_heat

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -116,7 +116,7 @@ class Pilot implements ICloudSyncable {
   private _id: string
   private _level: number
   private _portrait: string
-  private _current_hp: number
+  private _missing_hp: number
   private _background: string
 
   private _special_equipment: CompendiumItem[]
@@ -152,7 +152,7 @@ class Pilot implements ICloudSyncable {
     this._portrait = ''
     this._cloud_portrait = ''
     this._quirks = []
-    this._current_hp = Rules.BasePilotHP
+    this._missing_hp = 0
     this._loadout = new PilotLoadout(0)
     this._background = ''
     this._special_equipment = []
@@ -500,13 +500,13 @@ class Pilot implements ICloudSyncable {
   }
 
   public get CurrentHP(): number {
-    return this._current_hp
+    return this.MaxHP - this._missing_hp
   }
 
   public set CurrentHP(hp: number) {
-    if (hp > this.MaxHP) this._current_hp = this.MaxHP
-    else if (hp < 0) this._current_hp = 0
-    else this._current_hp = hp
+    if (hp > this.MaxHP) this._missing_hp = 0
+    else if (hp < 0) this._missing_hp = this.MaxHP
+    else this._missing_hp = this.MaxHP - hp
     this.save()
   }
 
@@ -1242,7 +1242,7 @@ class Pilot implements ICloudSyncable {
     this._portrait = data.portrait
     this._cloud_portrait = data.cloud_portrait
     this._quirks = data.quirks ? data.quirks : (data as any).quirk ? [(data as any).quirk] : []
-    this._current_hp = data.current_hp
+    this.CurrentHP = data.current_hp
     this._background = data.background
     this._mechSkills = MechSkills.Deserialize(this, data.mechSkills)
     this._licenses = data.licenses.map((x: IRankedData) => PilotLicense.Deserialize(x))


### PR DESCRIPTION
# Description

Changes current HP tracking to use a "missing HP" model so it will easily calculate adjustments to Max HP both immediately after pilot/frame/deployable creation, as well as scale Current HP to match increases in Max HP (e.g. if hp is 5/10 and Max HP increases by +2, new HP value is 7/12).

## Issue Number
Closes #1569

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)