### PR TITLE
fix(Pilot Sheet): fix Skill Focus, setup custom reserve retrieval

### DIFF
--- a/src/classes/Action.ts
+++ b/src/classes/Action.ts
@@ -39,9 +39,11 @@ enum ActivePeriod {
 class Frequency {
   public readonly Uses: number
   public readonly Duration: ActivePeriod
+  public readonly FreqText: string
   private _unlimited: boolean
 
   public constructor(frq: string) {
+    this.FreqText = frq
     if (!frq || !frq.includes('/')) {
       this.Uses = 1
       this.Duration = ActivePeriod.Unlimited
@@ -244,6 +246,31 @@ class Action {
     )
     a.Deployable = d
     return a
+  }
+
+  public static Serialize(action: Action): IActionData {
+    return {
+      id: action.ID,
+      name: action.Name,
+      activation: action.Activation,
+      cost: action.Cost,
+      frequency: action.Frequency.FreqText,
+      init: action.Init,
+      trigger: action.Trigger,
+      terse: action.Terse,
+      detail: action.Detail,
+      pilot: action.IsPilotAction,
+      mech: action.IsMechAction,
+      damage: action.Damage.map(x => Damage.Serialize(x)),
+      range: action.Range.map(x => Range.Serialize(x)),
+      hide_active: action.IsActiveHidden,
+      synergy_locations: action.SynergyLocations,
+      confirm: action.Confirm,
+      log: action.Log,
+      ignore_used: action._ignore_used,
+      heat_cost: action.HeatCost,
+      tech_attack: action.IsTechAttack
+    }
   }
 }
 

--- a/src/classes/Bonus.ts
+++ b/src/classes/Bonus.ts
@@ -3,7 +3,7 @@ import dict from '@/assets/bonus_dictionary.json'
 
 interface IBonusData {
   id: string
-  val: string | number
+  val: string | number | string[]
   damage_types?: DamageType[]
   range_types?: RangeType[]
   weapon_types?: WeaponType[]
@@ -212,6 +212,19 @@ class Bonus {
       })
     })
     return output
+  }
+
+  public static Serialize(bonus: Bonus): IBonusData {
+    return {
+      id: bonus.ID,
+      val: bonus.Value,
+      damage_types: bonus.DamageTypes,
+      range_types: bonus.RangeTypes,
+      weapon_types: bonus.WeaponTypes,
+      weapon_sizes: bonus.WeaponSizes,
+      overwrite: bonus.Overwrite,
+      replace: bonus.Replace
+    }
   }
 }
 

--- a/src/classes/Damage.ts
+++ b/src/classes/Damage.ts
@@ -109,6 +109,15 @@ class Damage {
     if (this.Override) return this.Value
     return `${this.Value} ${this.Type} Damage`
   }
+
+  public static Serialize(damage: Damage): IDamageData {
+    return {
+      type: damage.Type,
+      val: damage.Value,
+      override: damage.Override,
+      bonus: damage.Bonus
+    }
+  }
 }
 
 export { Damage, IDamageData }

--- a/src/classes/Range.ts
+++ b/src/classes/Range.ts
@@ -104,6 +104,15 @@ class Range {
   private static ci(a: string, b: string): boolean {
     return a.toLowerCase() === b.toLowerCase()
   }
+
+  public static Serialize(range: Range): IRangeData {
+    return {
+      type: range._range_type,
+      val: range._value,
+      override: range._override,
+      bonus: range._bonus
+    }
+  }
 }
 
 export { Range, IRangeData }

--- a/src/classes/Synergy.ts
+++ b/src/classes/Synergy.ts
@@ -52,6 +52,16 @@ class Synergy {
 
     return _.uniq(sArr)
   }
+
+  public static Serialize(synergy: Synergy): ISynergyData {
+    return {
+      locations: synergy.Locations,
+      detail: synergy.Detail,
+      weapon_types: synergy.WeaponTypes,
+      system_types: synergy.SystemTypes,
+      weapon_sizes: synergy.WeaponSizes
+    }
+  }
 }
 
 export { Synergy, ISynergyData }

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -558,8 +558,7 @@ class Pilot implements ICloudSyncable {
   }
 
   public get MaxSkillPoints(): number {
-    const bonus = this.Reserves.filter(x => x.ID === 'reserve_skill').length
-    return Bonus.IntPilot(Rules.MinimumPilotSkills + this._level + bonus, 'skill_point', this)
+    return Bonus.IntPilot(Rules.MinimumPilotSkills + this._level, 'skill_point', this)
   }
 
   public get IsMissingSkills(): boolean {

--- a/src/classes/pilot/reserves/Reserve.ts
+++ b/src/classes/pilot/reserves/Reserve.ts
@@ -173,6 +173,13 @@ class Reserve {
       resource_cost: reserve.ResourceCost,
       consumable: reserve.Consumable,
       used: reserve.Used,
+      bonuses: reserve.Bonuses.map(x => Bonus.Serialize(x)),
+      actions: reserve.Actions.map(x => Action.Serialize(x)),
+      synergies: reserve.Synergies.map(x => Synergy.Serialize(x)),
+      deployables: reserve.Deployables,
+      counters: reserve.Counters,
+      integrated: reserve._integrated,
+      special_equipment: reserve._special_equipment
     }
   }
 
@@ -185,6 +192,12 @@ class Reserve {
         name: rData.name,
         label: rData.label,
         description: rData.description,
+        bonuses: rData.bonuses,
+        actions: rData.actions,
+        deployables: rData.deployables,
+        counters: rData.counters,
+        integrated: rData.integrated,
+        special_equipment: rData.special_equipment
       }
     const r = new Reserve(data)
     r._resource_name = rData.resource_name

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_BuySomeTime.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_BuySomeTime.vue
@@ -120,7 +120,7 @@ export default Vue.extend({
         nr.ResourceCost = 'Only a little time, and only if drastic measures are taken right now'
       else if (this.skillRoll < 20)
         nr.ResourceCost = 'The situation becomes precarious or desperate'
-      this.pilot.Reserves.push(nr)
+      this.pilot.AddReserve(nr)
       this.close()
     },
     close() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GatherInformation.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GatherInformation.vue
@@ -146,7 +146,7 @@ export default Vue.extend({
       if (this.skillRoll < 10)
         nr.ResourceCost = 'Gathering this information has gotten you into immediate trouble'
       else if (this.skillRoll < 20) nr.ResourceCost = this.choices[this.choice]
-      this.pilot.Reserves.push(nr)
+      this.pilot.AddReserve(nr)
       this.close()
     },
     close() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetADamnDrink.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetADamnDrink.vue
@@ -199,7 +199,7 @@ export default Vue.extend({
           1
         )
         nr.ResourceCost = `You've lost ${lossArr[0].toLowerCase()}, as well as ${lossArr[1].toLowerCase()}`
-        this.pilot.Reserves.push(nr)
+        this.pilot.AddReserve(nr)
       } else if (this.skillRoll < 20) {
         const nr = new Reserve({
           id: 'reserve_damndrink',
@@ -215,7 +215,7 @@ export default Vue.extend({
         })
         nr.Note = this.details1
         nr.ResourceCost = `You've lost ${this.loss.toLowerCase()}`
-        this.pilot.Reserves.push(nr)
+        this.pilot.AddReserve(nr)
       } else {
         const nr = new Reserve({
           id: 'reserve_damndrink',
@@ -230,7 +230,7 @@ export default Vue.extend({
           used: false,
         })
         nr.Note = this.details1
-        this.pilot.Reserves.push(nr)
+        this.pilot.AddReserve(nr)
 
         const nr2 = new Reserve({
           id: 'reserve_damndrink',
@@ -245,7 +245,7 @@ export default Vue.extend({
           used: false,
         })
         nr2.Note = this.details2
-        this.pilot.Reserves.push(nr2)
+        this.pilot.AddReserve(nr2)
       }
       this.close()
     },

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetConnected.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetConnected.vue
@@ -124,7 +124,7 @@ export default Vue.extend({
           'You’ve got to do a favor or make good on a promise for your connection right away'
       else if (this.skillRoll < 20)
         nr.ResourceCost = 'You’ve got to do a favor or make good on a promise after they help you'
-      this.pilot.Reserves.push(nr)
+      this.pilot.AddReserve(nr)
       this.close()
     },
     close() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetCreative.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetCreative.vue
@@ -299,7 +299,7 @@ export default Vue.extend({
         requirements: [],
       })
       if (this.cost) p.ResourceCost = `Requires: ${this.cost.toString()}`
-      this.pilot.Reserves.push(p)
+      this.pilot.AddReserve(p)
       this.close()
     },
     improveProject() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetFocused.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetFocused.vue
@@ -47,12 +47,16 @@ export default Vue.extend({
   },
   methods: {
     addSkill() {
-      this.pilot.Reserves.push(
+      this.pilot.AddReserve(
         new Reserve({
-          id: 'reserve_skill',
+          id: 'reserve_skillfocus',
           type: 'Bonus',
           name: 'Skill Focus',
           description: 'Added via the "Get Focused" Downtime Action',
+          bonuses: [{
+            "id": "skill_point",
+            "val": 1
+          }],
           resource_name: 'Skill Focus',
           resource_cost: '',
           resource_note: '',

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetOrganized.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetOrganized.vue
@@ -407,16 +407,15 @@ export default Vue.extend({
       }
     },
     addOrg() {
-      this.pilot.Organizations.push(
-        new Organization({
-          name: this.name,
-          purpose: this.purpose,
-          efficiency: this.start === 'efficiency' ? 2 : 0,
-          influence: this.start === 'influence' ? 2 : 0,
-          description: this.details,
-          actions: '',
-        })
-      )
+      const org = new Organization({
+        name: this.name,
+        purpose: this.purpose,
+        efficiency: this.start === 'efficiency' ? 2 : 0,
+        influence: this.start === 'influence' ? 2 : 0,
+        description: this.details,
+        actions: '',
+      })
+      this.pilot.AddOrganization(org)
       this.close()
     },
     improveOrg() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_PowerAtACost.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_PowerAtACost.vue
@@ -98,7 +98,7 @@ export default Vue.extend({
         used: false,
       })
       if (this.complication2 !== 'None') nr.ResourceCost += `\n${this.complication2}`
-      this.pilot.Reserves.push(nr)
+      this.pilot.AddReserve(nr)
       this.close()
     },
     close() {

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_ScroungeAndBarter.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_ScroungeAndBarter.vue
@@ -121,8 +121,8 @@ export default Vue.extend({
       })
       if (this.skillRoll < 10) nr.ResourceCost = this.choices[this.choice]
       else if (this.skillRoll < 20)
-        nr.ResourceCost = `Aquiring this has cost you your ${this.trades[this.trade].toLowerCase()}`
-      this.pilot.Reserves.push(nr)
+        nr.ResourceCost = `Acquiring this has cost you your ${this.trades[this.trade].toLowerCase()}`
+      this.pilot.AddReserve(nr)
       this.close()
     },
     close() {


### PR DESCRIPTION
# Description

This PR started with fixing an issue introduced by #1564, and developed into realizing we don't actually store bonuses/actions/synergies/etc. for custom-made reserves (i.e., any stemming from Downtime Actions, *NOT* just the 'Custom Reserve' reserve).  Any bonuses, actions, synergies, etc. would only be available for the Reserves listed in `lancer-data`, as reserves with IDs matching those in `lancer-data` are retrieved fresh every time.  This PR aims to address the discrepancy, and hopefully will open the way to a wider variety of custom reserves.

## Issue Number

Closes #1589

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)