### PR TITLE
fix(vault): handle imported vault codes in a case insensitive manner

### DIFF
--- a/src/features/pilot_management/Roster/components/add_panels/VaultImport.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/VaultImport.vue
@@ -109,6 +109,7 @@ export default Vue.extend({
       this.reset()
       this.cloudLoading = true
       try {
+        this.importID = this.importID.toLowerCase()
         const pilotData = await AwsImport(this.importID)
         if (!pilotData.brews) pilotData.brews = []
         const installedPacks = getModule(CompendiumStore, this.$store).ContentPacks.map(


### PR DESCRIPTION
Closes #1606

# Description

This change converts input vault codes to lowercase before requesting them in AWS.

## Issue Number
`#1606`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
