### PR TITLE
fix(pilot): initialize pilot gear damage & desc

### DIFF
--- a/src/classes/CompendiumItem.ts
+++ b/src/classes/CompendiumItem.ts
@@ -60,6 +60,7 @@ abstract class CompendiumItem {
       this._name = data.name
       this._flavor_name = data.name
       this._description = data.description || ''
+      this._flavor_description = data.description || ''
       this.Brew = data.brew || 'Core'
       this.LcpName = packName || 'LANCER Core Book'
       this.InLcp = packName ? true : false

--- a/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
+++ b/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
@@ -39,6 +39,7 @@ abstract class PilotEquipment extends CompendiumItem {
     this._destroyed = false
     this._cascading = false
     this._loaded = true
+    this._custom_damage_type = null
     if (data.tags) {
       const ltd = data.tags.find(x => x.id === 'tg_limited')
       this.IsLimited = !!ltd

--- a/src/ui/components/panels/loadout/pilot_loadout/_PLCardBase.vue
+++ b/src/ui/components/panels/loadout/pilot_loadout/_PLCardBase.vue
@@ -149,7 +149,7 @@
       v-if="item"
       ref="damageTypeDialog"
       :allowed-types="['Explosive', 'Energy', 'Kinetic']"
-      @select="item.DamageTypeOverride = $event"
+      @select="save('DamageTypeOverride', $event)"
     />
   </v-col>
 </template>

--- a/src/ui/components/panels/loadout/pilot_loadout/_PLGearCard.vue
+++ b/src/ui/components/panels/loadout/pilot_loadout/_PLGearCard.vue
@@ -88,7 +88,7 @@ import { PilotGear, CompendiumItem, ItemType } from '@/class'
 import { flavorID } from '@/io/Generators'
 
 export default Vue.extend({
-  name: 'pl-pilot-weapon-card',
+  name: 'pl-pilot-gear-card',
   components: { PlCardBase },
   props: {
     item: {


### PR DESCRIPTION
# Description
This PR allows for instantaneous updating of the Description and DamageTypeOverride of pilot gear by initializing the `_flavor_description` and `_custom_damage_type` properties, respectively.  Learned from the fix to #1923 which had a similar fix.

## Issue Number
Closes #1840

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)