### PR TITLE
fix(Mech Sheet): add tooltips to the Mech Sheet Nav bar buttons

### DIFF
--- a/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
@@ -3,7 +3,9 @@
     <div id="cap" />
     <div v-if="$vuetify.breakpoint.mdAndUp" class="d-inline">
       <cc-nav-item tile depressed :selected="selected === 0" @click="$emit('set-page', 0)">
-        MECH CONFIGURATION
+        <cc-tooltip inlinde delayed content="Active Mech Configuration">
+          MECH CONFIGURATION
+        </cc-tooltip>
       </cc-nav-item>
       <cc-tooltip simple inline content="Feature In Development">
         <cc-nav-item disabled :selected="selected === 1" @click="$emit('set-page', 1)">
@@ -11,10 +13,14 @@
         </cc-nav-item>
       </cc-tooltip>
       <v-btn icon fab x-small outlined class="mx-4 unskew" dark @click="toPilotSheet()">
-        <v-icon large>cci-pilot</v-icon>
+        <cc-tooltip inline delayed content="Player Profile">
+          <v-icon large>cci-pilot</v-icon>
+        </cc-tooltip>
       </v-btn>
       <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
-        <v-icon large color="white">cci-activate</v-icon>
+        <cc-tooltip inline delayed content="Active Mode">
+          <v-icon large color="white">cci-activate</v-icon>
+        </cc-tooltip>
       </v-btn>
     </div>
     <v-menu v-else open-on-hover>
@@ -42,7 +48,9 @@
     <v-menu offset-y top>
       <template v-slot:activator="{ on: menu }">
         <v-btn class="unskew ml-2" icon dark v-on="menu">
-          <v-icon>mdi-settings</v-icon>
+          <cc-tooltip inline delayed content="Mech Options">
+            <v-icon>mdi-settings</v-icon>
+          </cc-tooltip>
         </v-btn>
       </template>
       <v-list two-line subheader>
@@ -85,7 +93,9 @@
     <v-menu offset-y top>
       <template v-slot:activator="{ on: menu }">
         <v-btn class="unskew ml-2" icon dark v-on="menu">
-          <v-icon>mdi-view-grid-plus</v-icon>
+          <cc-tooltip inline delayed content="Layout Options">
+            <v-icon>mdi-view-grid-plus</v-icon>
+          </cc-tooltip>
         </v-btn>
       </template>
       <v-list subheader>

--- a/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
@@ -2,26 +2,26 @@
   <div class="nav-body elevation-10">
     <div id="cap" />
     <div v-if="$vuetify.breakpoint.mdAndUp" class="d-inline">
-      <cc-nav-item tile depressed :selected="selected === 0" @click="$emit('set-page', 0)">
-        <cc-tooltip inlinde delayed content="Active Mech Configuration">
+      <cc-tooltip inline delayed content="Active Mech Configuration">
+        <cc-nav-item tile depressed :selected="selected === 0" @click="$emit('set-page', 0)">
           MECH CONFIGURATION
-        </cc-tooltip>
-      </cc-nav-item>
+        </cc-nav-item>
+      </cc-tooltip>
       <cc-tooltip simple inline content="Feature In Development">
         <cc-nav-item disabled :selected="selected === 1" @click="$emit('set-page', 1)">
           COMBAT ANALYTICS
         </cc-nav-item>
       </cc-tooltip>
-      <v-btn icon fab x-small outlined class="mx-4 unskew" dark @click="toPilotSheet()">
-        <cc-tooltip inline delayed content="Player Profile">
+      <cc-tooltip inline delayed content="Player Profile">
+        <v-btn icon fab x-small outlined class="mx-4 unskew" dark @click="toPilotSheet()">
           <v-icon large>cci-pilot</v-icon>
-        </cc-tooltip>
-      </v-btn>
-      <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
-        <cc-tooltip inline delayed content="Active Mode">
+        </v-btn>
+      </cc-tooltip>
+      <cc-tooltip inline delayed content="Active Mode">
+        <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
           <v-icon large color="white">cci-activate</v-icon>
-        </cc-tooltip>
-      </v-btn>
+        </v-btn>
+      </cc-tooltip>
     </div>
     <v-menu v-else open-on-hover>
       <template v-slot:activator="{ on }">


### PR DESCRIPTION
Closes #1597

# Description

Added tooltip text to the mech sheet nav buttons that was missing. 

## Issue Number
`#1597`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
