### PR TITLE
feat(Mech Sheet): enable all synergies for "???" type weapons

### DIFF
--- a/src/classes/Synergy.ts
+++ b/src/classes/Synergy.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { Mech } from '@/class'
+import { Mech, WeaponType } from '@/class'
 import { CompendiumItem } from './CompendiumItem'
 import { ItemType } from './enums'
 import { MechSystem } from './mech/MechSystem'
@@ -37,6 +37,7 @@ class Synergy {
     if (item.ItemType === ItemType.MechWeapon) {
       sArr = sArr.filter(s => {
         if (s.WeaponTypes.includes('any')) return true
+        if ((item as MechWeapon).WeaponType === WeaponType.All) return true
         return s.WeaponTypes.includes((item as MechWeapon).WeaponType)
       })
       sArr = sArr.filter(s => {

--- a/src/classes/enums.ts
+++ b/src/classes/enums.ts
@@ -56,6 +56,7 @@ enum WeaponType {
   CQB = 'CQB',
   Nexus = 'Nexus',
   Melee = 'Melee',
+  All = '???'
 }
 
 enum ItemType {


### PR DESCRIPTION
# Description
This feature adds an "All" enumeration to WeaponTypes that maps to `"???"`, and enables all
WeaponType synergies for that enumeration.  This is primariy in benefit to the Mimic Gun; hopefully
this won't negatively affect existing homebrews in the process.

## Issue Number
Closes #1734

## Type of change
- [x] New feature (non-breaking change which adds functionality)