### PR TITLE
Issue #1847 - fix GetOrganized active mode

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetOrganized.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/downtime/_GetOrganized.vue
@@ -167,25 +167,24 @@
                                 >
                                   <v-radio label="Folds Immediately" value="fold" color="error" />
                                   <v-radio
-                                    :label="`Loses Efficiency (${selected.Efficiency} available)`"
-                                    :disabled="selected.Efficiency === 0"
-                                    value="efficiency"
+                                    :label="`Loses 2 Efficiency (${selected.Efficiency} available) and 2 Influence (${selected.Influence} available)`"
+                                    :disabled="selected.Influence === 0 && selected.Efficiency === 0"
+                                    value="efficiencyInfluence"
                                     color="warning"
                                   />
                                   <v-radio
-                                    :label="`Loses Influence (${selected.Influence} available)`"
-                                    :disabled="selected.Influence === 0"
-                                    value="influence"
+                                    :label="`Needs to Take Action`"
+                                    value="takeAction"
                                     color="warning"
-                                  />
+                                  />     
                                 </v-radio-group>
                               </v-col>
                             </v-row>
                             <v-slide-x-reverse-transition>
-                              <div v-show="badChoice !== '' && badChoice !== 'fold'">
+                              <div v-show="badChoice === 'takeAction'">
                                 <br />
                                 <span>
-                                  Additionally, the organization takes one of the following actions:
+                                  The organization takes one of the following actions:
                                 </span>
                                 <v-btn-toggle v-model="action" mandatory>
                                   <v-btn text large value="Pay Debts">Pay Debts</v-btn>
@@ -425,13 +424,13 @@ export default Vue.extend({
             ),
             1
           )
-        } else if (this.badChoice === 'efficiency') {
-          this.selected.Efficiency -= 2
+        } else if (this.badChoice === 'efficiencyInfluence') {
+          if(this.selected.Efficiency > 0)
+            this.selected.Efficiency -= 2
+          if(this.selected.Influence > 0)
+            this.selected.Influence -= 2
           this.selected.Actions = this.action
-        } else if (this.badChoice === 'influence') {
-          this.selected.Influence -= 2
-          this.selected.Actions = this.action
-        }
+          }
       } else if (parseInt(this.improveRoll) < 20) {
         if (this.improvement === 'efficiency') {
           this.selected.Efficiency += 2


### PR DESCRIPTION
# Description

This change fixes the Get Organized downtime action in Active Mode to match the rules. Specifically, this addresses improvement roll results of 9 or less, when the player needs to reduce BOTH Efficiency and Influence by 2 (to a minimum of 0) OR take action. Below is the relevant ruling from the core book, pg. 55:

![image](https://user-images.githubusercontent.com/64377838/165005358-43d78553-885a-4901-82bc-64e5d98ec5da.png)


## Issue Number
#1847

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
