### PR TITLE
feat(Pilot Sheet): add basic pilot stats to Dossier

### DIFF
--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -1086,6 +1086,10 @@ class Pilot implements ICloudSyncable {
     }
   }
 
+  public get CombatHistory(): ICombatStats {
+    return this._combat_history
+  }
+
   public Kill(): void {
     this._status = 'KIA'
     this.IsDead = true
@@ -1210,7 +1214,7 @@ class Pilot implements ICloudSyncable {
       counter_data: p.CounterSaveData,
       custom_counters: p.CustomCounterData,
       special_equipment: this.serializeSE(p._special_equipment),
-      combat_history: p.State.Stats,
+      combat_history: p._combat_history,
       state: ActiveState.Serialize(p.State),
       brews: p._brews || [],
     }

--- a/src/features/pilot_management/PilotSheet/components/CloudManager.vue
+++ b/src/features/pilot_management/PilotSheet/components/CloudManager.vue
@@ -8,7 +8,7 @@
 import Vue from 'vue'
 
 export default Vue.extend({
-  name: 'ident-block',
+  name: 'cloud-manager',
   props: {
     pilot: {
       type: Object,

--- a/src/features/pilot_management/PilotSheet/sections/info/components/CombatHistoryBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/CombatHistoryBlock.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <cc-title small color="pilot" class="pl-3" style="margin-left: -70px!important">
+      <span class="ml-9">&emsp;</span>
+      Pilot Combat Telemetry Record
+    </cc-title>
+    <v-row dense class="stat-text pt-2 pb-2 pl-2 mt-n2">
+      <v-col>
+        <div>
+          MOVES:
+          <b class="stark--text">{{ pilot.CombatHistory.moves }}</b>
+        </div>
+        <div>
+          DAMAGE DEALT:
+          <b class="stark--text">{{ pilot.CombatHistory.damage }}</b>
+        </div>
+        <div>
+          ENEMIES DESTROYED:
+          <b class="stark--text">{{ pilot.CombatHistory.kills }}</b>
+        </div>
+        <div>
+          DAMAGE TAKEN:
+          <b class="stark--text">{{ pilot.CombatHistory.hp_damage }}</b>
+        </div>
+        <div>
+          STRUCTURE LOST:
+          <b class="stark--text">{{ pilot.CombatHistory.structure_damage }}</b>
+        </div>
+        <div>
+          HEAT TAKEN:
+          <b class="stark--text">{{ pilot.CombatHistory.heat_damage }}</b>
+        </div>
+        <div>
+          REACTOR STRESS:
+          <b class="stark--text">{{ pilot.CombatHistory.reactor_damage }}</b>
+        </div>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script lang="ts">
+import activePilot from '@/features/pilot_management/mixins/activePilot'
+import vueMixins from '@/util/vueMixins'
+
+export default vueMixins(activePilot).extend({
+  name: 'combat-history-block',
+
+})
+</script>

--- a/src/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/components/ImageBlock.vue
@@ -25,6 +25,6 @@ import activePilot from '@/features/pilot_management/mixins/activePilot'
 import vueMixins from '@/util/vueMixins'
 
 export default vueMixins(activePilot).extend({
-  name: 'history-block',
+  name: 'image-block',
 })
 </script>

--- a/src/features/pilot_management/PilotSheet/sections/info/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/info/index.vue
@@ -15,6 +15,7 @@
         <history-block />
         <appearance-block />
         <notes-block />
+        <combat-history-block />
       </v-col>
       <v-col v-if="$vuetify.breakpoint.mdAndUp" cols="4" dense>
         <image-block />
@@ -31,9 +32,10 @@ import AppearanceBlock from './components/AppearanceBlock.vue'
 import ImageBlock from './components/ImageBlock.vue'
 import NotesBlock from './components/NotesBlock.vue'
 import CloneBlock from './components/CloneBlock.vue'
+import CombatHistoryBlock from './components/CombatHistoryBlock.vue'
 
 export default Vue.extend({
   name: 'info-view',
-  components: { IdentBlock, HistoryBlock, AppearanceBlock, ImageBlock, NotesBlock, CloneBlock },
+  components: { IdentBlock, HistoryBlock, AppearanceBlock, ImageBlock, NotesBlock, CloneBlock, CombatHistoryBlock },
 })
 </script>


### PR DESCRIPTION
# Description
This change ensures persistent pilot combat stats between missions.  It adds a visible stat record under Pilot Combat Telemetry Record on the Dossier tab of Pilot Management.  This is an incredibly basic change; it could definitely stand to be improved upon in the future.

## Issue Number
Closes #1765

## Type of change
- [x] New feature (non-breaking change which adds functionality)