### PR TITLE
fix(Pilot Sheet): fix pilot group old data bug

### DIFF
--- a/src/features/pilot_management/store/index.ts
+++ b/src/features/pilot_management/store/index.ts
@@ -11,7 +11,7 @@ async function savePilots(pilots: Pilot[]) {
 }
 
 async function savePilotGroups(pilotGroups: PilotGroup[]) {
-  await saveData('pilot_groups.json', pilotGroups)
+  await saveData('pilot_groups_v2.json', pilotGroups)
 }
 
 export interface PilotGroup {
@@ -83,10 +83,11 @@ export class PilotManagementStore extends VuexModule {
     const allPilots = [...payload.pilotData.map(x => Pilot.Deserialize(x)).filter(x => x)]
     this.Pilots = allPilots
     const groupDataEmpty = payload.groupData.length === 0
-    const ungroupedOnly = payload.groupData.length === 1 && payload.groupData[0].name === ""
-    const ungroupedEmpty = payload.groupData.find(g => g.name === "")?.pilotIDs.length === 0
+    const ungroupedOnlyEmpty = payload.groupData.length === 1 && 
+                               payload.groupData[0].name === "" && 
+                               payload.groupData[0].pilotIDs.length === 0
 
-    if (groupDataEmpty || (ungroupedOnly && ungroupedEmpty)) {
+    if (groupDataEmpty || ungroupedOnlyEmpty) {
       console.info("Recreating groups")
       this.PilotGroups = createPilotGroups(this.Pilots)
     } else {
@@ -213,7 +214,7 @@ export class PilotManagementStore extends VuexModule {
   @Action({ rawError: true })
   public async loadPilots() {
     const pilotData = await loadData<IPilotData>('pilots_v2.json')
-    const pilotGroupData = await loadData<PilotGroup>('pilot_groups.json')
+    const pilotGroupData = await loadData<PilotGroup>('pilot_groups_v2.json')
     this.context.commit(LOAD_PILOTS, {'pilotData': pilotData, 'groupData': pilotGroupData})
   }
 

--- a/src/io/BulkData.ts
+++ b/src/io/BulkData.ts
@@ -12,7 +12,7 @@ const files = [
   'pilots_v2.json',
   'npcs_v2.json',
   'extra_content.json',
-  'pilot_groups.json',
+  'pilot_groups_v2.json',
 ]
 
 const exportV1Pilots = async function(): Promise<string> {


### PR DESCRIPTION
# Description
This fix sidesteps the old `pilot_groups.json` and its `string[]` data structure to create a new `pilot_groups_v2.json` using the new `PilotGroup[]` data structure.  Any preexisting `pilot_groups.json` with a  `string[]` structure led to errors when the updated code expected a `PilotGroup[]` structure.

## Issue Number
Closes #1785

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)