### PR TITLE
fix(Compendium): load static image for homebrew manufacturers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "aws-amplify": "^3.3.14",
     "aws-amplify-vue": "^2.1.4",
     "axios": "^0.19.0",
+    "external-svg-loader": "^1.3.4",
     "jszip": "^3.2.2",
     "lancer-data": "^3.0.36",
     "lodash": "^4.17.11",

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
       name="description"
       content="A digital toolset for the LANCER TTRPG by Massif Press. Create characters and track them in combat, or run games with the GM toolkit."
     />
+    <script src="../node_modules/external-svg-loader/svg-loader.min.js" async></script>
     <title>COMP/CON</title>
   </head>
   <body>

--- a/src/features/compendium/Views/Factions.vue
+++ b/src/features/compendium/Views/Factions.vue
@@ -29,10 +29,20 @@
               v-if="$vuetify.breakpoint.lgAndUp"
               style="float: right; margin-left: 20px; margin-right: 50px; min-height: 22vw"
             >
+              <img
+                v-if="f.LogoIsExternal"
+                :src="f.Logo"
+                :alt="f.Name"
+                :style="{
+                  maxWidth: '22vw',
+                  height: '22vw',
+                }"
+              />
               <svg
+                v-else
+                :data-src="f.Logo + '#Content'"
                 :style="`width:22vw; height:22vw; fill:${f.Color}; stroke:#fff; stroke-width: 8px;`"
               >
-                <use :href="f.Logo + '#Content'"></use>
               </svg>
             </div>
             <v-divider class="ma-2" style="width: 800px" />
@@ -53,13 +63,14 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
+import { Faction } from '@/classes/Faction'
 
 @Component
 export default class Factions extends Vue {
   public tabModel = 0
 
   private compendiumStore = getModule(CompendiumStore, this.$store)
-  get factions() {
+  get factions(): Faction[] {
     return this.compendiumStore.Factions
   }
 }

--- a/src/features/compendium/Views/Manufacturers.vue
+++ b/src/features/compendium/Views/Manufacturers.vue
@@ -29,10 +29,20 @@
               v-if="$vuetify.breakpoint.lgAndUp"
               style="float: right; margin-left: 20px; margin-right: 50px; min-height: 22vw"
             >
+              <img
+                v-if="m.LogoIsExternal"
+                :src="m.Logo"
+                :alt="m.Name"
+                :style="{
+                  maxWidth: '22vw',
+                  height: '22vw',
+                }"
+              />
               <svg
+                v-else
+                :data-src="m.Logo + '#Content'"
                 :style="`width:22vw; height:22vw; fill:${m.Color}; stroke:#fff; stroke-width: 8px;`"
               >
-                <use :href="m.Logo + '#Content'"></use>
               </svg>
             </div>
             <blockquote class="quote-block fluff-text text--text" v-html-safe="m.Quote" />

--- a/src/features/nav/pages/ExtraContent/PacksDirectory.vue
+++ b/src/features/nav/pages/ExtraContent/PacksDirectory.vue
@@ -56,9 +56,6 @@ export default class PacksDirectory extends Vue {
     fetch(this.massifPacksUrl, {
       method: 'GET',
       mode: 'cors',
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-      },
     })
       .then(res => res.json())
       .then(list => (this.massifPacks = list))
@@ -70,9 +67,6 @@ export default class PacksDirectory extends Vue {
     fetch(this.communityPacksUrl, {
       method: 'GET',
       mode: 'cors',
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-      },
     })
       .then(res => res.json())
       .then(list => (this.communityPacks = list))

--- a/src/ui/components/items/CCLogo.vue
+++ b/src/ui/components/items/CCLogo.vue
@@ -10,13 +10,13 @@
   />
   <svg
     v-else
+    :data-src="source.Logo + '#Content'"
     :style="
       `width:${iconSize}; height:${iconSize}; fill:${iconColor}; stroke:${stroke}; ${
         stroke ? 'stroke-width: 25px;' : ''
       }`
     "
   >
-    <use :href="source.Logo + '#Content'"></use>
   </svg>
 </template>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6615,6 +6615,13 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+external-svg-loader@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/external-svg-loader/-/external-svg-loader-1.3.4.tgz#e683da935c603ce3e881219a906de2ba4e18acf1"
+  integrity sha512-73h7/rYYA4KnIV74M/0r6zHWPLuY/8QHnwKymwh+46tbQAZ0ZtoN98TJZI+CUYTfP2nXgqslCgSsxcr7eOw45w==
+  dependencies:
+    idb-keyval "^3.2.0"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -7783,6 +7790,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   integrity sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==
   dependencies:
     postcss "^7.0.14"
+
+idb-keyval@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-3.2.0.tgz#cbbf354deb5684b6cdc84376294fc05932845bd6"
+  integrity sha512-slx8Q6oywCCSfKgPgL0sEsXtPVnSbTLWpyiDcu6msHOyKOLari1TD1qocXVCft80umnkk3/Qqh3lwoFt8T/BPQ==
 
 idb@5.0.6:
   version "5.0.6"


### PR DESCRIPTION
# Description

Loads large Manufacturer/Faction logo as a static img instead of a dynamic svg in the compendium. 

Incorporates [external-svg-loader](https://www.npmjs.com/package/external-svg-loader) for potential future use should content creators provide SVG references with CORS compatible with compcon.app.

## Issue Number
Closes #1535

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
