### PR TITLE
feat(compendium):change tag search to 'AND' logic

### DIFF
--- a/src/classes/utility/ItemFilter.ts
+++ b/src/classes/utility/ItemFilter.ts
@@ -7,8 +7,8 @@ class ItemFilter {
         items = items.filter(i => filter[p][0].includes(i.LcpName))
       } else if (p === 'Tags') {
         items = items.filter((e: MechEquipment) => {
-          if (e instanceof MechWeapon && e.ProfileTags?.map(t => t.ID).some(x => filter.Tags.includes(x))) return true
-          return e.Tags.map(t => t.ID).some(x => filter.Tags.includes(x))
+          const item_tags = (e instanceof MechWeapon && e.ProfileTags) ? e.ProfileTags : e.Tags
+          return filter.Tags.every(x => item_tags.map(t => t.ID).includes(x))
         }
         )
       } else if (p === 'SP_greater') {


### PR DESCRIPTION
# Description
This PR changes how the ItemFilter filters on tags.  The current Tag filter includes every weapon/system that includes at least 1 tag from the filter.  The new filter will now only include every weapon/system that possesses ALL tags from the filter.

## Issue Number
Closes #1849

## Type of change
- [x] New feature (non-breaking change which adds functionality)

