### PR TITLE
Remaining LCP indicators

### DIFF
--- a/src/classes/ContentPack.ts
+++ b/src/classes/ContentPack.ts
@@ -272,7 +272,7 @@ export class ContentPack {
         else if (x.type.toLowerCase() === 'reaction') return new NpcReaction(x as INpcReactionData,self._manifest.name)
         else if (x.type.toLowerCase() === 'trait') return new NpcTrait(x,self._manifest.name)
         else if (x.type.toLowerCase() === 'system') return new NpcSystem(x as INpcSystemData,self._manifest.name)
-        return new NpcTech(x as INpcTechData)
+        return new NpcTech(x as INpcTechData,self._manifest.name)
       }) || []
     self._NpcClasses = self._data.npcClasses?.map(x => new NpcClass(x,self._manifest.name)) || []
     self._NpcTemplates = self._data.npcTemplates?.map(x => new NpcTemplate(x,self._manifest.name)) || []

--- a/src/classes/ContentPack.ts
+++ b/src/classes/ContentPack.ts
@@ -268,14 +268,14 @@ export class ContentPack {
 
     self._NpcFeatures =
       self._data.npcFeatures?.map(function(x) {
-        if (x.type.toLowerCase() === 'weapon') return new NpcWeapon(x as INpcWeaponData)
-        else if (x.type.toLowerCase() === 'reaction') return new NpcReaction(x as INpcReactionData)
-        else if (x.type.toLowerCase() === 'trait') return new NpcTrait(x)
-        else if (x.type.toLowerCase() === 'system') return new NpcSystem(x as INpcSystemData)
+        if (x.type.toLowerCase() === 'weapon') return new NpcWeapon(x as INpcWeaponData,self._manifest.name)
+        else if (x.type.toLowerCase() === 'reaction') return new NpcReaction(x as INpcReactionData,self._manifest.name)
+        else if (x.type.toLowerCase() === 'trait') return new NpcTrait(x,self._manifest.name)
+        else if (x.type.toLowerCase() === 'system') return new NpcSystem(x as INpcSystemData,self._manifest.name)
         return new NpcTech(x as INpcTechData)
       }) || []
-    self._NpcClasses = self._data.npcClasses?.map(x => new NpcClass(x)) || []
-    self._NpcTemplates = self._data.npcTemplates?.map(x => new NpcTemplate(x)) || []
+    self._NpcClasses = self._data.npcClasses?.map(x => new NpcClass(x,self._manifest.name)) || []
+    self._NpcTemplates = self._data.npcTemplates?.map(x => new NpcTemplate(x,self._manifest.name)) || []
 
     self._PlayerActions = self._data.actions?.map(
       (x: PlayerAction.IActionData) => new PlayerAction.Action(x)

--- a/src/classes/npc/NpcClass.ts
+++ b/src/classes/npc/NpcClass.ts
@@ -15,6 +15,8 @@ export interface INpcClassData {
 }
 
 export class NpcClass {
+  public readonly LcpName: string
+  public readonly InLcp: boolean
   private _id: string
   private _name: string
   private _role: string
@@ -28,7 +30,7 @@ export class NpcClass {
   private _power: number
   private _brew: string
 
-  public constructor(data: INpcClassData) {
+  public constructor(data: INpcClassData, packName?: string) {
     this._id = data.id
     this._name = data.name
     this._role = data.role
@@ -38,6 +40,8 @@ export class NpcClass {
     this._base_features = data.base_features
     this._optional_features = data.optional_features
     this._brew = data.brew || 'CORE'
+    this.LcpName = packName || 'Lancer CORE NPCs'
+    this.InLcp = this.LcpName != 'Lancer CORE NPCs' ? true : false
   }
 
   public get ID(): string {

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -41,8 +41,10 @@ export abstract class NpcFeature {
   private _hide_active: boolean
   protected type: NpcFeatureType
   public IsHidden: boolean
+  public readonly LcpName: string
+  public readonly InLcp: boolean
 
-  public constructor(data: INpcFeatureData) {
+  public constructor(data: INpcFeatureData, packName?: string) {
     this._id = data.id
     this._name = data.name
     this._origin = data.origin
@@ -53,6 +55,8 @@ export abstract class NpcFeature {
     this._tags = data.tags
     this._brew = data.brew || 'CORE'
     this._hide_active = data.hide_active || false
+    this.LcpName = packName || 'Lancer CORE NPCs'
+    this.InLcp = this.LcpName != 'Lancer CORE NPCs' ? true : false
   }
 
   public get ID(): string {

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -9,8 +9,8 @@ export interface INpcReactionData extends INpcFeatureData {
 export class NpcReaction extends NpcFeature {
   private _trigger: string
 
-  public constructor(data: INpcReactionData) {
-    super(data)
+  public constructor(data: INpcReactionData, packName?: string) {
+    super(data, packName)
     this._trigger = data.trigger || ''
     this.type = NpcFeatureType.Reaction
   }

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -6,8 +6,8 @@ export interface INpcSystemData extends INpcFeatureData {
 }
 
 export class NpcSystem extends NpcFeature {
-  public constructor(data: INpcSystemData) {
-    super(data)
+  public constructor(data: INpcSystemData, packName?: string) {
+    super(data, packName)
     this.type = NpcFeatureType.System
   }
 

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -14,8 +14,8 @@ export class NpcTech extends NpcFeature {
   private _accuracy: number[]
   private _attack_bonus: number[]
 
-  public constructor(data: INpcTechData) {
-    super(data)
+  public constructor(data: INpcTechData, packName?: string) {
+    super(data, packName)
     this._tech_type = data.tech_type
     this._accuracy = data.accuracy || [0, 0, 0]
     this._attack_bonus = data.attack_bonus || [0, 0, 0]

--- a/src/classes/npc/NpcTemplate.ts
+++ b/src/classes/npc/NpcTemplate.ts
@@ -19,8 +19,10 @@ export class NpcTemplate {
   private _optional_features: string[]
   private _power: number
   private _brew: string
+  public readonly LcpName: string
+  public readonly InLcp: boolean
 
-  public constructor(data: INpcTemplateData) {
+  public constructor(data: INpcTemplateData, packName?: string) {
     this._id = data.id
     this._name = data.name
     this._description = data.description
@@ -28,6 +30,8 @@ export class NpcTemplate {
     this._optional_features = data.optional_features
     this._power = data.power
     this._brew = data.brew || 'CORE'
+    this.LcpName = packName || 'Lancer CORE NPCs'
+    this.InLcp = this.LcpName != 'Lancer CORE NPCs' ? true : false
   }
 
   public get ID(): string {

--- a/src/classes/npc/NpcTrait.ts
+++ b/src/classes/npc/NpcTrait.ts
@@ -2,8 +2,8 @@ import { NpcFeature, NpcFeatureType } from './'
 import { INpcFeatureData } from './interfaces'
 
 export class NpcTrait extends NpcFeature {
-  public constructor(data: INpcFeatureData) {
-    super(data)
+  public constructor(data: INpcFeatureData, packName?: string) {
+    super(data, packName)
     this.type = NpcFeatureType.Trait
   }
 

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -28,8 +28,8 @@ export class NpcWeapon extends NpcFeature {
   private _attack_bonus: number[]
   private _on_hit?: string
 
-  public constructor(data: INpcWeaponData) {
-    super(data)
+  public constructor(data: INpcWeaponData, packName?: string) {
+    super(data, packName)
     this._on_hit = data.on_hit || ''
     this._weapon_type = data.weapon_type
     this._damage_data = data.damage

--- a/src/features/compendium/Views/NpcTemplates.vue
+++ b/src/features/compendium/Views/NpcTemplates.vue
@@ -21,6 +21,7 @@
     <v-row v-for="(e, i) in templates" :id="`e_${e.ID}`" :key="`${e.ID}_${i}`">
       <v-col class="pl-0">
         <cc-titled-panel dense icon="cci-trait" :title="e.Name" color="primary">
+          <div v-if="e.InLcp" class="heading h3 text--text">{{ e.LcpName }}</div>
           <p class="flavor-text mb-0" v-html-safe="e.Description" />
           <v-divider class="my-2" />
           <span class="heading">

--- a/src/features/encounters/npc/components/TemplateSelector.vue
+++ b/src/features/encounters/npc/components/TemplateSelector.vue
@@ -24,6 +24,7 @@
     <v-row v-for="(e, i) in availableTemplates" :id="`e_${e.ID}`" :key="`${e.ID}_${i}`">
       <v-col>
         <cc-titled-panel dense icon="cci-trait" :title="e.Name" color="primary">
+          <div v-if="e.InLcp" class="heading h3 text--text">{{ e.LcpName }}</div>
           <p class="flavor-text mb-0" v-html-safe="e.Description" />
           <v-divider class="my-2" />
           <span class="heading">

--- a/src/features/encounters/npc/new/ClassCard.vue
+++ b/src/features/encounters/npc/new/ClassCard.vue
@@ -6,6 +6,9 @@
           {{ npcc.Name }}
         </span>
       </v-col>
+      <v-col v-if="npcc.InLcp" class="ml-auto mt-n4"
+        <div class="heading h3 text--text">{{ npcc.LcpName }}</div>
+      </v-col>
       <v-col cols="auto" class="ml-auto text-center mt-n4">
         <v-icon size="60" :color="npcc.Color">{{ npcc.RoleIcon }}</v-icon>
         <div class="overline mt-n1">{{ npcc.Role }}</div>

--- a/src/ui/components/cards/_EquipmentCardBase.vue
+++ b/src/ui/components/cards/_EquipmentCardBase.vue
@@ -64,7 +64,7 @@
 
     <slot name="profile" />
 
-    <div v-if="item.Tags && item.Tags.length">
+    <div v-if="item.Tags && item.Tags.length" class="mt-2">
       <div class="overline ml-n2 mb-n1 subtle--text">EQUIPMENT TAGS</div>
       <cc-tags :tags="item.Tags" extended />
     </div>

--- a/src/ui/components/cards/_NpcReactionCard.vue
+++ b/src/ui/components/cards/_NpcReactionCard.vue
@@ -2,6 +2,7 @@
   <equipment-card-base :item="item">
     <v-col cols="auto" class="ml-auto text-right">
       <span class="flavor-text subtle--text">// {{ item.Origin }}</span>
+      <div v-if="item.InLcp" class="flavor-text subtle--text">{{ item.LcpName }}</div>
     </v-col>
     <div slot="statblock">
       <span class="overline ml-n2">TRIGGER</span>

--- a/src/ui/components/cards/_PilotArmorCard.vue
+++ b/src/ui/components/cards/_PilotArmorCard.vue
@@ -1,14 +1,19 @@
 <template>
   <equipment-card-base :item="item">
-    <v-container slot="statblock" grid-list-md class="mt-0 pt-1">
-      <v-row dense justify="center">
-        <cc-statblock-panel icon="$vuetify.icons.armor" name="Armor" :value="armor" />
-        <cc-statblock-panel icon="$vuetify.icons.hp" name="HP Bonus" :value="`+${hp}`" />
-        <cc-statblock-panel icon="$vuetify.icons.edef" name="E-Defense" :value="edef" />
-        <cc-statblock-panel icon="$vuetify.icons.evasion" name="Evasion" :value="evasion" />
-        <cc-statblock-panel icon="$vuetify.icons.speed" name="Speed" :value="speed" />
-      </v-row>
-    </v-container>
+    <v-row v-if="item.InLcp">
+      <div class="heading h3 text-text" >{{ item.LcpName }}</div>
+    </v-row>
+    <v-row>
+      <v-container slot="statblock" grid-list-md class="mt-0 pt-1">
+        <v-row dense justify="center">
+          <cc-statblock-panel icon="$vuetify.icons.armor" name="Armor" :value="armor" />
+          <cc-statblock-panel icon="$vuetify.icons.hp" name="HP Bonus" :value="`+${hp}`" />
+          <cc-statblock-panel icon="$vuetify.icons.edef" name="E-Defense" :value="edef" />
+          <cc-statblock-panel icon="$vuetify.icons.evasion" name="Evasion" :value="evasion" />
+          <cc-statblock-panel icon="$vuetify.icons.speed" name="Speed" :value="speed" />
+        </v-row>
+      </v-container>
+    </v-row>
   </equipment-card-base>
 </template>
 

--- a/src/ui/components/cards/_PilotGearCard.vue
+++ b/src/ui/components/cards/_PilotGearCard.vue
@@ -1,5 +1,9 @@
 <template>
-  <equipment-card-base :item="item" />
+  <equipment-card-base :item="item">
+    <v-row v-if="item.InLcp">
+      <div class="heading h3 text-text" >{{ item.LcpName }}</div>
+    </v-row>
+  </equipment-card-base>
 </template>
 
 <script lang="ts">

--- a/src/ui/components/cards/_PilotWeaponCard.vue
+++ b/src/ui/components/cards/_PilotWeaponCard.vue
@@ -7,6 +7,9 @@
     <v-col cols="auto">
       <cc-damage-element :damage="item.Damage" :type-override="item.DamageTypeOverride" />
     </v-col>
+    <v-col v-if="item.InLcp" cols="auto" class="ml-auto text-right">
+        <div class="heading h3 text-text" >{{ item.LcpName }}</div>
+    </v-col>
   </equipment-card-base>
 </template>
 

--- a/src/ui/components/items/CCCoreBonusItem.vue
+++ b/src/ui/components/items/CCCoreBonusItem.vue
@@ -1,6 +1,11 @@
 <template>
   <cc-titled-panel :title="bonus.Name" dense>
     <p
+      v-if="bonus.InLcp"
+      class="stat--text heading h3"
+      v-html-safe="bonus.LcpName"
+    />
+    <p
       v-show="$vuetify.breakpoint.mdAndUp"
       class="flavor-text pb-0 mb-2 mt-0"
       v-html-safe="bonus.Description"


### PR DESCRIPTION
# Description

This change should display the origin ( if not originating from the Lancer CORE material, including the CORE Npc lcp ) for the following items:
Player Core Bonuses
Pilot Gear
Pilot Armor
Pilot Weapons
Npc Classes
Npc Features ( Systems, Weapons, Tech, Reactions )
Npc Templates

This should conclude the series of changes that I started a while ago.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
