### PR TITLE
style(Compendium): prevent overcropping License frame art

### DIFF
--- a/src/features/compendium/Views/Licenses.vue
+++ b/src/features/compendium/Views/Licenses.vue
@@ -47,7 +47,7 @@
                 :id="$vuetify.breakpoint.mdAndDown ? 'img-mobile' : 'img-hover'"
                 :src="frame(l.FrameID).DefaultImage"
                 max-height="100%"
-                :position="`top ${frame(l.FrameID).YPosition}% left 20vw`"
+                :position="`top ${frame(l.FrameID).YPosition}% left 80px`"
                 style="position:absolute; top: 0; right: 0;"
               />
             </v-expansion-panel-header>


### PR DESCRIPTION
# Description
This change increases visibility of the frame art in the License Compendium.  Prior to this,
expanding the viewable window led to a larger right-side cropping of the frame art.  While the
license banner loses some balance as a result, it will lead to fewer "weird" crops of the frames'
art.

NOTE: This PR was made primarily due to a somewhat unflattering crop of the Mourning Cloak's art in the License page of the Compendium.  If the previous style is desired, an alternative fix could be to mirror the Mourning Cloak's art so that its head is facing leftwards instead.  That said, the cropping issue could still affect other frames' art, regardless of where the frame creator positions the image in the banner.

## Issue Number
Closes #1690

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
