### PR TITLE
feat(Active Mode): auto-roll some dice when actions are selected

### DIFF
--- a/src/ui/components/CCDiceMenu.vue
+++ b/src/ui/components/CCDiceMenu.vue
@@ -285,6 +285,7 @@ export default Vue.extend({
     presetAccuracy: { type: Number, required: false, default: 0 },
     overkill: { type: Boolean },
     critical: { type: Boolean },
+    autoroll: { type: Boolean },
   },
   data: () => ({
     menu: false,
@@ -298,10 +299,17 @@ export default Vue.extend({
   }),
   mounted() {
     this.reset()
+    if (this.autoroll) this.$nextTick(this.autoRoll)
   },
   watch: {
     menu() {
-      this.reset()
+      if (!this.menu || !this.autoroll) this.reset()
+    },
+    presetAccuracy() {
+      if (this.autoroll) {
+        this.accuracy=this.presetAccuracy
+        this.autoRoll()
+      }
     },
   },
   computed: {
@@ -345,6 +353,10 @@ export default Vue.extend({
       this.result = null
       if (this.accuracy > 0) this.accuracy--
       else this.accuracy++
+    },
+    autoRoll() {
+      this.roll()
+      this.commit()
     },
     roll() {
       this.result = this.dice.map(x => {

--- a/src/ui/components/panels/loadout/active_loadout/components/_PilotAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_PilotAttack.vue
@@ -157,9 +157,11 @@
                 <v-row no-gutters>
                   <v-col class="mr-n2 ml-n2">
                     <cc-dice-menu
+                      v-if="resetAttackRoll"
                       :preset="`1d20+${pilot.Grit}`"
                       :preset-accuracy="accuracy - difficulty"
                       title="ATTACK ROLL"
+                      autoroll=true
                       @commit="attackRoll = $event.total"
                     />
                   </v-col>
@@ -295,6 +297,7 @@ each source of damage is used.`
                         :title="`${d.Type} DAMAGE ROLL`"
                         :overkill="overkill"
                         :critical="crit"
+                        autoroll=true
                         @commit="setDamage(i, $event)"
                       />
                     </v-col>
@@ -560,6 +563,7 @@ export default Vue.extend({
     bonusDamage: null,
     kill: false,
     confirmed: false,
+    resetAttackRoll: false,
   }),
   computed: {
     state() {
@@ -683,6 +687,9 @@ export default Vue.extend({
       this.kill = false
       this.confirmed = false
       this.overkillHeat = 0
+      this.$nextTick(function () {
+        this.resetAttackRoll = true
+      })
     },
   },
 })

--- a/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_TechAttack.vue
@@ -82,9 +82,11 @@
               <v-row no-gutters>
                 <v-col class="mr-n2 ml-n2">
                   <cc-dice-menu
+                    v-if="resetAttackRoll"
                     :preset="`1d20+${mech.TechAttack}`"
                     :preset-accuracy="accuracy - difficulty"
                     title="Tech Attack"
+                    autoroll=true
                     @commit="registerTechRoll($event.total)"
                   />
                 </v-col>
@@ -153,6 +155,7 @@ export default Vue.extend({
     attackRoll: '',
     succeeded: false,
     failed: false,
+    resetAttackRoll: false,
   }),
   watch: {
     used: {
@@ -172,6 +175,10 @@ export default Vue.extend({
       this.succeeded = false
       this.failed = false
       this.attackRoll = ''
+      this.resetAttackRoll = false
+      this.$nextTick(function () {
+        this.resetAttackRoll = true
+      })
     },
     registerTechRoll(roll) {
       Vue.set(this, 'attackRoll', roll)

--- a/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
@@ -215,8 +215,10 @@
                 <v-row no-gutters>
                   <v-col class="mr-n2 ml-n2">
                     <cc-dice-menu
+                      v-if="resetAttackRoll"
                       :preset="`1d20+${mech.AttackBonus}`"
                       :preset-accuracy="accuracy - difficulty"
+                      autoroll=true
                       title="ATTACK ROLL"
                       @commit="attackRoll = $event.total"
                     />
@@ -369,6 +371,7 @@ each source of damage is used.`"
                         :title="`${d.Type} DAMAGE ROLL`"
                         :overkill="overkill"
                         :critical="crit"
+                        autoroll=true
                         @commit="setDamage(i, $event)"
                       />
                     </v-col>
@@ -645,6 +648,7 @@ export default Vue.extend({
     bonusDamage: null,
     kill: false,
     confirmed: false,
+    resetAttackRoll: false,
   }),
   computed: {
     state() {
@@ -758,7 +762,7 @@ export default Vue.extend({
     },
     setDamage(index, damage) {
       Vue.set(this.damageRolls, index, damage.total)
-      this.overkillHeat = damage.overkill
+      this.overkillHeat += damage.overkill
     },
     setBonusDamage(damage) {
       this.bonusDamage = damage.total
@@ -815,6 +819,10 @@ export default Vue.extend({
       this.kill = false
       this.confirmed = false
       this.overkillHeat = 0
+      this.resetAttackRoll = false
+      this.$nextTick(function () {
+        this.resetAttackRoll = true
+      })
     },
   },
 })

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_GrappleDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_GrappleDialog.vue
@@ -123,6 +123,7 @@
                     :preset="`1d20+${mech.AttackBonus}`"
                     :preset-accuracy="accuracy - difficulty"
                     title="SKILL CHECK"
+                    autoroll=true
                     @commit="registerAttackRoll($event.total)"
                   />
                 </v-col>

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_OverchargeDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_OverchargeDialog.vue
@@ -16,8 +16,10 @@
       <v-col cols="auto">
         <cc-tooltip content="Roll Overcharge">
           <cc-dice-menu
+            v-if="resetRoll"
             :preset="mech.OverchargeTrack[mech.CurrentOvercharge]"
             title="OVERCHARGE"
+            autoroll=true
             @commit="registerOverchargeRoll($event.total)"
           />
         </cc-tooltip>
@@ -78,6 +80,7 @@ export default Vue.extend({
   data: () => ({
     finished: false,
     overcharge_heat: null,
+    resetRoll: true,
   }),
   methods: {
     registerOverchargeRoll(roll) {
@@ -96,6 +99,10 @@ export default Vue.extend({
     init(): void {
       this.finished = false
       this.overcharge_heat = null
+      this.resetRoll = false
+      this.$nextTick(function () {
+        this.resetRoll = true
+      })
     },
   },
 })

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_RamDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_RamDialog.vue
@@ -123,6 +123,7 @@
                     :preset="`1d20+${mech.AttackBonus}`"
                     :preset-accuracy="accuracy - difficulty"
                     title="SKILL CHECK"
+                    autoroll=true
                     @commit="registerAttackRoll($event.total)"
                   />
                 </v-col>

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SearchDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SearchDialog.vue
@@ -54,7 +54,7 @@
               :class="$vuetify.breakpoint.mdAndUp ? 'ml-auto px-12 panel dual-sliced' : ''"
               style="height: 70px"
             >
-              <div class="overline pl-4 mr-n4">Contested SYS</div>
+              <div class="overline pl-4 mr-n4">Contested AGI</div>
               <v-text-field
                 v-model="sys"
                 type="number"
@@ -132,6 +132,7 @@
                     :preset="`1d20+${mech.Sys}`"
                     :preset-accuracy="accuracy - difficulty"
                     title="SKILL CHECK"
+                    autoroll=true
                     @commit="registerSysRoll($event.total)"
                   />
                 </v-col>

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SkillCheckDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SkillCheckDialog.vue
@@ -139,7 +139,7 @@
               <v-row no-gutters>
                 <v-col class="mr-n2 ml-n2">
                   <cc-dice-menu
-                    :preset="`1d20+${mech.AttackBonus}`"
+                    :preset="`1d20`"
                     :preset-accuracy="accuracy - difficulty"
                     title="SKILL CHECK"
                     autoroll=true

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SkillCheckDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SkillCheckDialog.vue
@@ -142,6 +142,7 @@
                     :preset="`1d20+${mech.AttackBonus}`"
                     :preset-accuracy="accuracy - difficulty"
                     title="SKILL CHECK"
+                    autoroll=true
                     @commit="registerSkillRoll($event.total)"
                   />
                 </v-col>


### PR DESCRIPTION
Closes #1551

# Description

This change will auto-populate rolls for Mech attacks and damage, Pilot attacks and damage, Mech tech attacks, Skill checks, Ram, Grapple, Search, and Overcharge.

This does NOT auto-roll bonus damage, that will still need to be done manually.

## Issue Number
`#1551`

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)