### PR TITLE
fix(Mech Sheet): scale stats with max stat increases

### DIFF
--- a/src/classes/mech/MechEquipment.ts
+++ b/src/classes/mech/MechEquipment.ts
@@ -15,7 +15,7 @@ interface IMechEquipmentData extends ILicensedItemData {
 }
 
 abstract class MechEquipment extends LicensedItem {
-  protected _uses: number
+  protected _missing_uses: number
   protected _used: boolean
   protected _destroyed: boolean
   protected _cascading: boolean
@@ -64,7 +64,7 @@ abstract class MechEquipment extends LicensedItem {
     } else {
       this._max_uses = 0
     }
-    this._uses = this._max_uses
+    this._missing_uses = 0
     this.Ammo = data.ammo || []
     this.NoMods = data.no_mods
     this.NoBonuses = data.no_bonuses
@@ -154,12 +154,16 @@ abstract class MechEquipment extends LicensedItem {
   }
 
   public get Uses(): number {
-    return this._uses
+    return this.MaxUses - this._missing_uses
   }
 
   public set Uses(val: number) {
-    this._uses = val
+    this._missing_uses = this.MaxUses - val
     this.save()
+  }
+
+  public get MissingUses(): number {
+    return this._missing_uses
   }
 
   public get MaxUses(): number {

--- a/src/classes/mech/MechSystem.ts
+++ b/src/classes/mech/MechSystem.ts
@@ -37,7 +37,7 @@ class MechSystem extends MechEquipment {
 
   public static Deserialize(data: IEquipmentData): MechSystem {
     const item = store.getters.instantiate('MechSystems', data.id) as MechSystem
-    item._uses = data.uses || 0
+    item.Uses = data.uses || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._note = data.note

--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -236,7 +236,7 @@ class MechWeapon extends MechEquipment {
   public set MaxUseOverride(val: number) {
     const safeVal = MechWeapon.SanitizeUsesInput(val)
     this.max_use_override = safeVal
-    this._uses = safeVal
+    this._missing_uses = 0
     this.save()
   }
 
@@ -298,7 +298,7 @@ class MechWeapon extends MechEquipment {
 
   public static Deserialize(data: IMechWeaponSaveData): MechWeapon {
     const item = store.getters.instantiate('MechWeapons', data.id) as MechWeapon
-    item._uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
+    item.Uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._loaded = data.loaded || true

--- a/src/classes/mech/SystemMod.ts
+++ b/src/classes/mech/SystemMod.ts
@@ -40,7 +40,7 @@ class SystemMod extends MechEquipment {
 
   public static Deserialize(data: IEquipmentData): SystemMod {
     const item = store.getters.instantiate('SystemMods', data.id) as SystemMod
-    item._uses = data.uses || 0
+    item.Uses = data.uses || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._note = data.note

--- a/src/classes/mech/WeaponMod.ts
+++ b/src/classes/mech/WeaponMod.ts
@@ -72,7 +72,7 @@ class WeaponMod extends MechEquipment {
 
   public static Deserialize(data: IEquipmentData): WeaponMod {
     const item = store.getters.instantiate('WeaponMods', data.id) as WeaponMod
-    item._uses = data.uses || 0
+    item.Uses = data.uses || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._note = data.note

--- a/src/classes/pilot/PilotEquipment.ts
+++ b/src/classes/pilot/PilotEquipment.ts
@@ -8,9 +8,8 @@ interface IPilotEquipmentData extends ICompendiumItemData {
 }
 
 abstract class PilotEquipment extends CompendiumItem {
-  protected current_uses: number
   protected _custom_damage_type?: string
-  protected _uses: number
+  protected _missing_uses: number
   protected _destroyed: boolean
   protected _cascading: boolean
   protected _loaded: boolean
@@ -55,7 +54,7 @@ abstract class PilotEquipment extends CompendiumItem {
     } else {
       this._max_uses = 0
     }
-    this._uses = this._max_uses
+    this._missing_uses = 0
   }
 
   public Use(cost?: number): void {
@@ -139,12 +138,16 @@ abstract class PilotEquipment extends CompendiumItem {
   }
 
   public get Uses(): number {
-    return this._uses
+    return this.MaxUses - this._missing_uses
   }
 
   public set Uses(val: number) {
-    this._uses = val
+    this._missing_uses = this.MaxUses - val
     this.save()
+  }
+
+  public get MissingUses(): number {
+    return this._missing_uses
   }
 
   public get MaxUses(): number {
@@ -162,7 +165,7 @@ abstract class PilotEquipment extends CompendiumItem {
     return {
       id: item.ID,
       destroyed: false,
-      uses: item.current_uses,
+      uses: item.Uses,
       cascading: false,
       note: item.Note,
       flavorName: item._flavor_name,
@@ -174,7 +177,7 @@ abstract class PilotEquipment extends CompendiumItem {
   public static Deserialize(itemData: IEquipmentData | null): PilotEquipment | null {
     if (!itemData) return null
     const item = store.getters.instantiate('PilotGear', itemData.id)
-    item.current_uses = itemData.uses
+    item.Uses = itemData.uses
     item._note = itemData.note
     item._flavor_name = itemData.flavorName
     item._flavor_description = itemData.flavorDescription

--- a/src/ui/components/CCItemUses.vue
+++ b/src/ui/components/CCItemUses.vue
@@ -41,10 +41,10 @@ export default class CCItemUses extends Vue {
   readonly bonus: number
 
   get max(): number {
-    return this.item.MaxUses + this.bonus
+    return this.item.getTotalUses(this.bonus)
   }
   get current(): number {
-    return this.item.Uses
+    return this.max - this.item.MissingUses
   }
 
   set(val): void {

--- a/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
@@ -9,7 +9,7 @@
     </v-col>
     <v-col v-if="item.IsLimited" cols="auto" class="mx-2">
       <cc-item-uses :item="item" :bonus="useBonus" :color="color" class="d-inline" />
-      <span class="overline">({{ item.Uses }}/{{ item.MaxUses + useBonus }}) USES</span>
+      <span class="overline">({{ item.MaxUses + useBonus - item.MissingUses }}/{{ item.MaxUses + useBonus }}) USES</span>
     </v-col>
     <v-col v-if="item.IsLoading && readonly" cols="auto" class="ma-1">
       <v-btn


### PR DESCRIPTION
# Description

Use a "missing stat" approach similar to the HP changes in #1569 for similar statistics so that the "current" values scale with increases to the maximum values.  Most noticeable with Repair Cap due to Hull bonuses; Structure & Stress included in case respective bonuses are introduced.  Also performed similar scaling for Limited-use systems (though more of the math was on the Vue/HTML side), most noticeable on Prototype weapon.

## Issue Number

Closes #1586

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)