### PR TITLE
fix(Pilot Sheet): update login status at nav level

### DIFF
--- a/src/features/nav/index.vue
+++ b/src/features/nav/index.vue
@@ -62,13 +62,13 @@
     </div>
 
     <v-divider
-      v-if="$vuetify.breakpoint.mdAndUp && currentAuthedUser"
+      v-if="$vuetify.breakpoint.mdAndUp && isAuthed"
       vertical
       dark
       class="ml-2 mr-2"
     />
 
-    <cc-tooltip v-if="currentAuthedUser" bottom :content="syncTooltip">
+    <cc-tooltip v-if="isAuthed" bottom :content="syncTooltip">
       <v-btn icon dark :style="`opacity: ${unsaved.length ? '1' : '0.4'}`" @click="sync()">
         <v-icon>mdi-cloud-sync-outline</v-icon>
       </v-btn>
@@ -180,6 +180,9 @@ export default vueMixins(activePilot).extend({
     },
     unsaved() {
       return getModule(PilotManagementStore, this.$store).unsavedCloudPilots
+    },
+    isAuthed() {
+      return getModule(UserStore, this.$store).IsLoggedIn
     },
     syncTooltip(): string {
       if (!this.unsaved.length) return 'Pilot data synced'


### PR DESCRIPTION
# Description
This change computes the user's login status at the nav level instead of using the login status
retained since the initial mount. This means that elements like the Cloud Sync icon will properly
show/hide depending on the current login status of the browser without requiring a refresh. As a
result, manual syncing while logged in will be easier, and those who are logged out will not get
confused by a nonfunctional sync button.

## Issue Number
Closes #1667

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
