### PR TITLE
fix(Active Mode): limited uses initialize to correct maximum

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -244,7 +244,7 @@ class Statblock {
 [ SYSTEMS ]
   ${mechLoadout.Systems.map(sys => {
     let out = sys.TrueName
-    if (sys.IsLimited) out += ` x${sys.MaxUses + mech.LimitedBonus}`
+    if (sys.IsLimited) out += ` x${sys.getTotalUses(mech.LimitedBonus)}`
     return out
   }).join(', ')}`
   }

--- a/src/classes/mech/MechEquipment.ts
+++ b/src/classes/mech/MechEquipment.ts
@@ -61,8 +61,10 @@ abstract class MechEquipment extends LicensedItem {
       this.IsOrdnance = data.tags.some(x => x.id === 'tg_ordnance')
       this.CanSetDamage = data.tags.some(x => x.id === 'tg_set_damage_type')
       this.CanSetUses = data.tags.some(x => x.id === 'tg_set_max_uses')
+      this.max_use_override = this.CanSetUses ? 0 : null
     } else {
       this._max_uses = 0
+      this.max_use_override = null
     }
     this._missing_uses = 0
     this.Ammo = data.ammo || []
@@ -72,10 +74,8 @@ abstract class MechEquipment extends LicensedItem {
   }
 
   public Use(cost?: number, free?: boolean): void {
-    if (!free) {
-      if (!this.CheckUsable(cost)) return
-      this._used = true
-    }
+    if (!this.CheckUsable(cost)) return
+    if (!free) this._used = true
     if (this.IsLoading) this._loaded = false
     if (this.IsLimited && cost) this.Uses -= cost
   }
@@ -167,12 +167,12 @@ abstract class MechEquipment extends LicensedItem {
   }
 
   public get MaxUses(): number {
-    return this.max_use_override ? this.max_use_override : this._max_uses
+    return this.max_use_override !== null ? this.max_use_override : this._max_uses
   }
 
   public getTotalUses(bonus?: number): number {
     const b = bonus ? bonus : 0
-    return this.MaxUses + b
+    return this.max_use_override !== null ? this.max_use_override : this._max_uses + b
   }
 }
 

--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -124,7 +124,6 @@ class MechWeapon extends MechEquipment {
     this._selected_profile = 0
     this._mod = null
     this.ItemType = ItemType.MechWeapon
-    this.max_use_override = 0
     this._custom_damage_type = null
   }
 
@@ -290,7 +289,7 @@ class MechWeapon extends MechEquipment {
       flavorName: item._flavor_name,
       flavorDescription: item._flavor_description,
       customDamageType: item._custom_damage_type || null,
-      maxUseOverride: MechWeapon.SanitizeUsesInput(item.max_use_override) || 0,
+      maxUseOverride: item.max_use_override !== null ? MechWeapon.SanitizeUsesInput(item.max_use_override) : null,
       uses: MechWeapon.SanitizeUsesInput(item.Uses) || 0,
       selectedProfile: item._selected_profile || 0,
     }
@@ -306,7 +305,7 @@ class MechWeapon extends MechEquipment {
     item._flavor_name = data.flavorName
     item._flavor_description = data.flavorDescription
     item._custom_damage_type = data.customDamageType || null
-    item.max_use_override = MechWeapon.SanitizeUsesInput(data.maxUseOverride) || 0
+    item.max_use_override = data.maxUseOverride !== null ? MechWeapon.SanitizeUsesInput(data.maxUseOverride) : null
     item.Uses = MechWeapon.SanitizeUsesInput(data.uses) || 0
     item._selected_profile = data.selectedProfile || 0
     return item

--- a/src/classes/pilot/PilotEquipment.ts
+++ b/src/classes/pilot/PilotEquipment.ts
@@ -51,8 +51,10 @@ abstract class PilotEquipment extends CompendiumItem {
       this.IsOrdnance = data.tags.some(x => x.id === 'tg_ordnance')
       this.CanSetDamage = data.tags.some(x => x.id === 'tg_set_damage_type')
       this.CanSetUses = data.tags.some(x => x.id === 'tg_set_max_uses')
+      this.max_use_override = this.CanSetUses ? 0 : null
     } else {
       this._max_uses = 0
+      this.max_use_override = null
     }
     this._missing_uses = 0
   }
@@ -151,12 +153,12 @@ abstract class PilotEquipment extends CompendiumItem {
   }
 
   public get MaxUses(): number {
-    return this.max_use_override ? this.max_use_override : this._max_uses
+    return this.max_use_override !== null ? this.max_use_override : this._max_uses
   }
 
   public getTotalUses(bonus?: number): number {
     const b = bonus ? bonus : 0
-    return this.MaxUses + b
+    return this.max_use_override !== null ? this.max_use_override : this._max_uses + b
   }
 
   public static Serialize(item: PilotEquipment | null): IEquipmentData | null {

--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -258,7 +258,7 @@
           <v-spacer />
           <span v-if="w.Uses">
             <v-icon
-              v-for="n in w.MaxUses + mech.Pilot.LimitedBonus"
+              v-for="n in w.getTotalUses(mech.Pilot.LimitedBonus)"
               :key="`use_${w.ID}_${n}`"
               small
             >
@@ -302,7 +302,7 @@
           <v-spacer />
           <span v-if="s.Uses">
             <v-icon
-              v-for="n in s.MaxUses + mech.Pilot.LimitedBonus"
+              v-for="n in s.getTotalUses(mech.Pilot.LimitedBonus)"
               :key="`use_${s.ID}_${n}`"
               small
             >

--- a/src/ui/components/CCItemUses.vue
+++ b/src/ui/components/CCItemUses.vue
@@ -44,7 +44,7 @@ export default class CCItemUses extends Vue {
     return this.item.getTotalUses(this.bonus)
   }
   get current(): number {
-    return this.max - this.item.MissingUses
+    return this.item.Uses
   }
 
   set(val): void {

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -121,7 +121,7 @@ export default Vue.extend({
         this.displayLog = this.action.AnyUsed
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this
-        this.$emit('use')
+        this.$emit('use', free)
         Vue.nextTick().then(() => self.$forceUpdate())
       }
     },

--- a/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentHeader.vue
@@ -9,7 +9,7 @@
     </v-col>
     <v-col v-if="item.IsLimited" cols="auto" class="mx-2">
       <cc-item-uses :item="item" :bonus="useBonus" :color="color" class="d-inline" />
-      <span class="overline">({{ item.getTotalUses(useBonus) - item.MissingUses }}/{{ item.getTotalUses(useBonus) }}) USES</span>
+      <span class="overline">({{ item.Uses }}/{{ item.getTotalUses(useBonus) }}) USES</span>
     </v-col>
     <v-col v-if="item.IsLoading && readonly" cols="auto" class="ma-1">
       <v-btn


### PR DESCRIPTION
# Description
This change retools how Max Uses and Total Limited Uses are calculated and presented in Active mode
to ensure that a mech has the correct number of limited uses at the start of a mission.  It changes
the logic behind Max Use Override so that bonuses must be manually included in the override. Lastly,
this includes a couple of other minor changes that polish some of the Limited Systems behaviors in
Active Mode.

## Issue Number
Closes #1708

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)