### PR TITLE
fix(Active Mode): cast Tag vals as numbers, use profile tags

### DIFF
--- a/src/classes/CompendiumItem.ts
+++ b/src/classes/CompendiumItem.ts
@@ -65,9 +65,9 @@ abstract class CompendiumItem {
       this._baseTags = Tag.Deserialize(data.tags, packTags)
       this.IsExotic = this._baseTags.some(x => x.IsExotic)
       const heatTag = this.Tags.find(x => x.IsHeatCost)
-      const heatCost = heatTag ? heatTag.Value : 0
+      const heatCost = Number(heatTag ? heatTag.Value : 0)
       this.Actions = data.actions
-        ? data.actions.map(x => new Action(x, data.name, heatCost as number))
+        ? data.actions.map(x => new Action(x, data.name, heatCost))
         : []
       this.Bonuses = data.bonuses ? data.bonuses.map(x => new Bonus(x)) : []
       this.Synergies = data.synergies ? data.synergies.map(x => new Synergy(x, data.name)) : []

--- a/src/classes/Deployable.ts
+++ b/src/classes/Deployable.ts
@@ -123,7 +123,7 @@ class Deployable extends CompendiumItem {
       out = owner.Pilot.SpecialEval(out)
       out += Bonus.get(`${prefix}_${bonusID}`, owner)
     }
-    return out as number
+    return Number(out)
   }
 
   public get Name(): string {

--- a/src/classes/Tag.ts
+++ b/src/classes/Tag.ts
@@ -81,7 +81,7 @@ class Tag {
           } + ${bonus} bonus)</span>`
       return this._description.replace(/{VAL}/g, r)
     } else {
-      const str = this._val as string
+      const str = String(this._val)
       if (str.includes('+')) {
         const split = str.split('+')
         const newVal = `${split[0]}+${parseInt(split[1]) + bonus}`
@@ -102,7 +102,7 @@ class Tag {
     if (typeof this._val === 'number') {
       return this._name.replace(/{VAL}/g, (this._val + bonus).toString())
     } else {
-      const str = this._val as string
+      const str = String(this._val)
       if (str.includes('+')) {
         const split = str.split('+')
         const newVal = `${split[0]}+${parseInt(split[1]) + bonus}`

--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -199,7 +199,7 @@ class MechWeapon extends MechEquipment {
 
   public get ProfileHeatCost(): number {
     const selfHeatTag = this.ProfileTags.find(x => x.IsHeatCost)
-    return selfHeatTag ? (selfHeatTag.Value as number) : 0
+    return Number(selfHeatTag ? selfHeatTag.Value : 0)
   }
 
   public get ProfileActions(): Action[] {

--- a/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
@@ -668,7 +668,7 @@ export default Vue.extend({
       }
     },
     overkill() {
-      if (this.item.Tags.some(x => x.IsOverkill)) return true
+      if (this.item.ProfileTags.some(x => x.IsOverkill)) return true
       if (this.item.Mod && this.item.Mod.AddedTags.some(x => x.IsOverkill)) return true
       return false
     },
@@ -713,23 +713,23 @@ export default Vue.extend({
       return Damage.CalculateDamage(this.item, this.mech)
     },
     isSmart() {
-      if (this.item.Tags.some(x => x.IsSmart)) return true
+      if (this.item.ProfileTags.some(x => x.IsSmart)) return true
       if (this.item.Mod && this.item.Mod.AddedTags.some(x => x.IsSmart)) return true
       return false
     },
     reliable() {
-      const r = this.item.Tags.find(x => x.ID === 'tg_reliable')
-      return r ? r.Value : 0
+      const r = this.item.ProfileTags.find(x => x.ID === 'tg_reliable')
+      return Number(r ? r.Value : 0)
     },
     minAccuracy() {
       let bonus = 0
-      if (this.item.Tags.some(x => x.ID === 'tg_accurate')) bonus += 1
+      if (this.item.ProfileTags.some(x => x.ID === 'tg_accurate')) bonus += 1
       if (this.item.Mod && this.item.Mod.AddedTags.some(x => x.ID === 'tg_accurate')) bonus += 1
       if (this.hardpoints) bonus += 1
       return bonus
     },
     minDifficulty() {
-      if (this.item.Tags.some(x => x.ID === 'tg_inaccurate')) return 1
+      if (this.item.ProfileTags.some(x => x.ID === 'tg_inaccurate')) return 1
       if (this.item.Mod && this.item.Mod.AddedTags.some(x => x.ID === 'tg_inaccurate')) return 1
       return 0
     },


### PR DESCRIPTION
# Description
This PR properly casts ProfileHeatCost as a `number` object.  It also changes Item.Tags references in `_WeaponAttack.vue` to Item.ProfileTags, so weapon profile tags are properly applied in Active Mode.

## Issue Number
Closes #1655

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)