### PR TITLE
fix(mech): register mech's Pilot's reservescontroller

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -142,7 +142,8 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
     this.FeatureController.Register(
       this.Frame,
       this.MechLoadoutController,
-      this.Parent.CoreBonusController
+      this.Parent.CoreBonusController,
+      this.Parent.ReservesController
     )
 
     this.MechLoadoutController.UpdateLoadouts()


### PR DESCRIPTION
# Description
This PR updates the Mech class to register the parent pilot's ReservesController so any relevant bonuses are applied (e.g. Extra Repairs adding 2 to repcap).

## Issue Number
Closes #1938

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
