### PR TITLE
fix(Pilot Sheet): enable scroll-on-click for LL0 pilots in Skill & Talents

### DIFF
--- a/src/features/pilot_management/New/pages/MechSkillsPage.vue
+++ b/src/features/pilot_management/New/pages/MechSkillsPage.vue
@@ -37,7 +37,7 @@
         </v-alert>
       </v-container>
     </div>
-    <cc-mech-skills-selector :pilot="pilot" />
+    <cc-mech-skills-selector level-up :pilot="pilot" />
   </cc-stepper-content>
 </template>
 

--- a/src/features/pilot_management/New/pages/SkillsPage.vue
+++ b/src/features/pilot_management/New/pages/SkillsPage.vue
@@ -41,7 +41,7 @@
         </v-alert>
       </v-container>
     </div>
-    <cc-skill-selector :pilot="pilot" />
+    <cc-skill-selector level-up :pilot="pilot" />
   </cc-stepper-content>
 </template>
 

--- a/src/features/pilot_management/New/pages/TalentsPage.vue
+++ b/src/features/pilot_management/New/pages/TalentsPage.vue
@@ -38,7 +38,7 @@
         </v-alert>
       </v-container>
     </div>
-    <cc-talent-selector :pilot="pilot" />
+    <cc-talent-selector level-up :pilot="pilot" />
   </cc-stepper-content>
 </template>
 

--- a/src/ui/components/selectors/CCSkillSelector.vue
+++ b/src/ui/components/selectors/CCSkillSelector.vue
@@ -145,7 +145,7 @@ export default Vue.extend({
   },
   methods: {
     scroll(id) {
-      if (this.newPilot || this.levelUp)
+      if (this.levelUp)
         this.$vuetify.goTo(`#skill_${id}`, {
           duration: 150,
           easing: 'easeInOutQuad',

--- a/src/ui/components/selectors/CCTalentSelector.vue
+++ b/src/ui/components/selectors/CCTalentSelector.vue
@@ -164,7 +164,7 @@ export default Vue.extend({
       return this.pilot.IsMissingTalents
     },
     scroll(id) {
-      if (this.newPilot || this.levelUp)
+      if (this.levelUp)
         this.$vuetify.goTo(`#e_${id}`, {
           duration: 150,
           easing: 'easeInOutQuad',


### PR DESCRIPTION
# Description
Fixes error where skill & talent scrolling were disabled for LL0 characters when directly modifying their skills/talents outside of character creation or leveling up.  Adds 'level-up' prop to the New Pilot skill, talent, & (vestigially, but for consistency) mech skill selectors to indicate the difference in HTML containers.

## Issue Number
Closes #1609

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)