### PR TITLE
fix(style):adjust CCLog spacing to display more content

### DIFF
--- a/src/features/main_menu/_components/CCLog.vue
+++ b/src/features/main_menu/_components/CCLog.vue
@@ -152,11 +152,11 @@ export default Vue.extend({
 <style scoped>
 #output-container {
   position: absolute;
-  height: 90vh;
+  height: 85vh;
   overflow-y: scroll;
   overflow-x: hidden;
   width: calc(100vw - 665px);
-  top: 0;
+  top: 66px;
   right: 0;
   margin-right: 8px;
   z-index: 1;
@@ -166,8 +166,8 @@ export default Vue.extend({
   align-self: stretch;
   display: inline-flex;
   height: inherit;
-  min-height: 95%;
-  max-height: 95%;
+  min-height: calc(100% - 24px);
+  max-height: calc(100% - 24px);
   max-width: 16px;
   width: 16px;
   background: url(../../../assets/ui/scale_1.png);

--- a/src/features/main_menu/_components/CCLog.vue
+++ b/src/features/main_menu/_components/CCLog.vue
@@ -15,9 +15,6 @@
           class="flavor-text subtle--text text--darken-1 py-0 my-0"
         ></p>
         <p id="output" ref="output" class="flavor-text subtle--text text--darken-1 py-0 my-0">
-          <br />
-          <br />
-          <br />
         </p>
       </v-col>
       <v-col cols="auto" class="ml-2">
@@ -63,6 +60,7 @@ export default Vue.extend({
   },
   async mounted() {
     this.lock = true
+    this.restart()
   },
   methods: {
     restart() {
@@ -152,11 +150,11 @@ export default Vue.extend({
 <style scoped>
 #output-container {
   position: absolute;
-  height: 85vh;
+  height: 90vh;
   overflow-y: scroll;
   overflow-x: hidden;
   width: calc(100vw - 665px);
-  top: 66px;
+  top: 0;
   right: 0;
   margin-right: 8px;
   z-index: 1;

--- a/src/features/main_menu/_components/startup_logs/gms.ts
+++ b/src/features/main_menu/_components/startup_logs/gms.ts
@@ -3,6 +3,9 @@ import { encryption } from '@/io/Generators'
 const plog = typer => {
   typer
     .type('<br>')
+    .type('<br>')
+    .type('<br>')
+    .type('<br>')
     .type('COMPANION/CONCIERGE UNIT INITIALIZING')
     .break()
     .type('GMS COMP/CON Unit Mk XI Rev 11.4.1c')

--- a/src/features/main_menu/_components/startup_logs/horus.ts
+++ b/src/features/main_menu/_components/startup_logs/horus.ts
@@ -10,6 +10,9 @@ const HorusStart = typer => {
 
   typer
     .type('<br>')
+    .type('<br>')
+    .type('<br>')
+    .type('<br>')
     .type('COMPANION/CONCIERGE UNIT INITIALIZING')
     .break()
     .type('GMS COMP/CON Unit Mk XI Rev 11.4.1c')

--- a/src/features/main_menu/_components/startup_logs/msmc.ts
+++ b/src/features/main_menu/_components/startup_logs/msmc.ts
@@ -67,6 +67,9 @@ const getPhrase = (): string => {
 const plog = typer => {
   typer
     .type('<br>')
+    .type('<br>')
+    .type('<br>')
+    .type('<br>')
     .type('COMPANION/CONCIERGE UNIT INITIALIZING')
     .break()
     .type('GMS COMP/CON Unit Mk XI Rev 11.4.1c')


### PR DESCRIPTION
# Description
Perform some minor adjustments to the CCLog spacing so that it doesn't immediately start cut off at the top and occupies more of the webpage.

## Issue Number
None currently

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)