### PR TITLE
fix(Mech Sheet): unequip Flex Aux Equips on Main Equip

### DIFF
--- a/src/classes/mech/Mount.ts
+++ b/src/classes/mech/Mount.ts
@@ -64,13 +64,18 @@ abstract class Mount {
 
   public get Slots(): WeaponSlot[] {
     if (!this.slots[0]) this.generateSlots(this.Type)
-    if (
-      this.Type == MountType.Flex &&
-      this.slots[0].Weapon &&
-      this.slots[0].Weapon.Size === WeaponSize.Aux &&
-      this._name_override !== 'Retrofitted Mount'
-    )
-      return this.slots.concat(this.extra)
+    const isFlex = this.Type == MountType.Flex && this._name_override !== 'Retrofitted Mount'
+
+    if (isFlex) {
+      if (
+        this.slots[0].Weapon?.Size === WeaponSize.Aux ||
+        (!this.slots[0].Weapon && this.extra[0].Weapon)
+      ) {
+        return this.slots.concat(this.extra)
+      } else if (this.slots[0].Weapon?.Size === WeaponSize.Main) {
+        this.extra[0].UnequipWeapon()
+      }
+    }
     return this.slots
   }
 


### PR DESCRIPTION
# Description
This change unequips the extra auxiliary weapon on a Flex mount when a Main weapon is equipped to the primary slot.  If the primary slot is empty, any equipped extra auxiliary weapon remains equipped and visible.  This primarily benefits any external user or application processing pilot data imported from Comp/Con (e.g. FoundryVTT-Lancer).

## Issue Number
Closes #1692

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
