### PR TITLE
fix(Mech): cover optional damage/range cases

### DIFF
--- a/src/classes/mech/MechWeapon.ts
+++ b/src/classes/mech/MechWeapon.ts
@@ -248,7 +248,7 @@ class MechWeapon extends MechEquipment {
   }
 
   public get DamageType(): DamageType[] {
-    return this.SelectedProfile.Damage.map(x => x.Type)
+    return this.SelectedProfile.Damage ? this.SelectedProfile.Damage.map(x => x.Type) : []
   }
 
   public get DefaultDamageType(): DamageType {
@@ -264,7 +264,7 @@ class MechWeapon extends MechEquipment {
   }
 
   public get RangeType(): RangeType[] {
-    return this.SelectedProfile.Range.map(x => x.Type)
+    return this.SelectedProfile.Range ? this.SelectedProfile.Range.map(x => x.Type) : []
   }
 
   public set Mod(_mod: WeaponMod | null) {


### PR DESCRIPTION
# Description
This PR modifies logic behind `MechWeapon.DamageType` and `MechWeapon.RangeType` so that weapons that lack a damage field or range field won't throw an error in cases where CompCon attempts to access their damage/range type.

## Issue Number
Closes #1875

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
