### PR TITLE
Fix/pilot group vault bug

### DIFF
--- a/src/assets/generators/mechnames.txt
+++ b/src/assets/generators/mechnames.txt
@@ -755,7 +755,7 @@ Shantideva's Sword
 Shockingly Simple Method
 Shot Noise
 Shrinking Planet
-Shroedinger's Hammer
+Schroedinger's Hammer
 Signal To Noise
 Simplicity Itself
 Sincerity Couched Behind Humor

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -409,7 +409,7 @@ class Pilot implements ICloudSyncable {
     this.CloudID = itemCloudId
     this.CloudOwnerID = userCognitoId
     this.IsLocallyOwned = false
-    this.RenewID()
+    // this.RenewID()
   }
 
   public SetOwnedResource(userCognitoId: string): void {

--- a/src/features/pilot_management/Roster/components/PilotCard.vue
+++ b/src/features/pilot_management/Roster/components/PilotCard.vue
@@ -8,7 +8,7 @@
           :min-width="minWidth"
           tile
           flat
-          @click="$router.push(`pilot/${pilot.ID}`)"
+          @click="!dragging ? toPilotSheet() : null"
         >
           <div
             v-show="!(small && mobile)"
@@ -37,7 +37,7 @@
           </div>
           <v-img :src="pilot.Portrait" position="top center" height="100%" :aspect-ratio="1" />
           <v-fade-transition>
-            <v-overlay v-if="hover && !small" absolute color="grey darken-3" opacity="0.8">
+            <v-overlay v-if="hover && !small" absolute color="grey darken-3" opacity="0.8" style="pointer-events: none">
               <v-card flat tile class="flavor-text" light>
                 <v-card-text>
                   {{ pilot.Name }}
@@ -102,6 +102,9 @@ export default Vue.extend({
     small: {
       type: Boolean,
     },
+    dragging: {
+      type: Boolean,
+    },
   },
   computed: {
     mobile() {
@@ -114,6 +117,11 @@ export default Vue.extend({
       return this.small ? '10vw' : '20vw'
     },
   },
+  methods: {
+    toPilotSheet() {
+      this.$router.push(`pilot/${this.pilot.ID}`)
+    },
+  }
 })
 </script>
 

--- a/src/features/pilot_management/Roster/components/PilotListItem.vue
+++ b/src/features/pilot_management/Roster/components/PilotListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="pc-wrapper" class="my-1" @click="selectable ? $emit('select', pilot) : toPilotSheet()">
+  <div id="pc-wrapper" class="my-1" @click="selectable ? $emit('select', pilot) : !dragging ? toPilotSheet() : null">
     <v-card
       tile
       color="primary"
@@ -95,6 +95,9 @@ export default Vue.extend({
       required: true,
     },
     selectable: {
+      type: Boolean,
+    },
+    dragging: {
       type: Boolean,
     },
   },

--- a/src/user/sync.ts
+++ b/src/user/sync.ts
@@ -326,6 +326,9 @@ const AwsImport = async (code: string): Promise<any> => {
   const userID = 'us-east-1:' + arr[0]
   const resource = 'pilot/' + arr[1]
 
+  const ccid = await currentCognitoIdentity()
+  if (userID === ccid) throw new Error('Entity belongs to current account.')
+
   const url = await Storage.get(resource, {
     level: 'protected',
     identityId: userID,
@@ -333,7 +336,10 @@ const AwsImport = async (code: string): Promise<any> => {
 
   if (typeof url === 'object') throw new Error('Unsupported S3 return type')
 
-  return fetch(url).then(res => res.json())
+  return fetch(url).then(res => {
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json()
+  })
 }
 
 export { GetSync, ContentPull, CloudPull, CloudPush, AwsImport, UploadLcps }


### PR DESCRIPTION
# Description
This is a fix for the previous Pilot Group update.  It disables the renewal of a new pilot ID upon calling `SetRemoteResource`, which led to ID mismatches between the Pilot Group structure and the Pilot itself.  Weirdly enough, the Renewed ID was stored in the Pilot Group structure, while the Pilot's ID reverted back to the Pilot's CloudID. It's not clear why that reversion occurred, but it makes sense to me to keep the Pilot's ID the same as the CloudID instead of renewing it in these cases.  Feedback/explanations for the contrary would be appreciated!

This change also prevents importing pilots from the user's own account, as this leads to strange behavior when modifying/deleting the pilot.  Better to prevent it in the first place, in my opinion.  Also adds more informative error messages when a pilot ID is not found.

## Issue Number
#1777

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)