### PR TITLE
feat(dev): Make the dev server https capable

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A digital toolkit for the LANCER TTRPG",
   "author": "Massif Press",
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --https",
     "build": "vue-cli-service build"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

It is apparent that I haven't done any work on this in a while. I am sorry, but while I realized that the new `vue-cli-service serve` does allow for access off of locahost, it does not use https by default which is a requirement.
This works for me, accessing the dev server off of the dev machine, but I cannot test localhost access.

Will one of you please check on your end and see if this change causes an issue for that (more common ) usecase?

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
