### PR TITLE
fix(Mech Sheet): always clear Superheavy bracing, empty braced slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "A digital toolkit for the LANCER TTRPG",
   "license": "GPL-3.0-or-later",
   "author": "Massif Press",
-  "engines": {
-    "node": "10.15.0"
-  },
   "scripts": {
     "build": "webpack --env.platform=web --env.prod --max_old_space_size=4096",
     "dev": "webpack-dev-server --progress --env.platform=web",

--- a/src/classes/mech/EquippableMount.ts
+++ b/src/classes/mech/EquippableMount.ts
@@ -13,7 +13,7 @@ class EquippableMount extends Mount {
   public Lock(target?: Mount): void {
     this.lock = true
     this._lock_target = target
-    this.save()
+    this.Clear()
   }
 
   public Unlock(): void {

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
@@ -262,6 +262,8 @@ export default Vue.extend({
       this.$refs.lockDialog.show()
     },
     finalizeSuperheavy(lockTarget: EquippableMount) {
+      if (this.item && this.item.Size === WeaponSize.Superheavy)
+        this.mech.ActiveLoadout.UnequipSuperheavy()
       lockTarget.Lock(this.mount)
       this.weaponSlot.EquipWeapon(this.stagedSH, this.mech.Pilot)
       this.$refs.lockDialog.hide()


### PR DESCRIPTION
# Description
This change ensures that a previously-equipped Superheavy weapon's braced mount will always clear prior to equipping a new weapon, even if the new weapon is also Superheavy.  This change also clears the weapon slots of locked mounts, to prevent the locked weapons from importing to 3rd-party sites or users (like FoundryVTT).

## Issue Number
Closes #1719 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)