### PR TITLE
fix(Mech Sheet): enable Remove/Change item icons on IntWeapon

### DIFF
--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
@@ -56,7 +56,7 @@
             <span>{{ item.SP }}SP</span>
           </div>
         </v-col>
-        <v-col v-if="!intWeapon && !readonly" cols="auto">
+        <v-col v-if="!readonly" cols="auto">
           <div class="pl-3 ml-3" style=" border-left: 1px solid #616161;">
             <v-icon v-if="item" :small="small" dark class="fadeSelect mt-n1" @click.stop="remove()">
               delete


### PR DESCRIPTION
# Description

Enable icons on the Integrated Weapon mount for Remove/Change Item, since Integrated Weapon is a selectable mount unlike other integrated mounts.

## Issue Number
Closes #1638

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
