### PR TITLE
fix(content): Added Bonds to readable map

### DIFF
--- a/src/features/nav/pages/ExtraContent/PackInfo.vue
+++ b/src/features/nav/pages/ExtraContent/PackInfo.vue
@@ -81,6 +81,7 @@ export default class PackInfo extends Vue {
     mods: ['weapon mod', 'weapon mods'],
     pilotGear: ['pilot gear item', 'pilot gear items'],
     backgrounds: ['background', 'backgrounds'],
+    bonds: ['bond', 'bonds'],
     talents: ['pilot talent', 'pilot talents'],
     tags: ['equipment tag', 'equipment tags'],
     npcClasses: ['NPC class', 'NPC classes'],


### PR DESCRIPTION
# Description
Small bugfix for a non-breaking issue.  Adds Bonds to the PackInfo's humanReadableMap.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)