### PR TITLE
feat(Cloud): settings for manually pulling data from cloud

### DIFF
--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import uuid from 'uuid/v4'
 import { writeFile, readFile, exists, USER_DATA_PATH } from '../io/Data'
+import _ from 'lodash'
 
 const CONFIG_FILE_NAME = 'user.config'
 
@@ -111,6 +112,7 @@ class UserProfile {
   private _encounters: string[]
   private _missions: string[]
   private _active_missions: string[]
+  private _load_options: string []
   public id: string
   public _version: number
   public LastSync: string
@@ -132,6 +134,7 @@ class UserProfile {
     this._missions = []
     this._active_missions = []
     this.LastSync = 'Never'
+    this._load_options = ['onAppLoad', 'onLogIn']
   }
 
   private save(): void {
@@ -174,6 +177,22 @@ class UserProfile {
   public set SyncFrequency(data: ISyncFrequency) {
     this._syncFrequency = data
     this.save()
+  }
+
+  public get SaveOptions(): string[] {
+    return Object.keys(this.SyncFrequency).filter(x => !this.LoadOptions.includes(x))
+  }
+
+  public get LoadOptions(): string[] {
+    return this._load_options
+  }
+
+  public get SaveFrequency(): Partial<ISyncFrequency> {
+    return _.pick(this.SyncFrequency, this.SaveOptions)
+  }
+
+  public get LoadFrequency(): Partial<ISyncFrequency> {
+    return _.pick(this.SyncFrequency, this.LoadOptions)
   }
 
   public get Achievements(): string[] {


### PR DESCRIPTION
# Description
This change separates the "On App Load" and "On User Sign In" options into a "Load Frequency" category, indicating that when enabled, CompCon will automatically pull from the cloud when those events trigger.  This change also adds a "Cloud Load" button that manually pulls data from the cloud.  Lastly, this change modifies wording surrounding sync functions to clarify what is occurring during the sync (a "save" to the cloud, or a "load" from the cloud).

## Issue Number
Closes #1726

## Type of change
- [x] New feature (non-breaking change which adds functionality)
