### PR TITLE
fix(Pilot Sheet): Refactor Pilot groups for performance & roster improvements

### DIFF
--- a/src/features/pilot_management/Roster/components/PilotCard.vue
+++ b/src/features/pilot_management/Roster/components/PilotCard.vue
@@ -8,7 +8,7 @@
           :min-width="minWidth"
           tile
           flat
-          @click="$router.push(`pilot/${pilot.ID}`)"
+          @click="!dragging ? toPilotSheet() : null"
         >
           <div
             v-show="!(small && mobile)"
@@ -102,6 +102,9 @@ export default Vue.extend({
     small: {
       type: Boolean,
     },
+    dragging: {
+      type: Boolean,
+    },
   },
   computed: {
     mobile() {
@@ -114,6 +117,11 @@ export default Vue.extend({
       return this.small ? '10vw' : '20vw'
     },
   },
+  methods: {
+    toPilotSheet() {
+      this.$router.push(`pilot/${this.pilot.ID}`)
+    },
+  }
 })
 </script>
 

--- a/src/features/pilot_management/Roster/components/PilotCard.vue
+++ b/src/features/pilot_management/Roster/components/PilotCard.vue
@@ -37,7 +37,7 @@
           </div>
           <v-img :src="pilot.Portrait" position="top center" height="100%" :aspect-ratio="1" />
           <v-fade-transition>
-            <v-overlay v-if="hover && !small" absolute color="grey darken-3" opacity="0.8">
+            <v-overlay v-if="hover && !small" absolute color="grey darken-3" opacity="0.8" style="pointer-events: none">
               <v-card flat tile class="flavor-text" light>
                 <v-card-text>
                   {{ pilot.Name }}

--- a/src/features/pilot_management/Roster/components/PilotListItem.vue
+++ b/src/features/pilot_management/Roster/components/PilotListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="pc-wrapper" class="my-1" @click="selectable ? $emit('select', pilot) : toPilotSheet()">
+  <div id="pc-wrapper" class="my-1" @click="selectable ? $emit('select', pilot) : !dragging ? toPilotSheet() : null">
     <v-card
       tile
       color="primary"
@@ -95,6 +95,9 @@ export default Vue.extend({
       required: true,
     },
     selectable: {
+      type: Boolean,
+    },
+    dragging: {
       type: Boolean,
     },
   },

--- a/src/features/pilot_management/Roster/index.vue
+++ b/src/features/pilot_management/Roster/index.vue
@@ -48,83 +48,23 @@
     </v-row>
     <v-slide-x-transition mode="out-in">
       <v-container fluid :class="$vuetify.breakpoint.mdAndUp ? 'mx-1' : 'mx-n4 pa-0'">
-        <!-- <div v-for="g in groups" :key="`pg_${g}`">
-          <v-row no-gutters class="pl-10 ml-n12 heading h3 white--text primary sliced">
-            <v-col cols="auto">
-              <v-btn small dark icon class="mt-n1" @click="toggleHidden(g)">
-                <v-icon v-html="!hidden.includes(g) ? 'mdi-chevron-down' : 'mdi-chevron-up'" />
-              </v-btn>
-              {{ g ? g : 'Ungrouped' }}
-              <span class="overline">({{ pilots.filter(x => x.Group === g).length }})</span>
-            </v-col>
-            <v-col v-if="g" cols="auto" class="ml-auto mr-8">
-              <v-menu offset-x left :close-on-content-click="false">
-                <template v-slot:activator="{ on }">
-                  <v-btn dark small icon class="fadeSelect" v-on="on">
-                    <v-icon>mdi-circle-edit-outline</v-icon>
-                  </v-btn>
-                </template>
-                <v-card>
-                  <v-card-text>
-                    <v-text-field
-                      :value="g"
-                      autofocus
-                      outlined
-                      hide-details
-                      label="Group Name"
-                      @change="setGroupName(g, $event)"
-                    />
-                  </v-card-text>
-                </v-card>
-              </v-menu>
-              <v-btn dark small icon class="fadeSelect" @click="deleteGroup(g)">
-                <v-icon>mdi-delete</v-icon>
-              </v-btn>
-            </v-col>
-          </v-row>
-          <div
-            v-if="!hidden.includes(g)"
-            :style="profile.GetView('roster') !== 'list' ? 'margin-left: -8px; width: 100vw;' : ''"
-          >
-            <v-expand-transition>
-              <draggable
-                :key="`draggable${g}`"
-                :list="pilots.filter(x => x.Group === g)"
-                :disabled="preventDnd"
-                group="pilots"
-                v-bind="dragOptions"
-                @start="drag = true"
-                @end="drag = false"
-                @change="moved($event, g)"
-              >
-                <component
-                  :is="pilotCardType"
-                  v-for="(p, i) in pilots.filter(x => x.Group === g)"
-                  :key="`${pilotCardType}_${i}`"
-                  :pilot="p"
-                  :small="profile.GetView('roster') === 'small-cards'"
-                />
-              </draggable>
-            </v-expand-transition>
-          </div>
-        </div> -->
-
         <draggable
-          v-model="pilotGroups"
+          :list="groups"
           :disabled="preventDnd"
           v-bind="dragOptions"
+          @change="pilotStore.moveGroup"
         >
           <div
-            v-for="(g, i) in pilotGroups"
+            v-for="(g, i) in groups"
             :key="`pg_${g.name}_${i}`"
           >
             <v-row no-gutters class="pl-10 ml-n12 heading h3 white--text primary sliced">
               <v-col cols="auto">
-                <v-btn small dark icon class="mt-n1" @click="toggleHidden(g.name)">
-                  <v-icon v-html="!hidden.includes(g.name) ? 'mdi-chevron-down' : 'mdi-chevron-up'" />
+                <v-btn small dark icon class="mt-n1" @click="toggleHidden(g)">
+                  <v-icon v-html="!g.hidden ? 'mdi-chevron-down' : 'mdi-chevron-up'" />
                 </v-btn>
                 {{ g.name ? g.name : 'Ungrouped' }}
-                <span class="overline">({{ pilots.filter(x => x.Group === g.name).length }})</span>
+                <span class="overline">({{ g.pilotIDs.length }})</span>
               </v-col>
               <v-col v-if="g.name" cols="auto" class="ml-auto mr-8">
                 <v-menu offset-x left :close-on-content-click="false">
@@ -152,23 +92,24 @@
               </v-col>
             </v-row>
             <div
-              v-if="!hidden.includes(g.name)"
+              v-if="!g.hidden"
               :style="profile.GetView('roster') !== 'list' ? 'margin-left: -8px; width: 100vw;' : ''"
             >
               <v-expand-transition>
                 <draggable
-                  :v-model="pilots.filter(x => g.pilotIDs.includes(x.ID))"
+                  :list="g.pilotIDs"
                   :group="{ name: 'group' }"
                   :disabled="preventDnd"
                   v-bind="dragOptions"
                   @start="drag = true"
                   @end="dragOff()"
+                  @change="movePilot(g.name, $event)"
                 >
                   <component
                     :is="pilotCardType"
-                    v-for="(p, j) in pilots.filter(x => g.pilotIDs.includes(x.ID))"
+                    v-for="(id, j) in g.pilotIDs"
                     :key="`${pilotCardType}_${j}`"
-                    :pilot="p"
+                    :pilot="getPilotFromId(id)"
                     :small="profile.GetView('roster') === 'small-cards'"
                     :dragging="drag"
                   />
@@ -220,7 +161,6 @@
 </template>
 
 <script lang="ts">
-import _ from 'lodash'
 import Vue from 'vue'
 import PilotCard from './components/PilotCard.vue'
 import PilotListItem from './components/PilotListItem.vue'
@@ -231,6 +171,7 @@ import { Pilot } from '@/class'
 import { UserProfile } from '@/user'
 import draggable from 'vuedraggable'
 import { teamName } from '@/io/Generators'
+import { PilotGroup } from '../store'
 
 export default Vue.extend({
   name: 'roster-view',
@@ -239,11 +180,8 @@ export default Vue.extend({
     sortParams: null,
     drag: false,
     newGroupMenu: false,
-    tempGroups: [],
-    hidden: [],
     newGroupName: '',
     preventDnd: true,
-    pilotGroups: []
   }),
   computed: {
     pilotStore() {
@@ -264,14 +202,8 @@ export default Vue.extend({
       const store = getModule(UserStore, this.$store)
       return store.UserProfile
     },
-    groups: {
-      get() {
-        return this.pilotStore.PilotGroups
-      },
-      set(pGroups) {
-        console.log(pGroups)
-        this.pilotStore.reorderGroups(pGroups)
-      }
+    groups() {
+      return this.pilotStore.PilotGroups
     },
     pilots() {
       return this.pilotStore.Pilots
@@ -282,7 +214,8 @@ export default Vue.extend({
         disabled: false,
         ghostClass: 'ghost',
         scrollSensitivity: 200,
-        forceFallback: true
+        forceFallback: true,
+        fallbackTolerance: 3,
       }
     },
     dragClick() {
@@ -296,27 +229,18 @@ export default Vue.extend({
       }
     },
   },
-  watch: {
-    pilotGroups(newGroups) {
-      this.groups = newGroups
-    }
-  },
   created() {
-    this.hidden = []
     this.preventDnd = this.isTouch
-    this.pilotGroups = _.cloneDeep(this.groups)
   },
   methods: {
-    toggleHidden(g: string) {
-      const idx = this.hidden.indexOf(g)
-      if (idx === -1) this.hidden.push(g)
-      else this.hidden.splice(idx, 1)
+    toggleHidden(g: PilotGroup) {
+      g.hidden = !g.hidden
     },
     showAll() {
-      Vue.set(this, 'hidden', [])
+      this.groups.forEach(g => g.hidden = false)
     },
     hideAll() {
-      Vue.set(this, 'hidden', [...this.groups])
+      this.groups.forEach(g => g.hidden = true)
     },
     onSort(sortParams: any[]) {
       this.sortParams = sortParams
@@ -329,16 +253,16 @@ export default Vue.extend({
       this.newGroupName = ''
       this.newGroupMenu = false
     },
-    moved(e, g) {
-      if (e.moved && e.moved.element) {
-        const p = e.moved.element as Pilot
-        this.pilotStore.movePilot({ fromIndex: p.SortIndex, toIndex: e.moved.newIndex, g: g })
+    getPilotFromId(id: string): Pilot {
+      return this.pilots.find(p => p.ID === id)
+    },
+    movePilot(groupName, event) {
+      if (event.added) {
+        const pilotId = event.added.element
+        const p = this.getPilotFromId(pilotId)
+        p.Group = groupName
       }
-      if (e.added && e.added.element) {
-        const p = e.added.element as Pilot
-        this.pilotStore.movePilot({ fromIndex: p.SortIndex, toIndex: e.added.newIndex, g: g })
-        // if (this.tempGroups.includes(g))
-      }
+      this.pilotStore.movePilot()
     },
     deleteGroup(g) {
       this.pilotStore.deleteGroup(g)


### PR DESCRIPTION
# Description
~~This is an initial commit for improving performance in the Pilot Roster.  It lays the groundwork for using nested Draggable components, utilizing the yet-unused `pilot_groups.json` for persisting Roster organization, and fixes autoscrolling issues (and drag-and-drop ghost issues in Chrome).  It is far from complete; PilotStore needs cleaned up to fit the new Group paradigm, the Pilot Groups object needs to be used directly in Draggable, and it should probably be load-tested to see if it can handle large lists of pilots.~~

UPDATE: 
This change refactors the way we organize the pilot roster, storing group configuration in `pilot_groups.json`.  This file tracks the Group Name, Hidden status, and list of Pilot IDs of pilots in the group.  The groups themselves have become draggable, and their Hidden state is now persistent between visits to the Pilot Roster.

Current challenges: 
- How to meaningfully load test performance for high pilot counts.
- When performing a Cloud Pull on a freshly-deleted CompCon, there is no guarantee that the groups will retain their previous order, nor pilots within a group.  This could probably be solved by concatenating the `pilotIDs` fields of all the groups in order, mapping them to their Pilot, and then setting `this.Pilots` to the resultant map.  However, it's not immediately clear when this pilot reassignment should occur, and how reassigning `this.Pilots` on a regular basis would impact performance.
- ~~EDIT: One more snag: The draggable doesn't seem to be working for the Large Tiles viewing mode, though it's working fine for List and Small Tiles.  In Large Tiles, the tile just drags to the last spot in the list, refusing to move elsewhere.~~ EDIT 2: This has been remedied; see comments below.

Regardless of these current challenges, I feel that this PR provides enough value to ship as-is. Please let me know if you have any questions or feedback!

## Issue Number
Closes #1713 (hopefully, monitor this one)
Closes #1709
Closes #1611

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)