### PR TITLE
fix(Pilot Sheet): LL0 Pilots can select bonus skill triggers

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -575,14 +575,13 @@ class Pilot implements ICloudSyncable {
   }
 
   public CanAddSkill(skill: Skill | CustomSkill): boolean {
-    if (this._level === 0) {
-      return this._skills.length < Rules.MinimumPilotSkills && !this.has('Skill', skill.ID)
-    } else {
-      const underLimit = this.CurrentSkillPoints < this.MaxSkillPoints
-      if (!this.has('Skill', skill.ID) && underLimit) return true
-      const pSkill = this._skills.find(x => x.Skill.ID === skill.ID)
-      return underLimit && pSkill && pSkill.Rank < Rules.MaxTriggerRank
-    }
+    const hasMinSkills = this._skills.length >= Rules.MinimumPilotSkills
+    return this.IsMissingSkills && (
+      !this.has('Skill', skill.ID) || (
+        hasMinSkills && 
+        this._skills.find(x => x.Skill.ID === skill.ID).Rank < Rules.MaxTriggerRank
+      )
+    )
   }
 
   public AddSkill(skill: Skill | CustomSkill): void {

--- a/src/ui/components/selectors/CCSkillSelector.vue
+++ b/src/ui/components/selectors/CCSkillSelector.vue
@@ -87,7 +87,6 @@
       </div>
       <add-custom-skill 
         :pilot="pilot"
-        :can-add="pilot.IsMissingSkills"
         @add-custom="pilot.AddCustomSkill($event)" />
     </template>
   </selector>

--- a/src/ui/components/selectors/components/_AddCustomSkill.vue
+++ b/src/ui/components/selectors/components/_AddCustomSkill.vue
@@ -38,7 +38,7 @@
             :small="$vuetify.breakpoint.smAndDown"
             icon
             color="secondary"
-            :disabled="!canAdd || newSkill === ''"
+            :disabled="newSkill === '' || !canAdd"
             @click="addSkill"
           >
             <v-icon x-large>cci-accuracy</v-icon>
@@ -52,20 +52,23 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Pilot } from '@/class'
+import { CustomSkill } from '@/class'
 export default Vue.extend({
   name: 'add-custom-skill',
   props: {
-    pilot: Pilot,
-    canAdd: {
-      type: Boolean,
-      required: true,
-    },
+    pilot: Pilot
   },
   data: () => ({
     newSkill: '',
     newDesc: '',
     newDetail: '',
   }),
+  computed: {
+    canAdd(): boolean {
+      const custSkill = new CustomSkill(this.newSkill, this.newDesc, this.newDetail)
+      return this.pilot.CanAddSkill(custSkill)
+    }
+  },
   methods: {
     addSkill() {
       this.$emit('add-custom', {


### PR DESCRIPTION
# Description

This change modifies the logic checking if a pilot can add a skill trigger so that LL0 pilots with extra skill points can select additional talents.  In addition, it modifies the approach to protecting from custom added triggers to simply use `Pilot.CanAddSkill()`, differing from the original fix in #1582.

## Issue Number
Closes #1600

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)