### PR TITLE
fix(Pilot Sheet): disable custom skill creation when 0 skills remaining

### DIFF
--- a/src/ui/components/selectors/CCSkillSelector.vue
+++ b/src/ui/components/selectors/CCSkillSelector.vue
@@ -80,7 +80,10 @@
           @remove="pilot.RemoveSkill(s)"
         />
       </div>
-      <add-custom-skill :pilot="pilot" @add-custom="pilot.AddCustomSkill($event)" />
+      <add-custom-skill 
+        :pilot="pilot"
+        :can-add="pilot.IsMissingSkills"
+        @add-custom="pilot.AddCustomSkill($event)" />
     </template>
   </selector>
 </template>

--- a/src/ui/components/selectors/components/_AddCustomSkill.vue
+++ b/src/ui/components/selectors/components/_AddCustomSkill.vue
@@ -38,7 +38,7 @@
             :small="$vuetify.breakpoint.smAndDown"
             icon
             color="secondary"
-            :disabled="newSkill === ''"
+            :disabled="!canAdd || newSkill === ''"
             @click="addSkill"
           >
             <v-icon x-large>cci-accuracy</v-icon>
@@ -51,8 +51,16 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { Pilot } from '@/class'
 export default Vue.extend({
   name: 'add-custom-skill',
+  props: {
+    pilot: Pilot,
+    canAdd: {
+      type: Boolean,
+      required: true,
+    },
+  },
   data: () => ({
     newSkill: '',
     newDesc: '',


### PR DESCRIPTION
# Description

This change disables the `add-custom-skill` button when the pilot cannot select more skills.  Using `Pilot.IsMissingSkills` instead of `Pilot.CanAddSkill` since there's no pre-existing skill to search or compare against when adding a new custom skill.

## Issue Number
Closes #1580

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)