### PR TITLE
fix(Pilot Sheet): block pilot registration when quickstart is off

### DIFF
--- a/src/features/pilot_management/New/index.vue
+++ b/src/features/pilot_management/New/index.vue
@@ -69,7 +69,7 @@
           <mech-skills-page :pilot="pilot" :quickstart="quickstart" @next="step++" @back="step--" />
         </v-stepper-content>
         <v-stepper-content :class="$vuetify.breakpoint.smAndDown ? 'px-0' : ''" step="5">
-          <confirm-page :pilot="pilot" @next="step++" @back="step--" @done="onDone" />
+          <confirm-page :pilot="pilot" :quickstart="quickstart" @next="step++" @back="step--" @done="onDone" />
         </v-stepper-content>
         <v-stepper-content :class="$vuetify.breakpoint.smAndDown ? 'px-0' : ''" step="6">
           <templates-page :pilot="pilot" @next="step = 5" @back="step = 1" />

--- a/src/features/pilot_management/New/pages/ConfirmPage.vue
+++ b/src/features/pilot_management/New/pages/ConfirmPage.vue
@@ -1,6 +1,7 @@
 <template>
   <cc-stepper-content
     :complete="pilotReady"
+    :mandatory="!quickstart"
     exit="pilot_management"
     back
     no-confirm
@@ -23,6 +24,7 @@
     <v-btn
       :x-large="$vuetify.breakpoint.mdAndUp"
       block
+      :disabled="!pilotReady && !quickstart"
       color="secondary"
       tile
       class="mx-2 my-8"
@@ -52,6 +54,7 @@ export default Vue.extend({
       type: Object,
       required: true,
     },
+    quickstart: { type: Boolean },
   },
   data: () => ({
     default_callsign: "[NEW CALLSIGN]",


### PR DESCRIPTION
# Description
This fix enforces the Quickstart options on the confirm page, properly disabling the "Register Pilot" button when missing mandatory fields.

## Issue Number
Closes #1762

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)