### PR TITLE
feat(help): shorten app FAQ, point to wiki FAQ

### DIFF
--- a/src/features/nav/pages/Help.vue
+++ b/src/features/nav/pages/Help.vue
@@ -33,30 +33,6 @@
         and selecting the Core Book item from the LCP Directory tab. You can use the Content
         Manager's Install LCP tab to import the package and start building and running encounters.
       </p>
-      <b>Will COMP/CON get [feature]?</b>
-      <p>
-        You can check out what's next for COMP/CON on our
-        <a
-          target="_blank"
-          href="https://github.com/massif-press/compcon/issues?q=is%3Aopen+is%3Aissue+label%3Afeature"
-          v-html="'GitHub issue tracker'"
-        />
-        . If you don't see the feature you're interested in, you can suggest it by clicking the
-        "Request a Feature" button above.
-      </p>
-      <b>Is COMP/CON available on mobile devices?</b>
-      <p>
-        That's something we're working on currently. Although it's largely untested, you should be
-        able to use compcon.app in landscape mode on most modern tablets. Expect a more robust
-        tablet mode -- as well as a phone mode -- in the future. Also, COMP/CON can be saved as a
-        Progressive Web App to most mobile devices.
-      </p>
-      <b>Is there any way to get the Wallflower/KTB/other preview mechs in COMP/CON?</b>
-      <p>
-        Additional content, such as the Wallflower previews are available in the pins of the
-        #comp-con channel of the LANCER Discord. These will be officially released along with their
-        respective books, and downloadable through the LCP Directory.
-      </p>
       <b>I see a Roll20 import function, how do I use it?</b>
       <p>
         The importer on Roll20's side is not available yet.
@@ -65,10 +41,10 @@
 
     <h3 class="heading accent--text">Additional Help</h3>
     <p class="body-text">
-      We're currently working on more help resources for COMP/CON, especially for new players and
-      GMs. In the meantime, please stop by
-      <a target="_blank" href="https://discord.gg/rwcpzsU" v-html="`the LANCER discord`" />
-      (and specifically the #comp-con channel) if you have a question or comment for the developers.
+      The <a target="_blank" href="https://github.com/massif-press/compcon/wiki/Frequently-Asked-Questions" v-html="`COMP/CON FAQ`" /> 
+      may have an answer to your question! If you still can't find what you're looking for, please stop by
+      <a target="_blank" href="https://discord.gg/rwcpzsU" v-html="`the unofficial LANCER discord`" />
+      (and specifically the #comp-con channel) with your questions or comments for the developers.
     </p>
 
     <h3 class="heading accent--text">Video Guide</h3>


### PR DESCRIPTION
# Description
This change shortens the FAQ on the COMP/CON app and includes a link to the [COMP/CON Wiki FAQ](https://github.com/massif-press/compcon/wiki/Frequently-Asked-Questions).

## Issue Number
Closes #1889

## Type of change
- [x] New feature (non-breaking change which adds functionality)