### PR TITLE
fix(pilot): roster remote refresh, error handling

### DIFF
--- a/src/features/pilot_management/PilotSheet/components/PilotNav.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotNav.vue
@@ -187,6 +187,7 @@ export default Vue.extend({
         console.error(error)
         this.$notify('An error occurred while attempting to download remote data', 'error')
       }
+      this.loading = false
     },
   },
 })

--- a/src/features/pilot_management/PilotSheet/components/ShareDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/ShareDialog.vue
@@ -109,17 +109,19 @@ export default Vue.extend({
   methods: {
     async generate() {
       this.loading = true
-      const res = await generateCode(this.pilot)
-      this.pilot.CloudController.SetShareCode(res)
-      this.$notify('Share Code generated', 'success')
+      await generateCode(this.pilot)
+        .then(res => this.pilot.CloudController.SetShareCode(res))
+        .then(() => this.$notify('Share Code generated', 'success'))
+        .catch(() => this.$notify('An error occurred while attempting to generate a share code', 'error'))
       this.loading = false
     },
     async refresh() {
       this.loading = true
       const c = this.pilot.CloudController.ShareCode
       await refreshItem(c)
-      this.pilot.CloudController.SetShareCode(c)
-      this.$notify('Share Code refreshed', 'success')
+        .then(() => this.pilot.CloudController.SetShareCode(c))
+        .then(() => this.$notify('Share Code refreshed', 'success'))
+        .catch(() => this.$notify('An error occurred while attempting to refresh the share code', 'error'))
       this.loading = false
     },
     copy() {


### PR DESCRIPTION
# Description
This PR prevents users from creating Share Codes for remote pilots from the Pilot Roster, instead matching functionality with the Pilot Management Navbar.  It also improves error handling when an error occurs while generating/refreshing a share code.

## Issue Number
Closes #1970

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)