### PR TITLE
fix(Roster): revisit pilot groups

### DIFF
--- a/src/classes/components/group/GroupController.ts
+++ b/src/classes/components/group/GroupController.ts
@@ -42,7 +42,7 @@ class GroupController {
     if (!parent.GroupController) throw new Error(`GroupController not found on parent (${typeof parent}). New GroupControllers must be instantiated in the parent's constructor method.`);
 
     parent.GroupController._group = data.group || ''
-    parent.GroupController._sortIndex = data.sort_index || 0
+    parent.GroupController._sortIndex = data.sort_index || -1
   }
 }
 export {

--- a/src/features/pilot_management/PilotSheet/components/CloneDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/CloneDialog.vue
@@ -101,6 +101,7 @@ export default Vue.extend({
       for (const mech of newPilot.Mechs) {
         mech.RenewID()
       }
+      newPilot.GroupController.SortIndex = -1
       this.$store.dispatch('addPilot', newPilot)
       this.hide()
     },
@@ -113,6 +114,7 @@ export default Vue.extend({
       for (const mech of newPilot.Mechs) {
         mech.RenewID()
       }
+      newPilot.GroupController.SortIndex = -1
       this.$store.dispatch('addPilot', newPilot)
       this.hide()
     },

--- a/src/features/pilot_management/Roster/index.vue
+++ b/src/features/pilot_management/Roster/index.vue
@@ -202,7 +202,13 @@ export default Vue.extend({
       return store.UserProfile
     },
     groups() {
-      return this.pilotStore.PilotGroups
+      const groups = this.pilotStore.PilotGroups
+      groups.forEach(g => {
+        g.pilotIDs = this.pilots.filter(p => p.GroupController.Group === g.name)
+                                .sort((p1, p2) => p1.GroupController.SortIndex - p2.GroupController.SortIndex)
+                                .map(p => p.ID)
+      })
+      return groups
     },
     pilots() {
       return this.pilotStore.Pilots
@@ -258,11 +264,19 @@ export default Vue.extend({
       return this.pilots.find(p => p.ID === id)
     },
     movePilot(groupName, event) {
-      if (event.added) {
-        const pilotId = event.added.element
-        const p = this.getPilotFromId(pilotId)
-        p.Group = groupName
+      if (event.added || event.moved) {
+        const pilotId = event.added ? event.added.element : event.moved.element
+        const pilot = this.getPilotFromId(pilotId)
+        pilot.GroupController.Group = groupName
+
+        this.groups.forEach(g => {
+          g.pilotIDs.forEach((id, i) =>{
+            const p = this.getPilotFromId(id)
+            p.GroupController.SortIndex = i
+          })
+        })
       }
+      
       this.pilotStore.movePilot()
     },
     deleteGroup(g) {


### PR DESCRIPTION
# Description
Start of revisiting Pilot Groups in the context of the cloud rework.  Goal was to convert `pilot_groups_v2.json` into a data structure purely for ordering and configuring groups, with no knowledge of each group's pilots.  

Sorting within groups is handled via SortIndex.  The intent is for SortIndex to be preserved when adding a pilot if that pilot has a defined SortIndex of 0 or higher, so that when a user logs into CompCon, all of their pilots preserve their sorting.  Moving a pilot refreshes all sort indices (unsure if good practice; feedback appreciated).

Current challenge is acquiring the desired sort index when moving from one group to another.  Some of the means I've been using to maintain the sort order may be interfering with how cross-group sorting works.

As an aside about this: To be honest, I've seriously considered whether it would be better to have no draggable sorting within groups (only allowing dragging between groups), and simply sort by Callsign within groups by default.  Trying to maintain pilot order within groups has been very similar to playing Whack-a-Mole. If there are known patterns for how to accomplish this cleanly, I'd love to see them.
