### PR TITLE
fix(login): toLowerCase new accounts

### DIFF
--- a/src/features/main_menu/_components/login/SignIn.vue
+++ b/src/features/main_menu/_components/login/SignIn.vue
@@ -91,6 +91,12 @@ export default Vue.extend({
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
       Auth.signIn(this.email, this.password)
+        .catch(error => {
+          if (error.name === "UserNotFoundException") {
+            return Auth.signIn(this.email.toLowerCase(), this.password)
+          }
+          throw error
+        })
         .then(user => {
           localStorage.removeItem('user.config')
           userstore.setUser(user)

--- a/src/features/main_menu/_components/login/SignUp.vue
+++ b/src/features/main_menu/_components/login/SignUp.vue
@@ -134,6 +134,7 @@ export default Vue.extend({
     async createAccount() {
       this.loading = true
       try {
+        this.email = this.email.toLowerCase()
         const { user } = await Auth.signUp({
           username: this.email,
           password: this.password,


### PR DESCRIPTION
# Description
This change makes it so that all new CompCon accounts are created with a lowercase username to match their email account.  To prevent breaking existing accounts, it also preserves Uppercase username logins for legacy accounts, but if a valid case-sensitive username cannot be found, it will check for a case-insensitive username afterwards.

## Issue Number
Closes #1850

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)