### PR TITLE
style(Pilot Sheet): fix number spacing over icons in Print mode

### DIFF
--- a/src/features/pilot_management/Print/BlankMechPrint.vue
+++ b/src/features/pilot_management/Print/BlankMechPrint.vue
@@ -210,7 +210,9 @@ export default Vue.extend({
   position: absolute;
   top: -5px;
   left: 1px;
+  width: 100%;
   width: -webkit-fill-available;
+  width: -moz-available;
   text-align: center;
 }
 

--- a/src/features/pilot_management/Print/BlankPilotPrint.vue
+++ b/src/features/pilot_management/Print/BlankPilotPrint.vue
@@ -155,7 +155,9 @@ export default Vue.extend({
   position: absolute;
   top: -5px;
   left: 1px;
+  width: 100%;
   width: -webkit-fill-available;
+  width: -moz-available;
   text-align: center;
 }
 

--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -360,7 +360,9 @@ export default Vue.extend({
   position: absolute;
   top: 1.5px;
   left: 1px;
+  width: 100%;
   width: -webkit-fill-available;
+  width: -moz-available;
   text-align: center;
 }
 

--- a/src/features/pilot_management/Print/PilotPrint.vue
+++ b/src/features/pilot_management/Print/PilotPrint.vue
@@ -264,7 +264,9 @@ export default Vue.extend({
   position: absolute;
   top: -2px;
   left: 1px;
+  width: 100%;
   width: -webkit-fill-available;
+  width: -moz-available;
   text-align: center;
 }
 


### PR DESCRIPTION
# Description
This change includes some redundant width settings for browsers that don't recognize `-webkit-fill-available`.  The unrecognized options are subsequently ignored, so we are safe to add redundant `width` settings.

## Issue Number
Closes #1768

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)