### PR TITLE
fix(Active Mode): Make accuracy/difficulty adjustment more sane

### DIFF
--- a/src/features/ui_test/index.vue
+++ b/src/features/ui_test/index.vue
@@ -3,7 +3,7 @@
     <v-divider />
     <cc-title class="mb-2">dice menu</cc-title>
     <cc-dice-menu />
-    <cc-dice-menu preset="2d6+1" title="preset 1" />
+    <cc-dice-menu preset="2d6+1" title="preset 1" autoroll />
     <cc-dice-menu preset="2d6+1d20+3d8-9" :preset-accuracy="-2" title="preset 2" />
 
     <v-divider />

--- a/src/ui/components/CCDiceMenu.vue
+++ b/src/ui/components/CCDiceMenu.vue
@@ -323,12 +323,13 @@ export default Vue.extend({
   },
   watch: {
     menu() {
-      if (!this.menu || !this.autoroll) this.reset()
+      if (!this.autoroll) this.reset()
     },
     presetAccuracy() {
       if (this.autoroll) {
         this.accuracy=this.presetAccuracy
-        this.autoRoll()
+        this.rollAccuracy()
+        this.commit()
       }
     },
   },
@@ -368,7 +369,10 @@ export default Vue.extend({
           overkill: dRoll.overkillRerolls,
         }
       })
-
+      this.rollAccuracy()
+    },
+    rollAccuracy() {
+      this.accTotal=0
       if (this.accuracy) {
         this.accRolls = DiceRoller.rollDamage(
           `${Math.abs(this.accuracy)}d${6}`,
@@ -377,6 +381,7 @@ export default Vue.extend({
         ).rawDieRolls
         this.accTotal = Math.max(...this.accRolls) * (this.accuracy > 0 ? 1 : -1)
       }
+
     },
     reset() {
       this.clear()


### PR DESCRIPTION
# Description
Currently, adjusting accuracy or difficulty on an "autoroll" re-rolls every dice. This can cause frustration when a hit ( or especially a critical hit ) becomes a miss after adding accuracy, due to a drastically different base die roll, usually d20.

This change only re-rolls the accuracy / difficulty di(c)e when changing the preset accuracy. Please not that this does re-roll EVERY d6. This means that clicking the + button from 1 accuracy to 2 accuracy the total could go down, but never below the base value. The converse is true of difficulty, we will not longer have a miss turn into a hit after adding difficulty.

## Issue Number
Closes #1819 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
