### PR TITLE
fix(Pilot Sheet): new Prototype Weapon dynamically updates uses + damage

### DIFF
--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -123,6 +123,8 @@ class MechWeapon extends MechEquipment {
     this._selected_profile = 0
     this._mod = null
     this.ItemType = ItemType.MechWeapon
+    this.max_use_override = 0
+    this._custom_damage_type = null
   }
 
   public get TotalSP(): number {
@@ -231,9 +233,17 @@ class MechWeapon extends MechEquipment {
   }
 
   public set MaxUseOverride(val: number) {
-    this.max_use_override = val
-    this._uses = val
+    const safeVal = MechWeapon.SanitizeUsesInput(val)
+    this.max_use_override = safeVal
+    this._uses = safeVal
     this.save()
+  }
+
+  public static SanitizeUsesInput(val: number): number {
+    // Prevent Uses icon overflow - set reasonable limit on maximum uses
+    const absoluteMax = 25
+    const absoluteMin = 0
+    return Math.max(Math.min(val, absoluteMax), absoluteMin)
   }
 
   public get DamageType(): DamageType[] {
@@ -271,7 +281,7 @@ class MechWeapon extends MechEquipment {
   public static Serialize(item: MechWeapon): IMechWeaponSaveData {
     return {
       id: item.ID,
-      uses: item.Uses || 0,
+      uses: MechWeapon.SanitizeUsesInput(item.Uses) || 0,
       destroyed: item.Destroyed,
       cascading: item.IsCascading,
       loaded: item.Loaded,
@@ -280,14 +290,14 @@ class MechWeapon extends MechEquipment {
       flavorName: item._flavor_name,
       flavorDescription: item._flavor_description,
       customDamageType: item._custom_damage_type || null,
-      maxUseOverride: item.max_use_override || 0,
+      maxUseOverride: MechWeapon.SanitizeUsesInput(item.max_use_override) || 0,
       selectedProfile: item._selected_profile || 0,
     }
   }
 
   public static Deserialize(data: IMechWeaponSaveData): MechWeapon {
     const item = store.getters.instantiate('MechWeapons', data.id) as MechWeapon
-    item._uses = data.uses || 0
+    item._uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._loaded = data.loaded || true
@@ -296,7 +306,7 @@ class MechWeapon extends MechEquipment {
     item._flavor_name = data.flavorName
     item._flavor_description = data.flavorDescription
     item._custom_damage_type = data.customDamageType || null
-    item.max_use_override = data.maxUseOverride || 0
+    item.max_use_override = MechWeapon.SanitizeUsesInput(data.maxUseOverride) || 0
     item._selected_profile = data.selectedProfile || 0
     return item
   }


### PR DESCRIPTION
# Description

New MechWeapon objects did not set a default value for `max_use_override` or `_custom_damage_type` upon creation; this prevented the weapon card from grabbing those fields to update the UI.  The mentioned fields *are* set to a default when deserialized on reload, which is why refreshing the page made uses/damage dynamic again.

Included a "max use" cap to prevent negative max uses or enough max uses to overflow the page; current max uses is 25 but can be modified if appropriate in the future.  (I found out about the overflow by accidentally entering a 6-digit number for max uses.  Decided it may be best to cap it after that.)

## Issue Number
#1533

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)