### PR TITLE
feat(Pilot Sheet): allow skipping pilot creation

### DIFF
--- a/src/features/pilot_management/New/pages/ConfirmPage.vue
+++ b/src/features/pilot_management/New/pages/ConfirmPage.vue
@@ -7,22 +7,7 @@
     @back="$emit('back')"
   >
     <pilot-registration-card :pilot="pilot" :pilot-ready="pilotReady" />
-    <v-btn
-      :x-large="$vuetify.breakpoint.mdAndUp"
-      block
-      :disabled="!pilotReady"
-      color="secondary"
-      tile
-      class="mx-2 my-8"
-      @click="savePilot()"
-    >
-      <span v-if="$vuetify.breakpoint.mdAndUp">
-        Register New Pilot // {{ pilot.Callsign || 'ERR CALLSIGN NOT FOUND' }} ({{
-          pilot.Name || 'ERR NAME NOT FOUND'
-        }})
-      </span>
-      <span v-else>Register Pilot</span>
-    </v-btn>
+    <br />
     <v-alert type="error" outlined :value="!pilotReady">
       <span class="stat-text accent--text">
         WARNING: IDENT record {{ pilot.ID }} cannot be generated due to the following reason(s):
@@ -35,6 +20,23 @@
         <li v-if="!pilot.HasFullHASE">PILOT MECH SKILLS missing or incomplete</li>
       </ul>
     </v-alert>
+    <v-btn
+      :x-large="$vuetify.breakpoint.mdAndUp"
+      block
+      color="secondary"
+      tile
+      :class="pilotReady ? 'mx-2 my-8' : 'mx-2 my-8 v-btn--disabled'"
+      style="pointer-events: inherit"
+      enabled
+      @click="savePilot()"
+    >
+      <span v-if="$vuetify.breakpoint.mdAndUp" :class="!pilotReady ? 'horus--subtle' : ''">
+        Register New Pilot // {{ pilot.Callsign || 'ERR CALLSIGN NOT FOUND' }} ({{
+          pilot.Name || 'ERR NAME NOT FOUND'
+        }})
+      </span>
+      <span v-else>Register Pilot</span>
+    </v-btn>
   </cc-stepper-content>
 </template>
 
@@ -67,6 +69,8 @@ export default Vue.extend({
     savePilot() {
       this.pilot.cc_ver = Vue.prototype.version
       const store = getModule(PilotManagementStore, this.$store)
+      this.pilot.Callsign = this.pilot.Callsign ? this.pilot.Callsign : 'ERR CALLSIGN NOT FOUND'
+      this.pilot.Name = this.pilot.Name ? this.pilot.Name : 'ERR NAME NOT FOUND'
       store.addPilot({ pilot: this.pilot, update: true })
       this.$emit('done')
     },


### PR DESCRIPTION
# Description
This PR subtly enables the creation of a new pilot even when missing parameters from earlier in the wizard.  It assigns a default name and callsign for ease of reading.  This approach leans on the subtle side to encourage users to follow the wizard, but still allows experienced users to quickly skip the pilot creation wizard, register a new pilot, and directly edit that pilot in Pilot Management.

In the linked issue, I had previously checked that it was possible to assign an empty string to a Pilot Name or Callsign, and that it did not seem to break anything in-app save for a harmless default check when editing the Name field.  Regardless, I assigned a default value for Name and Callsign when left empty, if only so it wouldn't appear a less informative error had occurred for a given pilot.  Feedback on default name or callsign is welcome.

I took some liberty with the styling: I deliberately tried to make the "Register New Pilot" button appear disabled when `pilotReady` was false, except for the `horus--subtle` effect to indicate that otherwise.  This honestly may be *too* subtle; I'm happy to receive feedback on styling if a clearer approach would be preferable.

## Issue Number
Closes #1687

## Type of change
- [x] New feature (non-breaking change which adds functionality)
