### PR TITLE
fix(Pilot Sheet): improve Vault Code UX

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import _ from 'lodash'
 import uuid from 'uuid/v4'
 import {
@@ -234,7 +235,7 @@ class Pilot implements ICloudSyncable {
   }
 
   public get ShareCode(): string {
-    if (!this.ResourceURI || !this.CloudOwnerID) return 'ERR'
+    if (!this.ResourceURI || !this.CloudOwnerID) return 'ERR: PERFORM MANUAL SYNC AND RETRY'
     return `${this.CloudOwnerID.split(':')[1]}//${this.ResourceURI.split('/')[1]}`
   }
 
@@ -413,9 +414,10 @@ class Pilot implements ICloudSyncable {
 
   public SetOwnedResource(userCognitoId: string): void {
     console.log('pilot call, set owned resource')
-    this.CloudID = this.ID
-    this.CloudOwnerID = userCognitoId
+    Vue.set(this, 'CloudID', this.ID)
+    Vue.set(this, 'CloudOwnerID', userCognitoId)
     this.IsLocallyOwned = true
+    this.save()
   }
 
   public get CloudImage(): string {

--- a/src/features/pilot_management/PilotSheet/components/PilotEditMenu.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotEditMenu.vue
@@ -43,14 +43,14 @@
             </v-list-item-subtitle>
           </v-list-item-content>
         </v-list-item>
-        <v-list-item @click="$refs.vaultDialog.show()">
+        <v-list-item :disabled="!currentAuthedUser" @click="$refs.vaultDialog.show()">
           <v-list-item-icon class="ma-0 mr-2 mt-3">
             <v-icon>mdi-database</v-icon>
           </v-list-item-icon>
           <v-list-item-content>
             <v-list-item-title>COMP/CON Vault Record</v-list-item-title>
             <v-list-item-subtitle>
-              Share this pilot's synced data with other users via your COMP/CON account.
+              Share this pilot's synced data with other users. Requires COMP/CON account.
             </v-list-item-subtitle>
           </v-list-item-content>
         </v-list-item>
@@ -127,6 +127,8 @@ import DeleteDialog from './DeletePilotDialog.vue'
 import { getModule } from 'vuex-module-decorators'
 import { PilotManagementStore } from '@/store'
 
+import { Auth } from 'aws-amplify'
+
 export default Vue.extend({
   name: 'edit-menu',
   components: {
@@ -151,6 +153,14 @@ export default Vue.extend({
     dense: {
       type: Boolean,
     },
+  },
+  data: () => ({
+    currentAuthedUser: null
+  }),
+  async mounted() {
+    await Auth.currentAuthenticatedUser().then(res => {
+      this.currentAuthedUser = !!res.username
+    })
   },
   methods: {
     deletePilot() {

--- a/src/features/pilot_management/PilotSheet/components/VaultDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/VaultDialog.vue
@@ -24,7 +24,7 @@
           <div class="text-center">
             <div class="overline">THIS PILOT'S VAULT CODE IS</div>
             <div class="heading h3 primary--text">
-              {{ pilot.ShareCode }}
+              {{ getShareCode }}
               <cc-tooltip simple inline content="Copy Vault Code to clipboard">
                 <v-icon :color="copyConfirm ? 'success' : 'grey'" @click="copyCode()">
                   {{ copyConfirm ? 'mdi-check-outline' : 'mdi-clipboard-text-outline' }}
@@ -84,6 +84,11 @@ export default Vue.extend({
     syncing: false,
     copyConfirm: false,
   }),
+  computed: {
+    getShareCode() {
+      return this.pilot.ShareCode
+    }
+  },
   methods: {
     show() {
       this.$refs.dialog.show()
@@ -94,7 +99,7 @@ export default Vue.extend({
     async copyCode() {
       this.copyConfirm = true
 
-      navigator.clipboard.writeText(this.pilot.ShareCode).then(
+      navigator.clipboard.writeText(this.getShareCode).then(
         function () {
           Vue.prototype.$notify('Cloud ID copied to clipboard.', 'confirmation')
         },


### PR DESCRIPTION
# Description
This change aims to streamline the process of acquiring a pilot's vault code. It does so by limiting Vault Code access to when the user is logged in, improving messaging when a pilot has yet to sync, and detecting/updating a pilot's cloud ID information once a sync has occurred.

## Issue Number
Closes #1664

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
