### PR TITLE
fix(Mech Sheet): save ActiveMech when mech is activated

### DIFF
--- a/src/classes/mech/ActiveState.ts
+++ b/src/classes/mech/ActiveState.ts
@@ -407,6 +407,7 @@ class ActiveState {
     } else {
       this._remoteMech = mech
     }
+    this.save()
   }
 
   public get ActiveMech(): Mech | null {

--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -185,7 +185,7 @@ class Mech implements IActor {
   }
 
   public get IsActive(): boolean {
-    return this.Pilot.State.ActiveMech && this.Pilot.State.ActiveMech.ID === this.ID
+    return this.Pilot.State.ActiveMech?.ID === this.ID
   }
 
   public get IsCascading(): boolean {

--- a/src/features/pilot_management/PilotSheet/sections/hangar/components/MechListItem.vue
+++ b/src/features/pilot_management/PilotSheet/sections/hangar/components/MechListItem.vue
@@ -72,7 +72,7 @@
                     icon
                     class="fadeSelect"
                     :disabled="mech.Pilot.ActiveMech === mech"
-                    @click.stop="mech.Pilot.ActiveMech = mech"
+                    @click.stop="mech.Pilot.State.ActiveMech = mech"
                   >
                     <v-icon>cci-activate</v-icon>
                   </v-btn>


### PR DESCRIPTION
# Description
This change ensures that a pilot's ActiveState updates its ActiveMech upon setting a new ActiveMech by calling `save()` after setting the mech.

## Issue Number
Closes #1659

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
