### PR TITLE
fix(Packs):include backgrounds in pack summary

### DIFF
--- a/src/features/nav/pages/ExtraContent/PackInfo.vue
+++ b/src/features/nav/pages/ExtraContent/PackInfo.vue
@@ -80,6 +80,7 @@ export default class PackInfo extends Vue {
     systems: ['system', 'systems'],
     mods: ['weapon mod', 'weapon mods'],
     pilotGear: ['pilot gear item', 'pilot gear items'],
+    backgrounds: ['background', 'backgrounds'],
     talents: ['pilot talent', 'pilot talents'],
     tags: ['equipment tag', 'equipment tags'],
     npcClasses: ['NPC class', 'NPC classes'],


### PR DESCRIPTION
# Description
This fix includes "backgrounds" under the `humanReadableMap` when summarizing Pack Info from an LCP.

## Issue Number
Closes #1857

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
