### PR TITLE
feat(Compendium): use AND filter on Frame role/mounts

### DIFF
--- a/src/classes/utility/ItemFilter.ts
+++ b/src/classes/utility/ItemFilter.ts
@@ -1,4 +1,4 @@
-import { MechEquipment, CompendiumItem, MechWeapon } from '@/class'
+import { MechEquipment, CompendiumItem, MechWeapon, Frame } from '@/class'
 
 class ItemFilter {
   public static Filter(items: CompendiumItem[], filter: any): CompendiumItem[] {
@@ -16,6 +16,10 @@ class ItemFilter {
         items = items.filter((x: MechEquipment) => x.SP < filter[p])
       } else if (p === 'SP_eq') {
         items = items.filter((x: MechEquipment) => x.SP === filter[p])
+      } else if (p === 'MechType') {
+        items = items.filter((f: Frame) => filter[p].every(t => f.MechType.includes(t)))
+      } else if (p === 'Mounts') {
+        items = items.filter((f: Frame) => filter[p].every(m => f.Mounts.includes(m)))
       } else if (filter[p].length) items = items.filter(x => filter[p].some(e => x[p].includes(e)))
     })
     return items

--- a/src/ui/components/cards/_MechWeaponCard.vue
+++ b/src/ui/components/cards/_MechWeaponCard.vue
@@ -114,9 +114,6 @@
           </v-col>
         </v-row>
       </div>
-
-      hello world
-
       <div v-if="item.Profiles.length > 1 && item.ProfileTags && item.ProfileTags.length">
         <div class="overline ml-n2 mb-n1 subtle--text">PROFILE TAGS</div>
         <cc-tags :tags="item.ProfileTags" extended />


### PR DESCRIPTION
# Description
This PR Changes the filters for Frames such that all Role and Mount selections must match for a Frame to be displayed. For example, Caliban will appear for when the Roles "Controller", "Striker", and "Controller+Striker"  are selected, but not "Controller + Defender".  In a similar way, Caliban will appear when "Heavy" mount is selected, but not when "Heavy + Flex" mounts are selected.  This is a similar change to #1860.

## Issue Number
Closes #1966

## Type of change
- [x] New feature (non-breaking change which adds functionality)
