### PR TITLE
fix(icons): check if SVG CORS are friendly for loading

### DIFF
--- a/src/features/compendium/Views/Manufacturers.vue
+++ b/src/features/compendium/Views/Manufacturers.vue
@@ -29,8 +29,14 @@
               v-if="$vuetify.breakpoint.lgAndUp"
               style="float: right; margin-left: 20px; margin-right: 50px; min-height: 22vw"
             >
+              <svg
+                v-if="isSvg(m.Logo) && isValidUrl(m.Logo)"
+                :data-src="m.Logo + '#Content'"
+                :style="`width:22vw; height:22vw; fill:${m.Color}; stroke:#fff; stroke-width: 8px;`"
+              >
+              </svg>
               <img
-                v-if="m.LogoIsExternal"
+                v-else
                 :src="m.Logo"
                 :alt="m.Name"
                 :style="{
@@ -38,12 +44,6 @@
                   height: '22vw',
                 }"
               />
-              <svg
-                v-else
-                :data-src="m.Logo + '#Content'"
-                :style="`width:22vw; height:22vw; fill:${m.Color}; stroke:#fff; stroke-width: 8px;`"
-              >
-              </svg>
             </div>
             <blockquote class="quote-block fluff-text text--text" v-html-safe="m.Quote" />
             <v-divider class="ma-2" style="width: 800px" />
@@ -72,6 +72,23 @@ export default class Manufacturers extends Vue {
   public tabModel = 0
 
   private compendiumStore = getModule(CompendiumStore, this.$store)
+
+  // FIXME - Consider putting the Logo checking in Manufacturer.ts/Faction.ts
+  isSvg(logoUrl: string): boolean {
+    const filenameQuery = logoUrl.split("/").slice(-1)[0]
+    const filename = filenameQuery.split("?")[0]
+    const isSvg = filename.endsWith(".svg")
+    return isSvg
+  }
+
+  async isValidUrl(logoUrl: string): Promise<boolean> {
+    return await fetch(logoUrl).then(r => {
+      return r.ok
+    }).catch(e => {
+      return false
+    })
+  }
+
   get manufacturers(): Manufacturer[] {
     return this.compendiumStore.Manufacturers.filter(x => !x.IsHidden)
   }

--- a/src/ui/components/items/CCLogo.vue
+++ b/src/ui/components/items/CCLogo.vue
@@ -1,6 +1,15 @@
 <template>
+  <svg
+    v-if="isSvg && corsSafe"
+    :data-src="source.Logo + '#Content'"
+    :style="
+      `width:${iconSize}; height:${iconSize}; fill:${iconColor}; stroke:${stroke}; ${
+        stroke ? 'stroke-width: 25px;' : ''
+      }`
+    "
+  ></svg>
   <img
-    v-if="isExternal"
+    v-else
     :src="source.Logo"
     :alt="source.Name"
     :style="{
@@ -9,15 +18,6 @@
       filter: getFilter,
     }"
   />
-  <svg
-    v-else
-    :data-src="source.Logo + '#Content'"
-    :style="
-      `width:${iconSize}; height:${iconSize}; fill:${iconColor}; stroke:${stroke}; ${
-        stroke ? 'stroke-width: 25px;' : ''
-      }`
-    "
-  ></svg>
 </template>
 
 <script lang="ts">
@@ -55,6 +55,9 @@ export default Vue.extend({
       default: '',
     },
   },
+  data: () => ({
+    corsSafe: false
+  }),
   computed: {
     iconSize(): string {
       return sizeMap[this.size] ? sizeMap[this.size] : sizeMap.default
@@ -65,10 +68,24 @@ export default Vue.extend({
     isExternal(): string {
       return this.source.LogoIsExternal
     },
+    isSvg(): boolean {
+      const filenameQuery = this.source.Logo.split("/").slice(-1)[0]
+      const filename = filenameQuery.split("?")[0]
+      const isSvg = filename.endsWith(".svg")
+      return isSvg
+    },
     getFilter(): string {
       if (this.$vuetify.theme.dark) return 'brightness(0) invert(1)'
       return 'brightness(0)'
     },
+  },
+  mounted: async function() {
+    try {
+      const response = await fetch(this.source.Logo)
+      this.corsSafe = response.ok
+    } catch (e) {
+      this.corsSafe = false
+    }
   },
 })
 </script>


### PR DESCRIPTION
# Description
This change adds a `v-if` check for if an SVG image is accessible with appropriate CORS.  It works best on CCLogo.vue, but needs some more work elsewhere (e.g. Manufacturers.vue, Factions.vue, etc.) WIP.  Uses `external-svg-loader`, which I know was removed in a recent performance update (it may work better with these changes).

## Issue Number
Closes #1618

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)