### PR TITLE
fix(Mech Sheet): frames with webhosted images use the webhost address

### DIFF
--- a/src/ui/components/selectors/CCImageSelectorWeb.vue
+++ b/src/ui/components/selectors/CCImageSelectorWeb.vue
@@ -121,7 +121,10 @@ export default Vue.extend({
       reader.readAsBinaryString(file)
     },
     async saveImage() {
-      if (this.selectedImage) {
+      if (this.selectedImage && this.validURL(this.selectedImage)) {
+        this.item.SetCloudImage(this.selectedImage)
+        this.close()
+      } else if (this.selectedImage) {
         this.item.SetCloudImage(null)
         this.item.SetLocalImage(path.basename(this.selectedImage))
         this.close()
@@ -140,6 +143,16 @@ export default Vue.extend({
         this.loading = false
         this.imageData = null
       }
+    },
+    // Pulled from Stackoverflow: https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
+    validURL(str: string): boolean {
+      const pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+        '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+      return !!pattern.test(str);
     },
     open() {
       this.$refs.dialog.show()


### PR DESCRIPTION
# Description

With this fix, in the image selector: If the selected image's source is a URL, it uses the image URL for displaying the image.

Prior to this fix, the selected image would only have its basename stored as a "local" filename, which appended `static/img/(mech/pilot)` to the file's basename.  This led to broken references for frames that lacked a corresponding local static image file, e.g. Wallflower frames and Long Rim frames with alternative naming schemes (e.g. `lich_off.png` remote vs. `mf_lich.png` local).

I also created a [sibling PR](https://github.com/massif-press/long-rim-data/pull/10) that addresses consistency in frame `image_url` naming conventions in the Long Rim data pack.

## Issue Number
Closes #1439

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)