### PR TITLE
fix(encounter): Correctly display the sitrep of selected encounters

### DIFF
--- a/src/features/encounters/encounter/components/EncounterCard.vue
+++ b/src/features/encounters/encounter/components/EncounterCard.vue
@@ -370,6 +370,9 @@ export default Vue.extend({
     selRep: 'Standard Combat',
     ctest: ['a', 'b', 'c'],
   }),
+  mounted() {
+    this.selRep = this.encounter.Sitrep.name;
+  },
   computed: {
     labels() {
       const store = getModule(EncounterStore, this.$store)


### PR DESCRIPTION
# Description
This change looks at the currently selected encounter to update the default value for the sitrep select.

## Issue Number
Closes #1843
Closes #1886

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
