### PR TITLE
fix(pilot): Random Bond Ideals refresh on buttonclick

### DIFF
--- a/src/features/pilot_management/PilotSheet/sections/bonds/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/bonds/index.vue
@@ -48,7 +48,7 @@
               icon
               class="fadeSelect"
               @click="
-                pilot.BondController.MajorIdeal = pilot.BondController.Bond.RandomIdeal('Major')
+                $set(pilot.BondController, 'MajorIdeal', pilot.BondController.Bond.RandomIdeal('Major'))
               "
             >
               <v-icon>mdi-dice-multiple-outline</v-icon>
@@ -71,7 +71,7 @@
               icon
               class="fadeSelect"
               @click="
-                pilot.BondController.MinorIdeal = pilot.BondController.Bond.RandomIdeal('Minor')
+                $set(pilot.BondController, 'MinorIdeal', pilot.BondController.Bond.RandomIdeal('Minor'))
               "
             >
               <v-icon>mdi-dice-multiple-outline</v-icon>


### PR DESCRIPTION
# Description
This change uses Vue's `$set` to update the BondController's `MajorIdeal` and `MinorIdeal`, so they automatically populate a random result when the multi-dice button is pressed.

## Issue Number
Closes #1923

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
