### PR TITLE
fix(Mech Sheet): correctly display mech weapon type when printing sheet

### DIFF
--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -253,7 +253,7 @@
         <v-row no-gutters class="stat-text">
           {{ w.Name }}
           <div class="d-inline-block overline ml-2 my-n1">
-            {{ w.Source }} {{ w.Size }} {{ w.Type }}
+            {{ w.Source }} {{ w.Size }} {{ w.WeaponType }}
           </div>
           <v-spacer />
           <span v-if="w.Uses">


### PR DESCRIPTION
Closes #1617

# Description

Fix a typo which prevented the weapon types from being displayed when printing a characters mech.

## Issue Number
`#1617`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)