### PR TITLE
fix(Pilot Sheet): pilot imports ungrouped, immediately visible

### DIFF
--- a/src/features/pilot_management/Roster/components/add_panels/CloudImportOld.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/CloudImportOld.vue
@@ -119,6 +119,7 @@ export default Vue.extend({
       if (!importPilot.GistCode) {
         importPilot.GistCode = this.importID
       }
+      importPilot.Group = ''
       getModule(PilotManagementStore, this.$store).addPilot({ pilot: importPilot, update: true })
       this.reset()
       this.dialog = false

--- a/src/features/pilot_management/Roster/components/add_panels/FileImport.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/FileImport.vue
@@ -113,6 +113,7 @@ export default Vue.extend({
     },
     confirmImport() {
       this.importPilot.RenewID()
+      this.importPilot.Group = ''
       this.$store.dispatch('addPilot', { pilot: this.importPilot, update: true })
       this.reset()
       this.dialog = false

--- a/src/features/pilot_management/Roster/components/add_panels/ImportDialog.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/ImportDialog.vue
@@ -23,7 +23,7 @@
       </v-card-actions>
       <v-card-actions v-else-if="pilot">
         <span class="white--text flavor-text">
-          Import
+          Import pilot
           <b>{{ pilot.Callsign.toUpperCase() }}</b>
           //
           <b>{{ pilot.Name }}</b>

--- a/src/features/pilot_management/Roster/components/add_panels/VaultImport.vue
+++ b/src/features/pilot_management/Roster/components/add_panels/VaultImport.vue
@@ -134,6 +134,7 @@ export default Vue.extend({
       if (!importPilot.CloudID) {
         importPilot.CloudID = this.importID
       }
+      importPilot.Group = ''
       getModule(PilotManagementStore, this.$store).addPilot({ pilot: importPilot, update: true })
       this.reset()
       this.dialog = false

--- a/src/features/pilot_management/Roster/index.vue
+++ b/src/features/pilot_management/Roster/index.vue
@@ -51,8 +51,8 @@
         <div v-for="g in groups" :key="`pg_${g}`">
           <v-row no-gutters class="pl-10 ml-n12 heading h3 white--text primary sliced">
             <v-col cols="auto">
-              <v-btn small dark icon class="mt-n1" @click="toggleShown(g)">
-                <v-icon v-html="shown.includes(g) ? 'mdi-chevron-down' : 'mdi-chevron-up'" />
+              <v-btn small dark icon class="mt-n1" @click="toggleHidden(g)">
+                <v-icon v-html="!hidden.includes(g) ? 'mdi-chevron-down' : 'mdi-chevron-up'" />
               </v-btn>
               {{ g ? g : 'Ungrouped' }}
               <span class="overline">({{ pilots.filter(x => x.Group === g).length }})</span>
@@ -83,7 +83,7 @@
             </v-col>
           </v-row>
           <div
-            v-if="shown.includes(g)"
+            v-if="!hidden.includes(g)"
             :style="profile.GetView('roster') !== 'list' ? 'margin-left: -8px; width: 100vw;' : ''"
           >
             <v-expand-transition>
@@ -171,7 +171,7 @@ export default Vue.extend({
     drag: false,
     newGroupMenu: false,
     tempGroups: [],
-    shown: [],
+    hidden: [],
     newGroupName: '',
     preventDnd: true,
   }),
@@ -215,27 +215,26 @@ export default Vue.extend({
     },
   },
   created() {
-    this.shown = [...this.groups]
+    this.hidden = []
     this.preventDnd = this.isTouch
   },
   methods: {
-    toggleShown(g: string) {
-      const idx = this.shown.indexOf(g)
-      if (idx === -1) this.shown.push(g)
-      else this.shown.splice(idx, 1)
+    toggleHidden(g: string) {
+      const idx = this.hidden.indexOf(g)
+      if (idx === -1) this.hidden.push(g)
+      else this.hidden.splice(idx, 1)
     },
     showAll() {
-      Vue.set(this, 'shown', [...this.groups])
+      Vue.set(this, 'hidden', [])
     },
     hideAll() {
-      Vue.set(this, 'shown', [])
+      Vue.set(this, 'hidden', [...this.groups])
     },
     onSort(sortParams: any[]) {
       this.sortParams = sortParams
     },
     addNewGroup() {
       this.pilotStore.addGroup(this.newGroupName)
-      this.shown.push(this.newGroupName)
       this.newGroupName = ''
       this.newGroupMenu = false
     },
@@ -255,7 +254,6 @@ export default Vue.extend({
     },
     setGroupName(oldName, newName) {
       this.pilotStore.setGroupName({oldName: oldName, newName: newName})
-      this.shown.push(newName)
     },
     randomName() {
       this.newGroupName = teamName()


### PR DESCRIPTION
# Description
This PR refines #1647 such that newly-imported pilots ~~import their group with them, and~~ are immediately visible. This PR also makes pilot sorting/reindexing more robust.  Finally, this PR changes the default display state for new groups to "visible", ~~and adds more detail to the Import Pilot message to include Pilot Group~~.

EDIT: Updated such that ~~newly-created and~~ imported pilots do NOT import their group, and are instead Ungrouped.  Removed Pilot Group from Import Pilot message.  Keeping the sorting/reindexing and the default display states, as I think they meaningfully add to the project.

EDIT 2: Moved the "ungrouping" to pilot imports only, so that cloned pilots retain the group of their original pilot (a feature that I feel will be more convenient than always sending a "new" pilot to Ungrouped).  Completely new pilots lack a group in the first place, so this changes nothing for them.

## Issue Number
Closes #1650

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)