### PR TITLE
fix(Pilot Sheet): remove SpeedBonus stat from PilotArmor

### DIFF
--- a/src/classes/pilot/PilotArmor.ts
+++ b/src/classes/pilot/PilotArmor.ts
@@ -5,7 +5,6 @@ import { Bonus } from '../Bonus'
 interface IPilotArmorData extends IPilotEquipmentData {
   hp_bonus?: number
   speed?: number
-  speed_bonus?: number
   armor?: number
   edef?: number
   edef_bonus?: number
@@ -16,7 +15,6 @@ interface IPilotArmorData extends IPilotEquipmentData {
 class PilotArmor extends PilotEquipment {
   public readonly HPBonus: string
   public readonly Speed: string
-  public readonly SpeedBonus: string
   public readonly Armor: string
   public readonly EDefense: string
   public readonly Evasion: string
@@ -25,7 +23,6 @@ class PilotArmor extends PilotEquipment {
     super(data, packTags, packName)
     this.HPBonus = Bonus.SumStatic(data, 'pilot_hp')
     this.Speed = Bonus.SumStatic(data, 'pilot_speed')
-    this.SpeedBonus = Bonus.SumStatic(data, 'pilot_evasion')
     this.Armor = Bonus.SumStatic(data, 'pilot_armor')
     this.EDefense = Bonus.SumStatic(data, 'pilot_edef')
     this.Evasion = Bonus.SumStatic(data, 'pilot_evasion')

--- a/src/features/pilot_management/Print/PilotPrint.vue
+++ b/src/features/pilot_management/Print/PilotPrint.vue
@@ -193,9 +193,9 @@
             class="pa-1 mt-n2"
             v-html="
               `+${a.Armor || 0} Armor / E-Def: ${a.EDefense || 'N/A'} / Evasion: ${a.Evasion ||
-                'N/A'}${a.HPBonus ? ` HP Bonus: +${a.HPBonus}` : ''}${
-                a.Speed ? ` Speed: ${a.Speed}` : ''
-              }${a.SpeedBonus ? ` Speed Bonus: +${a.SpeedBonus}` : ''}`
+                'N/A'}<br>${a.HPBonus ? `HP Bonus: +${a.HPBonus}` : ''}${
+                a.Speed ? ` / Speed: ${a.Speed}` : ''
+              }`
             "
           />
         </fieldset>


### PR DESCRIPTION
# Description
Removes the Speed Bonus stat from PilotArmor, as it appears to be a deprecated statistic that will be accounted for within the armor's Speed stat calculation.  Removes reference to the stat from Print mode, and makes slight formatting adjustments for readability.

## Issue Number
Closes  #1624

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)