### PR TITLE
feat(Compendium): sort Mech frames/weapons/systems in book order

### DIFF
--- a/src/features/compendium/Views/Frames.vue
+++ b/src/features/compendium/Views/Frames.vue
@@ -36,11 +36,15 @@ export default class Frames extends Vue {
 
   private compendium = getModule(CompendiumStore, this.$store)
   private user = getModule(UserStore, this.$store).UserProfile
+  private sourceIds = this.compendium.Manufacturers.map(x => x.ID)
+
   public get frames(): Frame[] {
     let arr = this.compendium.Frames.filter(x => !x.IsHidden)
     if (!this.user.GetView('showExotics')) arr = arr.filter(x => !x.IsExotic)
-
-    return _.sortBy(arr, ['Source', 'Name'])
+    return _.sortBy(arr, [
+      item => this.sourceIds.indexOf(item.Source), 
+      'Name'
+    ])
   }
 
   public frameTypes = Object.keys(MechType).sort() as MechType[]

--- a/src/features/compendium/Views/Systems.vue
+++ b/src/features/compendium/Views/Systems.vue
@@ -27,6 +27,8 @@ export default class Systems extends Vue {
 
   private compendium = getModule(CompendiumStore, this.$store)
   private user = getModule(UserStore, this.$store).UserProfile
+  private sourceIds = this.compendium.Manufacturers.map(x => x.ID)
+
   public get systems(): MechEquipment[] {
     let sys = this.compendium.MechSystems.filter(x => !x.IsHidden && !(!x.Source && !x.IsExotic))
     let mod = this.compendium.WeaponMods.filter(x => !x.IsHidden && !(!x.Source && !x.IsExotic))
@@ -35,7 +37,10 @@ export default class Systems extends Vue {
       mod = mod.filter(x => !x.IsExotic)
     }
 
-    return _.orderBy((sys as MechEquipment[]).concat(mod as MechEquipment[]), ['Source', 'Name'])
+    return _.orderBy((sys as MechEquipment[]).concat(mod as MechEquipment[]), [
+      item => this.sourceIds.indexOf(item.Source), 
+      'Name'
+    ])
   }
 }
 </script>

--- a/src/features/compendium/Views/Weapons.vue
+++ b/src/features/compendium/Views/Weapons.vue
@@ -29,13 +29,18 @@ export default class Weapons extends Vue {
 
   private compendium = getModule(CompendiumStore, this.$store)
   private user = getModule(UserStore, this.$store).UserProfile
+  private sourceIds = this.compendium.Manufacturers.map(x => x.ID)
+
   public get weapons(): MechWeapon[] {
     let arr = this.compendium.MechWeapons.filter(x => !x.IsHidden && !(!x.Source && !x.IsExotic))
     if (!this.user.GetView('showExotics')) {
       arr = arr.filter(x => !x.IsExotic)
     }
 
-    return _.orderBy(arr, ['Source', 'Name'])
+    return _.orderBy(arr, [
+      item => this.sourceIds.indexOf(item.Source), 
+      'Name'
+    ])
   }
 }
 </script>


### PR DESCRIPTION
# Description

This PR changes the default sort of compendium entries for Mech-related items (frames, systems, and weapons) to book order of the manufacturers, for consistency with the Manufacturers, Licenses, and Core Bonuses pages.

## Issue Number
Closes #1496

## Type of change

- [x] New feature (non-breaking change which adds functionality)