### PR TITLE
fix(homepage): fix .txt 'require's in horus.ts

### DIFF
--- a/src/features/main_menu/_components/startup_logs/horus.ts
+++ b/src/features/main_menu/_components/startup_logs/horus.ts
@@ -2,11 +2,11 @@ import _ from 'lodash'
 import { tracert } from '@/io/Generators'
 
 function motd(): string {
-  return _.sample(require('raw-loader!./horus_chat/motd.txt').split('\n'))
+  return _.sample(require('raw-loader!./horus_chat/motd.txt').default.split('\n'))
 }
 
 const HorusStart = typer => {
-  const nfo = require('raw-loader!./horus_chat/nfo.txt')
+  const nfo = require('raw-loader!./horus_chat/nfo.txt').default
 
   typer
     .type('<br>')
@@ -124,10 +124,10 @@ function randomNoRepeat(arr) {
 }
 
 const HorusChat = output => {
-  const chat = require('raw-loader!./horus_chat/chat.txt').split('\n')
-  const mods = require('raw-loader!./horus_chat/mods.txt').split('\n')
-  const admin = require('raw-loader!./horus_chat/admin.txt').split('\n')
-  const bans = require('raw-loader!./horus_chat/bans.txt').split('\n')
+  const chat = require('raw-loader!./horus_chat/chat.txt').default.split('\n')
+  const mods = require('raw-loader!./horus_chat/mods.txt').default.split('\n')
+  const admin = require('raw-loader!./horus_chat/admin.txt').default.split('\n')
+  const bans = require('raw-loader!./horus_chat/bans.txt').default.split('\n')
 
   const allLines = []
 


### PR DESCRIPTION
# Description
This PR fixes the `n(...).split is not a function` error in `horus.ts` by setting the `require` statements to return their "default", similar to what we see in `io/Generators.ts`.  At time of writing, this does *NOT* fix the initial load of the theme always defaulting to GMS; that part is a WIP.

UPDATE: I'm almost certain that the GMS default start has been present since before the performance update.  After doing some tests, the GMS startup runs because the UserProfile's theme is undefined, probably because the deserialization hasn't completed by the time the GMS switch case begins.  We may ultimately want the typer to wait until the UserProfile is properly deserialized, but I'd say that's an issue for another day.

## Issue Number
Closes #1829

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)