### PR TITLE
fix(Mech Sheet): handle mechs with frame sizes greater than 3

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -252,10 +252,10 @@ class Mech implements IActor {
   }
 
   public get Size(): number {
-    let size = Bonus.Int(this._frame.Size, 'size', this)
+    let size = this._frame.Size >= Rules.MaxFrameSize ? this._frame.Size : Bonus.Int(this._frame.Size, 'size', this)
     if (size < 0.5) size = 0.5
     if (size > 0.5 && size % 1 !== 0) size = Math.floor(size)
-    return size > Rules.MaxFrameSize ? Rules.MaxFrameSize : size
+    return size
   }
 
   public get SizeContributors(): string[] {


### PR DESCRIPTION
# Description
This change modifies the logic behind a Mech's size calculation.  It returns the size of the mech's
Frame, unaltered, if the Frame's size already equals or exceeds the max frame size set by the rules.
Otherwise, it includes any bonuses to the mech's size, as normal.  This primarily benefits any
homebrew content making Size 4 frames.

## Issue Number
Closes #1682

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)