### PR TITLE
fix(options): adds option to sync on Theme change (default true)

### DIFF
--- a/src/features/main_menu/_components/login/SignedIn.vue
+++ b/src/features/main_menu/_components/login/SignedIn.vue
@@ -102,6 +102,14 @@
               <!-- <v-col lg="4" cols="6"><v-switch v-model="userProfile.SyncFrequency.onAppLoad" hide-details color="accent" label="On App Exit" /></v-col> -->
               <v-col lg="4" cols="6">
                 <v-switch
+                  v-model="userProfile.SyncFrequency.onThemeChange"
+                  hide-details
+                  color="accent"
+                  label="On Theme Change"
+                />
+              </v-col>
+              <v-col lg="4" cols="6">
+                <v-switch
                   v-model="userProfile.SyncFrequency.onPilotLevel"
                   hide-details
                   color="accent"

--- a/src/features/main_menu/_components/login/SignedIn.vue
+++ b/src/features/main_menu/_components/login/SignedIn.vue
@@ -93,7 +93,7 @@
               </v-col>
               <v-col lg="4" cols="6">
                 <v-switch
-                  v-model="userProfile.SyncFrequency.onSignIn"
+                  v-model="userProfile.SyncFrequency.onLogIn"
                   hide-details
                   color="accent"
                   label="On User Sign In"

--- a/src/features/nav/pages/Options/Settings.vue
+++ b/src/features/nav/pages/Options/Settings.vue
@@ -224,6 +224,7 @@ export default Vue.extend({
         this.$vuetify.theme.themes.light = allThemes[this.theme].colors
         this.$vuetify.theme.dark = false
       }
+      this.$store.dispatch('cloudSync', { callback: null, condition: 'themeChange' })
     },
     showMessage() {
       const store = getModule(UserStore, this.$store)

--- a/src/features/pilot_management/store/index.ts
+++ b/src/features/pilot_management/store/index.ts
@@ -117,7 +117,7 @@ export class PilotManagementStore extends VuexModule {
   public addPilot(payload: { pilot: Pilot; update: boolean }): void {
     this.context.commit(ADD_PILOT, payload.pilot)
     if (payload.update)
-      this.context.dispatch('cloudSync', { callback: null, condition: 'pilotAdd' })
+      this.context.dispatch('cloudSync', { callback: null, condition: 'pilotCreate' })
   }
 
   @Action

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -17,6 +17,7 @@ interface ISyncFrequency {
   onAppLoad: boolean
   onLogIn: boolean
   onAppExit: boolean
+  onThemeChange: boolean
   onPilotLevel: boolean
   onPilotCreate: boolean
   onPilotDelete: boolean
@@ -70,6 +71,7 @@ const defaultSyncFrequency = (): ISyncFrequency => ({
   onAppLoad: true,
   onLogIn: true,
   onAppExit: true,
+  onThemeChange: true,
   onPilotLevel: true,
   onPilotCreate: true,
   onPilotDelete: true,

--- a/src/user/store/index.ts
+++ b/src/user/store/index.ts
@@ -159,9 +159,9 @@ export class UserStore extends VuexModule {
       sync = false
     if (payload.condition === 'mechDelete' && !this.UserProfile.SyncFrequency.onMechDelete)
       sync = false
-    if (payload.condition === 'mechDelete' && !this.UserProfile.SyncFrequency.onNpcCreate)
+    if (payload.condition === 'npcCreate' && !this.UserProfile.SyncFrequency.onNpcCreate)
       sync = false
-    if (payload.condition === 'mechDelete' && !this.UserProfile.SyncFrequency.onNpcDelete)
+    if (payload.condition === 'npcDelete' && !this.UserProfile.SyncFrequency.onNpcDelete)
       sync = false
     if (
       payload.condition === 'encounterCreate' &&

--- a/src/user/store/index.ts
+++ b/src/user/store/index.ts
@@ -147,6 +147,8 @@ export class UserStore extends VuexModule {
     }
 
     let sync = true
+    if (payload.condition === 'themeChange' && !this.UserProfile.SyncFrequency.onThemeChange)
+      sync = false
     if (payload.condition === 'pilotLevel' && !this.UserProfile.SyncFrequency.onPilotLevel)
       sync = false
     if (payload.condition === 'pilotCreate' && !this.UserProfile.SyncFrequency.onPilotCreate)


### PR DESCRIPTION
# Description

Adds a user toggle to sync data when the user changes their COMP/CON theme.  When enabled, theme should sync immediately with the cloud.

UPDATE: While setting up the `onThemeChange` toggle condition, I noticed several sync conditions were routed on the wrong condition name or SyncFrequency property.  This update fixes most of them; still todo are:
1. `onPilotLevel` lacks a cloudsync call
2. `onAppExit` lacks any sort of implementation.  

These will need additional work to fix, but would be better off in a new PR.  Current PR state is ready for review.

## Issue Number
Closes #1450

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
