### PR TITLE
fix(compendium): create Licenses using 'source' filter

### DIFF
--- a/src/classes/pilot/components/license/License.ts
+++ b/src/classes/pilot/components/license/License.ts
@@ -26,7 +26,7 @@ class License {
         store.getters.getItemCollection('WeaponMods'),
         store.getters.getItemCollection('MechSystems')
       )
-      .filter((x: LicensedItem) => x.License.toUpperCase() === frame.Name.toUpperCase())
+      .filter((x: LicensedItem) => (x.License.toUpperCase() === frame.Name.toUpperCase()) && x.Source.toUpperCase() === frame.Source.toUpperCase())
 
     const lls = [...items].map(i => i.LicenseLevel)
 

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -167,7 +167,7 @@ export class CompendiumStore extends VuexModule {
 
   get Licenses(): License[] {
     return this.Frames.filter(x => x.Source !== 'GMS' && !x.IsHidden).map(frame => {
-      const variants = this.Frames.filter(f => f.Variant.toUpperCase() === frame.Name.toUpperCase())
+      const variants = this.Frames.filter(f => (f.Variant.toUpperCase() === frame.Name.toUpperCase()) && (f.Source.toUpperCase() === frame.Source.toUpperCase()))
       return new License(frame, variants)
     })
   }


### PR DESCRIPTION
# Description
This PR additionally filters licensed items and Variant Frames by "source" (aka Manufacturer abbreviation, like HA or IPS-N).  This is a stopgap fix for homebrew LCPs with matching Frame Names.  In the future, we will probably want to implement a "parent ID" data field for Weapons, Systems, Mods, and variant frames.

## Issue Number
Partially covers #1981, but additional work would be good to make this more robust.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
