### PR TITLE
fix(npc): give NPCs CounterControllers, optl FeatController counts

### DIFF
--- a/src/classes/components/counters/CounterController.ts
+++ b/src/classes/components/counters/CounterController.ts
@@ -65,7 +65,8 @@ class CounterController {
   }
 
   public get CounterData(): ICounterData[] {
-    return [...this.Parent.FeatureController.Counters, ...this.CustomCounterData]
+    const parent_counters = this.Parent.FeatureController.Containers.length ? this.Parent.FeatureController.Counters : []
+    return [...parent_counters, ...this.CustomCounterData]
       .flat()
       .filter(x => x)
   }


### PR DESCRIPTION
# Description
This PR adds a CounterController to the NPC class to avoid errors getting thrown when retrieving CounterData within the Mission Runner.  It also makes the FeatureController counter check optional depending on whether there's actually Features within the FeatureController.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)