### PR TITLE
feat(Homebrew Content): display original LCP for player mech items

### DIFF
--- a/src/ui/components/cards/_FrameCard.vue
+++ b/src/ui/components/cards/_FrameCard.vue
@@ -19,6 +19,7 @@
             </cc-tooltip>
           </v-col>
         </v-row>
+        <div v-if="item.LcpName" class="heading h4 text--text">{{ item.LcpName }}</div>
         <div v-if="item.Description">
           <div class="overline ml-n2 my-1 text--text">COMPENDIUM ENTRY</div>
           <p class="flavor-text" v-html-safe="item.Description" />

--- a/src/ui/components/cards/_MechSystemCard.vue
+++ b/src/ui/components/cards/_MechSystemCard.vue
@@ -12,6 +12,7 @@
     <v-col v-if="item.LicenseString" cols="auto" class="ml-auto text-right">
       <div class="heading h2">{{ item.Type }}</div>
       <span class="flavor-text subtle--text">// {{ item.LicenseString }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
   </equipment-card-base>
 </template>

--- a/src/ui/components/cards/_MechWeaponCard.vue
+++ b/src/ui/components/cards/_MechWeaponCard.vue
@@ -46,6 +46,7 @@
     <v-col cols="auto" class="ml-auto text-right">
       <div class="heading h2">{{ item.Size }} {{ item.WeaponType }}</div>
       <span v-if="item.Source" class="flavor-text subtle--text">// {{ item.LicenseString }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
     <v-col v-if="item.Profiles && item.Profiles.length > 1" cols="12">
       <div v-if="item.ProfileEffect" class="panel clipped pa-2">

--- a/src/ui/components/cards/_NpcSystemCard.vue
+++ b/src/ui/components/cards/_NpcSystemCard.vue
@@ -3,6 +3,7 @@
     <v-col cols="auto" class="ml-auto text-right">
       <div class="heading h2">{{ item.FeatureType }}</div>
       <span class="flavor-text subtle--text">// {{ item.Origin }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
   </equipment-card-base>
 </template>

--- a/src/ui/components/cards/_NpcTechCard.vue
+++ b/src/ui/components/cards/_NpcTechCard.vue
@@ -47,6 +47,7 @@
     <v-col cols="auto" class="ml-auto text-right">
       <div class="heading h2">{{ item.TechType }} Tech</div>
       <span class="flavor-text subtle--text">// {{ item.Origin }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
   </equipment-card-base>
 </template>

--- a/src/ui/components/cards/_NpcTraitCard.vue
+++ b/src/ui/components/cards/_NpcTraitCard.vue
@@ -2,6 +2,7 @@
   <equipment-card-base :item="item">
     <v-col cols="auto" class="ml-auto text-right">
       <span class="flavor-text subtle--text">// {{ item.Origin }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
   </equipment-card-base>
 </template>

--- a/src/ui/components/cards/_NpcWeaponCard.vue
+++ b/src/ui/components/cards/_NpcWeaponCard.vue
@@ -68,6 +68,7 @@
     <v-col cols="auto" class="ml-auto text-right">
       <div class="heading h2">{{ item.WeaponType }}</div>
       <span class="flavor-text subtle--text">// {{ item.Origin }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
     <p
       v-if="item.OnHit"

--- a/src/ui/components/cards/_WeaponModCard.vue
+++ b/src/ui/components/cards/_WeaponModCard.vue
@@ -29,6 +29,7 @@
     </v-col>
     <v-col cols="auto" class="ml-auto text-right">
       <span class="flavor-text subtle--text">// {{ item.LicenseString }}</span>
+      <div v-if="item.LcpName" class="flavor-text subtle--text">{{ item.LcpName }}</div>
       <div v-if="item.Restricted">
         <span class="stat-text error--text">
           RESTRICTED: {{ item.Restricted.join('/').toUpperCase() }} MOUNTS


### PR DESCRIPTION
Closes #1502
Do we need this info for talents and NPC features?

# Description
This displays originating LCP information for various pieces of content

## Issue Number
`#1502`

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
