### PR TITLE
fix(Compendium): revised svg-loader usage to NPM module style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
       name="description"
       content="A digital toolset for the LANCER TTRPG by Massif Press. Create characters and track them in combat, or run games with the GM toolkit."
     />
-    <script src="../node_modules/external-svg-loader/svg-loader.min.js" async></script>
     <title>COMP/CON</title>
   </head>
   <body>

--- a/src/features/compendium/Views/Factions.vue
+++ b/src/features/compendium/Views/Factions.vue
@@ -64,6 +64,7 @@ import Component from 'vue-class-component'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
 import { Faction } from '@/classes/Faction'
+import "external-svg-loader"
 
 @Component
 export default class Factions extends Vue {

--- a/src/features/compendium/Views/Manufacturers.vue
+++ b/src/features/compendium/Views/Manufacturers.vue
@@ -65,6 +65,7 @@ import Component from 'vue-class-component'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
 import { Manufacturer } from '@/class'
+import "external-svg-loader"
 
 @Component
 export default class Manufacturers extends Vue {

--- a/src/ui/components/items/CCLogo.vue
+++ b/src/ui/components/items/CCLogo.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-
+import "external-svg-loader"
 enum sizeMap {
   xSmall = '16px',
   small = '20px',


### PR DESCRIPTION
# Description
The external-svg-loader module didn't work as a script embedded in the head of the index.html when deployed to netlify.  Attempting an alternate approach using NPM imports to perform the desired svg-loader behavior without having to figure out how relative imports work on webpack/netlify/etc.

Referencing the [external-svg-loader README](https://github.com/shubhamjain/svg-loader#or-use-from-the-npm-package) for this change.

## Issue Number
Closes #1618

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)