### PR TITLE
fix(Mech Sheet): temporarily hide duration chips for Core Systems

### DIFF
--- a/src/features/pilot_management/PilotSheet/sections/mech/components/CoreItem.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/components/CoreItem.vue
@@ -37,7 +37,7 @@
         </span>
       </v-col>
       <v-col cols="auto" class="ml-auto">
-        <v-chip
+        <!-- <v-chip
           v-if="
             coreSystem.Use !== 'Mission' ||
               coreSystem.Duration !== 'Unlimited' ||
@@ -48,7 +48,7 @@
           outlined
         >
           {{ coreSystem.Duration.toUpperCase() }}
-        </v-chip>
+        </v-chip> -->
         <v-chip small label dark :color="`action--${coreSystem.Activation.toLowerCase()}`">
           {{ coreSystem.Activation.toUpperCase() }}
         </v-chip>

--- a/src/ui/components/cards/frame/_FrameCoreSystemPanel.vue
+++ b/src/ui/components/cards/frame/_FrameCoreSystemPanel.vue
@@ -26,7 +26,7 @@
         <span class="heading sub">ACTIVE {{ cs.ActiveName ? ` - ${cs.ActiveName}` : '' }}</span>
       </v-col>
       <v-col cols="auto" class="ml-auto">
-        <v-chip
+        <!-- <v-chip
           v-if="
             cs.Duration !== 'Mission' || cs.Duration !== 'Unlimited' || cs.Duration !== 'Mission'
           "
@@ -35,7 +35,7 @@
           outlined
         >
           {{ cs.Duration.toUpperCase() }}
-        </v-chip>
+        </v-chip> -->
         <v-chip small label dark :color="`action--${cs.Activation.toLowerCase()}`">
           {{ cs.Activation.toUpperCase() }}
         </v-chip>


### PR DESCRIPTION
# Description
This fix serves to temporarily hide the Duration chips from Core System descriptions due to inconsistent use of the duration tags causing confusion amongst users.  They will remain commented out until a more robust fix is implemented.  A more robust fix will involve modifying the logic behind assigning Core System durations, as well as adjusting CompCon's lexicon to cleave more closely to the Lancer Core Book (e.g. prefer using "Scene" over "Encounter").

## Issue Number
Addresses #1736, but I would like to keep the issue open for tracking a future fix.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)