### PR TITLE
fix(Mech Sheet): prototype Weapon deserializes Uses after MaxOverride

### DIFF
--- a/src/classes/mech/MechEquipment.ts
+++ b/src/classes/mech/MechEquipment.ts
@@ -167,8 +167,7 @@ abstract class MechEquipment extends LicensedItem {
   }
 
   public get MaxUses(): number {
-    if (this.max_use_override) return this.max_use_override
-    return this._max_uses
+    return this.max_use_override ? this.max_use_override : this._max_uses
   }
 
   public getTotalUses(bonus?: number): number {

--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -282,7 +282,6 @@ class MechWeapon extends MechEquipment {
   public static Serialize(item: MechWeapon): IMechWeaponSaveData {
     return {
       id: item.ID,
-      uses: MechWeapon.SanitizeUsesInput(item.Uses) || 0,
       destroyed: item.Destroyed,
       cascading: item.IsCascading,
       loaded: item.Loaded,
@@ -292,13 +291,13 @@ class MechWeapon extends MechEquipment {
       flavorDescription: item._flavor_description,
       customDamageType: item._custom_damage_type || null,
       maxUseOverride: MechWeapon.SanitizeUsesInput(item.max_use_override) || 0,
+      uses: MechWeapon.SanitizeUsesInput(item.Uses) || 0,
       selectedProfile: item._selected_profile || 0,
     }
   }
 
   public static Deserialize(data: IMechWeaponSaveData): MechWeapon {
     const item = store.getters.instantiate('MechWeapons', data.id) as MechWeapon
-    item.Uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
     item._destroyed = data.destroyed || false
     item._cascading = data.cascading || false
     item._loaded = data.loaded || true
@@ -308,6 +307,7 @@ class MechWeapon extends MechEquipment {
     item._flavor_description = data.flavorDescription
     item._custom_damage_type = data.customDamageType || null
     item.max_use_override = MechWeapon.SanitizeUsesInput(data.maxUseOverride) || 0
+    item.Uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
     item._selected_profile = data.selectedProfile || 0
     return item
   }

--- a/src/classes/pilot/PilotEquipment.ts
+++ b/src/classes/pilot/PilotEquipment.ts
@@ -151,8 +151,7 @@ abstract class PilotEquipment extends CompendiumItem {
   }
 
   public get MaxUses(): number {
-    if (this.max_use_override) return this.max_use_override
-    return this._max_uses
+    return this.max_use_override ? this.max_use_override : this._max_uses
   }
 
   public getTotalUses(bonus?: number): number {

--- a/src/ui/components/CCItemUses.vue
+++ b/src/ui/components/CCItemUses.vue
@@ -2,7 +2,7 @@
   <div class="mt-n2">
     <v-btn
       v-for="n in max"
-      :key="`chk_${item.ID}-${n}_of_${item.MaxUses}`"
+      :key="`chk_${item.ID}-${n}_of_${max}`"
       class="d-inline my-0 mx-n1 pa-0"
       icon
       :small="small"

--- a/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
@@ -9,7 +9,7 @@
     </v-col>
     <v-col v-if="item.IsLimited" cols="auto" class="mx-2">
       <cc-item-uses :item="item" :bonus="useBonus" :color="color" class="d-inline" />
-      <span class="overline">({{ item.MaxUses + useBonus - item.MissingUses }}/{{ item.MaxUses + useBonus }}) USES</span>
+      <span class="overline">({{ item.getTotalUses(useBonus) - item.MissingUses }}/{{ item.getTotalUses(useBonus) }}) USES</span>
     </v-col>
     <v-col v-if="item.IsLoading && readonly" cols="auto" class="ma-1">
       <v-btn


### PR DESCRIPTION
# Description
This fix rearranges the Serialization & Deserialization of MechWeapon's MaxUseOverride & total Uses so that Deserialization of Uses occurs *after* MaxUseOverride.  This is relevant since Uses is calculated based upon MaxUseOverride. Also includes minor refactors that will hopefully make the code more readable & maintainable.

## Issue Number
Closes #1649

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)