### PR TITLE
fix(Active Mode): remove burn check from Active Mode End Round

### DIFF
--- a/src/features/pilot_management/ActiveSheet/layout/footers/CombatFooter.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/footers/CombatFooter.vue
@@ -298,8 +298,7 @@ export default vueMixins(activePilot).extend({
       else this.endTurn()
     },
     stageNextRound() {
-      if (this.mech.Burn) this.$refs.burnDialog.show()
-      else this.nextRound()
+      this.nextRound()
     },
     nextRound() {
       this.state.NextRound()


### PR DESCRIPTION
# Description
This fix removes the burn check from the "Start Round X" button, since Burn is only checked at the end of a player's turn.

## Issue Number
#1774

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)