### PR TITLE
fix(Active Mode): reset self-destruct counter on repair, mech change

### DIFF
--- a/src/classes/mech/ActiveState.ts
+++ b/src/classes/mech/ActiveState.ts
@@ -348,7 +348,7 @@ class ActiveState {
     this._mission += 1
     this._stats = ActiveState.NewCombatStats()
     this._pilot.FullRestore()
-    this.ActiveMech.FullRepair()
+    this.RepairMech('full')
     this.SetLog({
       id: 'start_mission',
       event: 'MISSION.START',
@@ -398,7 +398,25 @@ class ActiveState {
 
   RepairDestroyed(selfRepairPts: number): void {
     this.ActiveMech.CurrentRepairs -= selfRepairPts
-    this.ActiveMech.Repair()
+    this.RepairMech()
+  }
+
+  RepairMech(repairType?: string): void {
+    this.CancelSelfDestruct()
+    switch (repairType) {
+      case 'full':
+        this.ActiveMech.FullRepair()
+        break
+      case 'basic_w_reactor':
+        this.ActiveMech.BasicRepair(true)
+        break
+      case 'basic_wo_reactor':
+        this.ActiveMech.BasicRepair(false)
+        break
+      default:
+        this.ActiveMech.Repair()
+        break
+    }
   }
 
   public set ActiveMech(mech: Mech | null) {
@@ -679,7 +697,7 @@ class ActiveState {
   }
 
   public CommitFullRepair() {
-    this.ActiveMech.FullRepair()
+    this.RepairMech('full')
     this.SetLog({
       id: `full_repair`,
       event: 'FULL REPAIR',

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -995,6 +995,11 @@ class Pilot implements ICloudSyncable {
     return this._state.ActiveMech
   }
 
+  public set ActiveMech(mech: Mech | null) {
+    this._state = new ActiveState(this)
+    this._state.ActiveMech = mech
+  }
+
   // -- COUNTERS ----------------------------------------------------------------------------------
 
   private _counterSaveData = []

--- a/src/features/encounters/mission/runner/PilotSelector.vue
+++ b/src/features/encounters/mission/runner/PilotSelector.vue
@@ -31,7 +31,7 @@
                 <v-list-item
                   v-for="mech in p.Mechs"
                   :key="`mech-select-${mech.ID}`"
-                  @click="p.State.ActiveMech = mech"
+                  @click="p.ActiveMech = mech"
                 >
                   <v-list-item-icon class="ma-0 mr-2 mt-3">
                     <cc-logo size="large" :source="mech.Frame.Manufacturer" />

--- a/src/features/pilot_management/ActiveSheet/components/DestroyedAlert.vue
+++ b/src/features/pilot_management/ActiveSheet/components/DestroyedAlert.vue
@@ -31,7 +31,7 @@
         v-if="!mech.ReactorDestroyed"
         content="Certain actions and equipment allow for battlefield repairs. Clicking here will restore your mech to 1 Structure Point and 1 HP."
       >
-        <v-btn x-small color="primary" class="fadeSelect" @click="$emit('restore', false)">
+        <v-btn x-small color="primary" class="fadeSelect" @click="restore(false)">
           <v-icon small left>cci-repair</v-icon>
           REPAIR
         </v-btn>
@@ -40,7 +40,7 @@
         v-else-if="mech.ReactorDestroyed"
         content="Revert this state and restore your mech to 1 Structure Point and 1 HP."
       >
-        <v-btn x-small color="primary" class="fadeSelect" @click="$emit('restore', true)">
+        <v-btn x-small color="primary" class="fadeSelect" @click="restore(true)">
           <v-icon small left>mdi-reload</v-icon>
           RESTORE
         </v-btn>
@@ -59,5 +59,11 @@ export default Vue.extend({
       required: true,
     },
   },
+  methods: {
+    restore(restoreReactor: boolean): void {
+      this.mech.Pilot.State.CancelSelfDestruct()
+      this.$emit('restore', restoreReactor)
+    }
+  }
 })
 </script>

--- a/src/features/pilot_management/ActiveSheet/layout/footers/NarrativeFooter.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/footers/NarrativeFooter.vue
@@ -65,7 +65,7 @@
                 <mech-select-button
                   v-if="pilot.Mechs.length"
                   :mechs="pilot.Mechs"
-                  @select="pilot.State.ActiveMech = $event"
+                  @select="pilot.ActiveMech = $event"
                 />
               </v-col>
             </v-row>

--- a/src/features/pilot_management/New/pages/TemplatesPage.vue
+++ b/src/features/pilot_management/New/pages/TemplatesPage.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
         this.pilot.RemoveMech(m)
       })
       this.pilot.AddMech(mech)
-      this.pilot.State.ActiveMech = mech
+      this.pilot.ActiveMech = mech
 
       this.$emit('next')
     },

--- a/src/features/pilot_management/PilotSheet/sections/hangar/components/MechCard.vue
+++ b/src/features/pilot_management/PilotSheet/sections/hangar/components/MechCard.vue
@@ -158,7 +158,7 @@
                         icon
                         class="fadeSelect"
                         :disabled="mech.Pilot.ActiveMech === mech"
-                        @click.stop="mech.Pilot.State.ActiveMech = mech"
+                        @click.stop="mech.Pilot.ActiveMech = mech"
                       >
                         <v-icon>cci-activate</v-icon>
                       </v-btn>

--- a/src/features/pilot_management/PilotSheet/sections/hangar/components/MechListItem.vue
+++ b/src/features/pilot_management/PilotSheet/sections/hangar/components/MechListItem.vue
@@ -72,7 +72,7 @@
                     icon
                     class="fadeSelect"
                     :disabled="mech.Pilot.ActiveMech === mech"
-                    @click.stop="mech.Pilot.State.ActiveMech = mech"
+                    @click.stop="mech.Pilot.ActiveMech = mech"
                   >
                     <v-icon>cci-activate</v-icon>
                   </v-btn>


### PR DESCRIPTION
# Description
This change resets the active state self-destruct timer on any repairs performed.  It also creates a new ActiveState upon setting a new mech to Active.

It would probably not be unreasonable to move the Self Destruct Counter into an individual mech, either, and to reset it on repairs.  Please let me know if you think moving the Counter would be cleaner than what I currently have here.

## Issue Number
Closes  #1728

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)