### PR TITLE
1887 [FEATURE]Generate Statblock Revision

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -35,159 +35,165 @@ function addWeaponToOutput(output: string, discordEmoji: boolean, w: MechWeapon 
 }
 
 class Statblock {
-  public static Generate(pilot: Pilot, mech: Mech, discordEmoji: boolean, fullView: boolean): string {
+  public static Generate(pilot: Pilot, mech: Mech, discordEmoji: boolean, view: string): string {
     let output = ''
 
-    output += `» ${pilot.Name} // ${pilot.Callsign.toUpperCase()} «\n  `
-    if (pilot.Background) {
-      output += `${pilot.Background}, `
-    }
-    output += `LL${pilot.Level}\n`
-    output += `[ SKILL TRIGGERS ]\n  `
-    for (let i = 0; i < pilot.SkillsController.Skills.length; i++) {
-      const s = pilot.SkillsController.Skills[i]
-      output += `${s.Skill.Trigger} (+${s.Bonus})${linebreak(
-        i,
-        pilot.SkillsController.Skills.length
-      )}`
-    }
+    if (view == "pilotBuild" || "full") {
 
-    const loadout = pilot.PilotLoadoutController.Loadout
-    if (loadout) {
-      output += '[ GEAR ]\n  '
-      for (let i = 0; i < loadout.Items.length; i++) {
-        if (loadout.Items[i]) {
-          output += `${loadout.Items[i].TrueName}${linebreak(i, loadout.Items.length)}`
-          if (discordEmoji) {
-            const weapon = loadout.Items[i] as PilotWeapon
-            if ('Range' in weapon) {
-              const ranges: string[] = []
-              weapon.Range.forEach(r => {
-                ranges.push(`${r.DiscordEmoji} ${r.Value}`)
-              })
-              output += ` ${ranges.join(' ')}`
-            }
-            if ('Damage' in weapon) {
-              const damages: string[] = []
-              weapon.Damage.forEach(d => {
-                damages.push(`${d.DiscordEmoji} ${d.Value}`)
-              })
-              output += ` ${damages.join(' ')}`
-            }
-          }
-        }
+      output += `» ${pilot.Name} // ${pilot.Callsign.toUpperCase()} «\n  `
+      if (pilot.Background) {
+        output += `${pilot.Background}, `
       }
-    }
-
-    const bond = pilot.BondController
-    if (bond.Bond) {
-      output += '[ BOND ]\n  '
-      output += `${bond.Bond.Name.toUpperCase()}\n`
-      if (bond.BondPowers) {
-        output += '  Powers: '
-        for (let i = 0; i < bond.BondPowers.length; i++) {
-          output += `${bond.BondPowers[i].name.toUpperCase()}${linebreak(i, bond.BondPowers.length)}`
-        }
-      }
-    }
-    output += '**\n'
-
-    output += '[ MECH SKILLS]\n  '
-    output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
-
-    output += '[ TALENTS ]\n  '
-    for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
-      const t = pilot.TalentsController.Talents[i]
-      output += `${t.Talent.Name} ${t.Rank}${linebreak(
-        i,
-        pilot.TalentsController.Talents.length
-      )}`
-    }
-
-    if (pilot.LicenseController.Licenses.length) {
-      output += '[ LICENSES ]\n  '
-      for (let i = 0; i < pilot.LicenseController.Licenses.length; i++) {
-        const l = pilot.LicenseController.Licenses[i]
-        output += `${l.License.Source} ${l.License.Name} ${l.Rank}${linebreak(
+      output += `LL${pilot.Level}\n`
+      output += `[ SKILL TRIGGERS ]\n  `
+      for (let i = 0; i < pilot.SkillsController.Skills.length; i++) {
+        const s = pilot.SkillsController.Skills[i]
+        output += `${s.Skill.Trigger} (+${s.Bonus})${linebreak(
           i,
-          pilot.LicenseController.Licenses.length
+          pilot.SkillsController.Skills.length
         )}`
       }
-    }
 
-    if (pilot.CoreBonusController.CoreBonuses.length) {
-      output += '[ CORE BONUSES ]\n  '
-      for (let i = 0; i < pilot.CoreBonusController.CoreBonuses.length; i++) {
-        const cb = pilot.CoreBonusController.CoreBonuses[i]
-        output += `${cb.Name}${linebreak(i, pilot.CoreBonusController.CoreBonuses.length)}`
-      }
-    }
-
-
-    if (mech && fullView == true) {
-      output += '----------\n'
-    
-      output += `« ${mech.Name.toUpperCase()} »\n[ ${mech.Frame.Source} ${mech.Frame.Name} ]\n`
-      if (!pilot)
-        output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
-      output += `  STRUCTURE:${mech.CurrentStructure}${
-        mech.IsActive ? '/' + mech.MaxStructure : ''
-      }`
-      output += ` HP:${mech.CurrentHP}${mech.IsActive ? '/' + mech.MaxHP : ''}`
-      output += ` ARMOR:${mech.Armor}\n`
-      output += `  STRESS:${mech.CurrentStress}${mech.IsActive ? '/' + mech.MaxStress : ''}`
-      output += ` HEAT:${mech.CurrentHeat}${mech.IsActive ? '/' + mech.HeatCapacity : ''}`
-      output += ` REPAIR:${mech.CurrentRepairs}${mech.IsActive ? '/' + mech.RepairCapacity : ''}\n`
-      output += `  ATK BONUS:${mech.AttackBonus} TECH ATK:${mech.TechAttack} LTD BONUS:${mech.LimitedBonus}\n`
-      output += `  SPD:${mech.Speed} EVA:${mech.Evasion} EDEF:${mech.EDefense} SENS:${mech.SensorRange} SAVE:${mech.SaveTarget}\n`
-
-      output += '[ WEAPONS ]\n'
-      for (const im of mech.FeatureController.IntegratedWeapons) {
-        output += '  INTEGRATED MOUNT: '
-        output = addWeaponToOutput(output, discordEmoji, im)
-        output += '\n'
-      }
-      const loadout = mech.MechLoadoutController.ActiveLoadout
-        ? mech.MechLoadoutController.ActiveLoadout
-        : mech.MechLoadoutController.Loadouts[0]
+      const loadout = pilot.PilotLoadoutController.Loadout
       if (loadout) {
-        for (const mount of loadout.AllEquippableMounts(
-          pilot && pilot.has('CoreBonus', 'cb_improved_armament'),
-          pilot && pilot.has('CoreBonus', 'cb_integrated_weapon')
-        )) {
-          output += `  ${mount.Name}: `
-          if (mount.IsLocked) {
-            output += 'SUPERHEAVY WEAPON BRACING'
-          } else {
-            mount.Weapons.forEach((w, idx) => {
-              output = addWeaponToOutput(output, discordEmoji, w)
-              if (w.Mod) output += ` (${w.Mod.TrueName})`
-              if (idx + 1 < mount.Weapons.length) output += ' / '
-            })
+        output += '[ GEAR ]\n  '
+        for (let i = 0; i < loadout.Items.length; i++) {
+          if (loadout.Items[i]) {
+            output += `${loadout.Items[i].TrueName}${linebreak(i, loadout.Items.length)}`
+            if (discordEmoji) {
+              const weapon = loadout.Items[i] as PilotWeapon
+              if ('Range' in weapon) {
+                const ranges: string[] = []
+                weapon.Range.forEach(r => {
+                  ranges.push(`${r.DiscordEmoji} ${r.Value}`)
+                })
+                output += ` ${ranges.join(' ')}`
+              }
+              if ('Damage' in weapon) {
+                const damages: string[] = []
+                weapon.Damage.forEach(d => {
+                  damages.push(`${d.DiscordEmoji} ${d.Value}`)
+                })
+                output += ` ${damages.join(' ')}`
+              }
+            }
           }
+        }
+      }
 
-          if (mount.Bonuses.length > 0) {
-            output += ' // ' + mount.Bonuses.map(bonus => bonus.Name).join(', ')
+      const bond = pilot.BondController
+      if (bond.Bond) {
+        output += '[ BOND ]\n  '
+        output += `${bond.Bond.Name.toUpperCase()}\n`
+        if (bond.BondPowers) {
+          output += '  Powers: '
+          for (let i = 0; i < bond.BondPowers.length; i++) {
+            output += `${bond.BondPowers[i].name.toUpperCase()}${linebreak(i, bond.BondPowers.length)}`
           }
+        }
+      }
 
+      if (view == "full") {output += '***\n'}
+
+      output += '[ MECH SKILLS]\n  '
+      output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
+
+      output += '[ TALENTS ]\n  '
+      for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
+        const t = pilot.TalentsController.Talents[i]
+        output += `${t.Talent.Name} ${t.Rank}${linebreak(
+          i,
+          pilot.TalentsController.Talents.length
+        )}`
+      }
+
+      if (pilot.LicenseController.Licenses.length) {
+        output += '[ LICENSES ]\n  '
+        for (let i = 0; i < pilot.LicenseController.Licenses.length; i++) {
+          const l = pilot.LicenseController.Licenses[i]
+          output += `${l.License.Source} ${l.License.Name} ${l.Rank}${linebreak(
+            i,
+            pilot.LicenseController.Licenses.length
+          )}`
+        }
+      }
+
+      if (pilot.CoreBonusController.CoreBonuses.length) {
+        output += '[ CORE BONUSES ]\n  '
+        for (let i = 0; i < pilot.CoreBonusController.CoreBonuses.length; i++) {
+          const cb = pilot.CoreBonusController.CoreBonuses[i]
+          output += `${cb.Name}${linebreak(i, pilot.CoreBonusController.CoreBonuses.length)}`
+        }
+      }
+    }   
+
+
+    if (mech) {
+      if (view == "full") {
+    
+        output += `[ MECH ]\n  « ${mech.Name.toUpperCase()} »\n  ${mech.Frame.Source} ${mech.Frame.Name}\n`
+          output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
+        output += `  STRUCTURE:${mech.CurrentStructure}${
+          mech.IsActive ? '/' + mech.MaxStructure : ''
+        }`
+        output += ` HP:${mech.CurrentHP}${mech.IsActive ? '/' + mech.MaxHP : ''}`
+        output += ` ARMOR:${mech.Armor}\n`
+        output += `  STRESS:${mech.CurrentStress}${mech.IsActive ? '/' + mech.MaxStress : ''}`
+        output += ` HEAT:${mech.CurrentHeat}${mech.IsActive ? '/' + mech.HeatCapacity : ''}`
+        output += ` REPAIR:${mech.CurrentRepairs}${mech.IsActive ? '/' + mech.RepairCapacity : ''}\n`
+        output += `  ATK BONUS:${mech.AttackBonus} TECH ATK:${mech.TechAttack} LTD BONUS:${mech.LimitedBonus}\n`
+        output += `  SPD:${mech.Speed} EVA:${mech.Evasion} EDEF:${mech.EDefense} SENS:${mech.SensorRange} SAVE:${mech.SaveTarget}\n`
+  
+        output += '[ WEAPONS ]\n'
+        for (const im of mech.FeatureController.IntegratedWeapons) {
+          output += '  INTEGRATED MOUNT: '
+          output = addWeaponToOutput(output, discordEmoji, im)
           output += '\n'
         }
-
-        output += '[ SYSTEMS ]\n  '
-        const allsys = mech.MechLoadoutController.ActiveLoadout.IntegratedSystems.concat(
-          loadout.Systems
-        )
-        allsys.forEach((sys, i) => {
-          output += `${sys.TrueName}${linebreak(i, allsys.length)}`
-        })
+        const loadout = mech.MechLoadoutController.ActiveLoadout
+          ? mech.MechLoadoutController.ActiveLoadout
+          : mech.MechLoadoutController.Loadouts[0]
+        if (loadout) {
+          for (const mount of loadout.AllEquippableMounts(
+            pilot && pilot.has('CoreBonus', 'cb_improved_armament'),
+            pilot && pilot.has('CoreBonus', 'cb_integrated_weapon')
+          )) {
+            output += `  ${mount.Name}: `
+            if (mount.IsLocked) {
+              output += 'SUPERHEAVY WEAPON BRACING'
+            } else {
+              mount.Weapons.forEach((w, idx) => {
+                output = addWeaponToOutput(output, discordEmoji, w)
+                if (w.Mod) output += ` (${w.Mod.TrueName})`
+                if (idx + 1 < mount.Weapons.length) output += ' / '
+              })
+            }
+  
+            if (mount.Bonuses.length > 0) {
+              output += ' // ' + mount.Bonuses.map(bonus => bonus.Name).join(', ')
+            }
+  
+            output += '\n'
+          }
+  
+          output += '[ SYSTEMS ]\n  '
+          const allsys = mech.MechLoadoutController.ActiveLoadout.IntegratedSystems.concat(
+            loadout.Systems
+          )
+          allsys.forEach((sys, i) => {
+            output += `${sys.TrueName}${linebreak(i, allsys.length)}`
+          })
+        }
       }
-    }
-
+      else { output += "\n> ERR: NO MECHS FOUND"}
+    }  
+    
     return output
   }
 
   public static GenerateBuildSummary(pilot: Pilot, mech: Mech, discordEmoji: boolean): string {
-    const mechLoadout = mech.MechLoadoutController.ActiveLoadout
+    if (mech) {
+      const mechLoadout = mech.MechLoadoutController.ActiveLoadout
       ? mech.MechLoadoutController.ActiveLoadout
       : mech.MechLoadoutController.Loadouts[0]
     return `-- ${mech.Frame.Source} ${mech.Frame.Name} @ LL${pilot.Level} --
@@ -281,6 +287,8 @@ class Statblock {
     if (sys.IsLimited) out += ` x${sys.getTotalUses(mech.LimitedBonus)}`
     return out
   }).join(', ')}`
+}
+    else return "No Mechs? o.0"
   }
 
   public static GenerateNPC(npc: Npc): string {

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -35,98 +35,98 @@ function addWeaponToOutput(output: string, discordEmoji: boolean, w: MechWeapon 
 }
 
 class Statblock {
-  public static Generate(pilot: Pilot, mech: Mech, discordEmoji: boolean): string {
+  public static Generate(pilot: Pilot, mech: Mech, discordEmoji: boolean, fullView: boolean): string {
     let output = ''
-    if (pilot) {
-      output += `» ${pilot.Name} // ${pilot.Callsign.toUpperCase()} «\n  `
-      if (pilot.Background) {
-        output += `${pilot.Background}, `
-      }
-      output += `LL${pilot.Level}\n`
-      output += `[ SKILL TRIGGERS ]\n  `
-      for (let i = 0; i < pilot.SkillsController.Skills.length; i++) {
-        const s = pilot.SkillsController.Skills[i]
-        output += `${s.Skill.Trigger} (+${s.Bonus})${linebreak(
-          i,
-          pilot.SkillsController.Skills.length
-        )}`
-      }
 
-      const loadout = pilot.PilotLoadoutController.Loadout
-      if (loadout) {
-        output += '[ GEAR ]\n  '
-        for (let i = 0; i < loadout.Items.length; i++) {
-          if (loadout.Items[i]) {
-            output += `${loadout.Items[i].TrueName}${linebreak(i, loadout.Items.length)}`
-            if (discordEmoji) {
-              const weapon = loadout.Items[i] as PilotWeapon
-              if ('Range' in weapon) {
-                const ranges: string[] = []
-                weapon.Range.forEach(r => {
-                  ranges.push(`${r.DiscordEmoji} ${r.Value}`)
-                })
-                output += ` ${ranges.join(' ')}`
-              }
-              if ('Damage' in weapon) {
-                const damages: string[] = []
-                weapon.Damage.forEach(d => {
-                  damages.push(`${d.DiscordEmoji} ${d.Value}`)
-                })
-                output += ` ${damages.join(' ')}`
-              }
+    output += `» ${pilot.Name} // ${pilot.Callsign.toUpperCase()} «\n  `
+    if (pilot.Background) {
+      output += `${pilot.Background}, `
+    }
+    output += `LL${pilot.Level}\n`
+    output += `[ SKILL TRIGGERS ]\n  `
+    for (let i = 0; i < pilot.SkillsController.Skills.length; i++) {
+      const s = pilot.SkillsController.Skills[i]
+      output += `${s.Skill.Trigger} (+${s.Bonus})${linebreak(
+        i,
+        pilot.SkillsController.Skills.length
+      )}`
+    }
+
+    const loadout = pilot.PilotLoadoutController.Loadout
+    if (loadout) {
+      output += '[ GEAR ]\n  '
+      for (let i = 0; i < loadout.Items.length; i++) {
+        if (loadout.Items[i]) {
+          output += `${loadout.Items[i].TrueName}${linebreak(i, loadout.Items.length)}`
+          if (discordEmoji) {
+            const weapon = loadout.Items[i] as PilotWeapon
+            if ('Range' in weapon) {
+              const ranges: string[] = []
+              weapon.Range.forEach(r => {
+                ranges.push(`${r.DiscordEmoji} ${r.Value}`)
+              })
+              output += ` ${ranges.join(' ')}`
+            }
+            if ('Damage' in weapon) {
+              const damages: string[] = []
+              weapon.Damage.forEach(d => {
+                damages.push(`${d.DiscordEmoji} ${d.Value}`)
+              })
+              output += ` ${damages.join(' ')}`
             }
           }
         }
       }
+    }
 
-      const bond = pilot.BondController
-      if (bond.Bond) {
-        output += '[ BOND ]\n  '
-        output += `${bond.Bond.Name.toUpperCase()}\n`
-        if (bond.BondPowers) {
-          output += '  Powers: '
-          for (let i = 0; i < bond.BondPowers.length; i++) {
-            output += `${bond.BondPowers[i].name.toUpperCase()}${linebreak(i, bond.BondPowers.length)}`
-          }
-        }
-      }
-      output += '---\n'
-
-      output += '[ MECH SKILLS]\n  '
-      output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
-
-      output += '[ TALENTS ]\n  '
-      for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
-        const t = pilot.TalentsController.Talents[i]
-        output += `${t.Talent.Name} ${t.Rank}${linebreak(
-          i,
-          pilot.TalentsController.Talents.length
-        )}`
-      }
-
-      if (pilot.LicenseController.Licenses.length) {
-        output += '[ LICENSES ]\n  '
-        for (let i = 0; i < pilot.LicenseController.Licenses.length; i++) {
-          const l = pilot.LicenseController.Licenses[i]
-          output += `${l.License.Source} ${l.License.Name} ${l.Rank}${linebreak(
-            i,
-            pilot.LicenseController.Licenses.length
-          )}`
-        }
-      }
-
-      if (pilot.CoreBonusController.CoreBonuses.length) {
-        output += '[ CORE BONUSES ]\n  '
-        for (let i = 0; i < pilot.CoreBonusController.CoreBonuses.length; i++) {
-          const cb = pilot.CoreBonusController.CoreBonuses[i]
-          output += `${cb.Name}${linebreak(i, pilot.CoreBonusController.CoreBonuses.length)}`
+    const bond = pilot.BondController
+    if (bond.Bond) {
+      output += '[ BOND ]\n  '
+      output += `${bond.Bond.Name.toUpperCase()}\n`
+      if (bond.BondPowers) {
+        output += '  Powers: '
+        for (let i = 0; i < bond.BondPowers.length; i++) {
+          output += `${bond.BondPowers[i].name.toUpperCase()}${linebreak(i, bond.BondPowers.length)}`
         }
       }
     }
+    output += '**\n'
 
-    if (pilot && mech) output += '----------\n'
+    output += '[ MECH SKILLS]\n  '
+    output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
 
-    if (mech) {
+    output += '[ TALENTS ]\n  '
+    for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
+      const t = pilot.TalentsController.Talents[i]
+      output += `${t.Talent.Name} ${t.Rank}${linebreak(
+        i,
+        pilot.TalentsController.Talents.length
+      )}`
+    }
+
+    if (pilot.LicenseController.Licenses.length) {
+      output += '[ LICENSES ]\n  '
+      for (let i = 0; i < pilot.LicenseController.Licenses.length; i++) {
+        const l = pilot.LicenseController.Licenses[i]
+        output += `${l.License.Source} ${l.License.Name} ${l.Rank}${linebreak(
+          i,
+          pilot.LicenseController.Licenses.length
+        )}`
+      }
+    }
+
+    if (pilot.CoreBonusController.CoreBonuses.length) {
+      output += '[ CORE BONUSES ]\n  '
+      for (let i = 0; i < pilot.CoreBonusController.CoreBonuses.length; i++) {
+        const cb = pilot.CoreBonusController.CoreBonuses[i]
+        output += `${cb.Name}${linebreak(i, pilot.CoreBonusController.CoreBonuses.length)}`
+      }
+    }
+
+
+    if (fullView == true) {
+      output += '----------\n'
+
       output += `« ${mech.Name.toUpperCase()} »\n[ ${mech.Frame.Source} ${mech.Frame.Name} ]\n`
       if (!pilot)
         output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
@@ -182,6 +182,7 @@ class Statblock {
         })
       }
     }
+    
 
     return output
   }

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -95,9 +95,10 @@ class Statblock {
 
       if (view == "full") {output += '***\n'}
 
-      output += '[ MECH SKILLS]\n  '
-      output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
-
+      if (view == "pilotBuild"){ 
+        output += '[ MECH SKILLS]\n  '
+        output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
+      }
       output += '[ TALENTS ]\n  '
       for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
         const t = pilot.TalentsController.Talents[i]
@@ -132,7 +133,7 @@ class Statblock {
       if (view == "full") {
     
         output += `[ MECH ]\n  « ${mech.Name.toUpperCase()} »\n  ${mech.Frame.Source} ${mech.Frame.Name}\n`
-          output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
+          output += `  H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
         output += `  STRUCTURE:${mech.CurrentStructure}${
           mech.IsActive ? '/' + mech.MaxStructure : ''
         }`
@@ -185,9 +186,8 @@ class Statblock {
           })
         }
       }
-      else { output += "\n> ERR: NO MECHS FOUND"}
     }  
-    
+    else if (view == "full") { output += "\n>> NO MECHS FOUND <<"}
     return output
   }
 
@@ -288,7 +288,7 @@ class Statblock {
     return out
   }).join(', ')}`
 }
-    else return "No Mechs? o.0"
+    else return ">> NO MECHS FOUND <<"
   }
 
   public static GenerateNPC(npc: Npc): string {

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -124,9 +124,9 @@ class Statblock {
     }
 
 
-    if (fullView == true) {
+    if (mech && fullView == true) {
       output += '----------\n'
-
+    
       output += `« ${mech.Name.toUpperCase()} »\n[ ${mech.Frame.Source} ${mech.Frame.Name} ]\n`
       if (!pilot)
         output += `H:${mech.Hull} A:${mech.Agi} S:${mech.Sys} E:${mech.Eng} SIZE:${mech.Size}\n`
@@ -182,7 +182,6 @@ class Statblock {
         })
       }
     }
-    
 
     return output
   }

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -187,7 +187,7 @@ class Statblock {
         }
       }
     }  
-    else if (view == "full") { output += "\n>> NO MECHS FOUND <<"}
+    else if (view == "full") { output += "\n>> NO MECH SELECTED <<"}
     return output
   }
 
@@ -288,7 +288,7 @@ class Statblock {
     return out
   }).join(', ')}`
 }
-    else return ">> NO MECHS FOUND <<"
+    else return ">> NO MECH SELECTED <<"
   }
 
   public static GenerateNPC(npc: Npc): string {

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -96,7 +96,7 @@ class Statblock {
       if (view == "full") {output += '***\n'}
 
       if (view == "pilotBuild"){ 
-        output += '[ MECH SKILLS]\n  '
+        output += '[ MECH SKILLS ]\n  '
         output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
       }
       output += '[ TALENTS ]\n  '

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -1,9 +1,10 @@
+import { Bond } from '@/classes/pilot/components/bond/Bond';
 /* eslint-disable @typescript-eslint/indent */
 import { Pilot, Mech, Npc, PilotWeapon, MechWeapon } from '../class'
 
 function linebreak(i: number, length: number): string {
   if (i > 0 && (i + 1) % 2 === 0 && i + 1 !== length) {
-    return '\n  '
+    return ',\n  '
   } else if (i + 1 < length) {
     return ', '
   } else {
@@ -37,9 +38,11 @@ class Statblock {
   public static Generate(pilot: Pilot, mech: Mech, discordEmoji: boolean): string {
     let output = ''
     if (pilot) {
-      output += `» ${pilot.Callsign.toUpperCase()} «\n`
-      output += `${pilot.Name}\n${pilot.Background}, LL${pilot.Level}\n`
-      output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
+      output += `» ${pilot.Name} // ${pilot.Callsign.toUpperCase()} «\n  `
+      if (pilot.Background) {
+        output += `${pilot.Background}, `
+      }
+      output += `LL${pilot.Level}\n`
       output += `[ SKILL TRIGGERS ]\n  `
       for (let i = 0; i < pilot.SkillsController.Skills.length; i++) {
         const s = pilot.SkillsController.Skills[i]
@@ -48,6 +51,49 @@ class Statblock {
           pilot.SkillsController.Skills.length
         )}`
       }
+
+      const loadout = pilot.PilotLoadoutController.Loadout
+      if (loadout) {
+        output += '[ GEAR ]\n  '
+        for (let i = 0; i < loadout.Items.length; i++) {
+          if (loadout.Items[i]) {
+            output += `${loadout.Items[i].TrueName}${linebreak(i, loadout.Items.length)}`
+            if (discordEmoji) {
+              const weapon = loadout.Items[i] as PilotWeapon
+              if ('Range' in weapon) {
+                const ranges: string[] = []
+                weapon.Range.forEach(r => {
+                  ranges.push(`${r.DiscordEmoji} ${r.Value}`)
+                })
+                output += ` ${ranges.join(' ')}`
+              }
+              if ('Damage' in weapon) {
+                const damages: string[] = []
+                weapon.Damage.forEach(d => {
+                  damages.push(`${d.DiscordEmoji} ${d.Value}`)
+                })
+                output += ` ${damages.join(' ')}`
+              }
+            }
+          }
+        }
+      }
+
+      const bond = pilot.BondController
+      if (bond.Bond) {
+        output += '[ BOND ]\n  '
+        output += `${bond.Bond.Name.toUpperCase()}\n`
+        if (bond.BondPowers) {
+          output += '  Powers: '
+          for (let i = 0; i < bond.BondPowers.length; i++) {
+            output += `${bond.BondPowers[i].name.toUpperCase()}${linebreak(i, bond.BondPowers.length)}`
+          }
+        }
+      }
+      output += '---\n'
+
+      output += '[ MECH SKILLS]\n  '
+      output += `GRIT:${pilot.Grit} // H:${pilot.MechSkillsController.MechSkills.Hull} A:${pilot.MechSkillsController.MechSkills.Agi} S:${pilot.MechSkillsController.MechSkills.Sys} E:${pilot.MechSkillsController.MechSkills.Eng}\n`
 
       output += '[ TALENTS ]\n  '
       for (let i = 0; i < pilot.TalentsController.Talents.length; i++) {
@@ -76,41 +122,9 @@ class Statblock {
           output += `${cb.Name}${linebreak(i, pilot.CoreBonusController.CoreBonuses.length)}`
         }
       }
-
-      const loadout = pilot.PilotLoadoutController.Loadout
-      if (loadout) {
-        output += '[ GEAR ]\n  '
-        for (let i = 0; i < loadout.Items.length; i++) {
-          if (loadout.Items[i]) {
-            output += `${loadout.Items[i].TrueName}`
-            if (discordEmoji) {
-              const weapon = loadout.Items[i] as PilotWeapon
-              if ('Range' in weapon) {
-                const ranges: string[] = []
-                weapon.Range.forEach(r => {
-                  ranges.push(`${r.DiscordEmoji} ${r.Value}`)
-                })
-                output += ` ${ranges.join(' ')}`
-              }
-              if ('Damage' in weapon) {
-                const damages: string[] = []
-                weapon.Damage.forEach(d => {
-                  damages.push(`${d.DiscordEmoji} ${d.Value}`)
-                })
-                output += ` ${damages.join(' ')}`
-              }
-            }
-            if (i > 0 && (i + 1) % 2 === 0 && i + 1 !== loadout.Items.length) {
-              output += '\n  '
-            } else if (i + 1 < loadout.Items.length) {
-              output += ', '
-            }
-          }
-        }
-      }
     }
 
-    if (pilot && mech) output += '\n----------\n'
+    if (pilot && mech) output += '----------\n'
 
     if (mech) {
       output += `« ${mech.Name.toUpperCase()} »\n[ ${mech.Frame.Source} ${mech.Frame.Name} ]\n`

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -38,18 +38,19 @@ export default class StatblockDialog extends Vue {
   @Prop({type: Object, required: true})
   readonly pilot: Pilot
 
-  mechSelect = ""
+  mechSelect = ''
   discordEmoji = false
   genRadios = 'mechBuild'
 
   mounted() {
     this.mechSelect = this.pilot.ActiveMech?.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1]?.ID ?? ''
+    if (this.mechSelect == '') {this.genRadios='pilotBuild'} 
   }
 
   get statblock(): string {
     const mech = this.mechSelect ? this.pilot.Mechs.find(x => x.ID === this.mechSelect) : null
     
-    if (this.genRadios != "mechBuild") {
+    if (this.genRadios != 'mechBuild') {
       return Statblock.Generate(this.pilot, mech, this.discordEmoji, this.genRadios)
     }
     else return Statblock.GenerateBuildSummary(this.pilot, mech, this.discordEmoji)  

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -36,10 +36,11 @@ export default class StatblockDialog extends Vue {
   discordEmoji = false
   genRadios = 'mechBuild'
 
+  mounted() {
+    this.mechSelect = this.pilot.ActiveMech?.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1]?.ID ?? ''
+  }
+
   get statblock(): string {
-    if (this.pilot.Mechs.length > 0) {
-      this.mechSelect = this.pilot.ActiveMech.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1].ID ?? ''
-    }
     const mech = this.mechSelect ? this.pilot.Mechs.find(x => x.ID === this.mechSelect) : null
     
     if (this.genRadios != "mechBuild") {

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <cc-solo-dialog ref="dialog" icon="mdi-text-subject" large no-confirm title="Pilot Statblock">
+  <cc-solo-dialog ref="dialog" icon="mdi-text-subject" large no-confirm title="Generate Statblock">
     <v-card-text>
       <v-select
         v-model="mechSelect"
@@ -7,15 +7,16 @@
         placeholder="N/A"
         item-text="Name"
         item-value="ID"
-        label="Include Mech (optional)"
+        label="Select Mech"
         outlined
-        clearable
         hide-details
       />
-      <div v-if="!!mechSelect">
-        <v-checkbox v-model="buildSummary" label="Compact / Build Summary" />
-      </div>
-      <v-checkbox v-model="discordEmoji" label="Enhance with Pilot NET Discord Emoji" />
+      <v-radio-group v-model="genRadios" row mandatory label="Generate:">
+        <v-radio label="Mech Build" value="mech"></v-radio>
+        <v-radio label="Pilot" value="pilot"></v-radio>
+        <v-radio label="Both" value="full"></v-radio>
+      </v-radio-group>
+      <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
       <v-textarea :value="statblock" auto-grow readonly outlined filled class="flavor-text" />
     </v-card-text>
   </cc-solo-dialog>
@@ -23,7 +24,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop} from 'vue-property-decorator'
-import { Mech, Pilot, Statblock } from '@/class'
+import { Pilot, Statblock } from '@/class'
 import CCSoloDialog from '@/ui/components/CCSoloDialog.vue'
 
 @Component({ name: 'statblock-dialog' })
@@ -31,16 +32,20 @@ export default class StatblockDialog extends Vue {
   @Prop({type: Object, required: true})
   readonly pilot: Pilot
 
-  mechSelect = ""
-  buildSummary = false
+  mechSelect =  this.pilot.ActiveMech.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1].ID ?? ''
   discordEmoji = false
+  codeBlock = false
+  genRadios = 'mech'
 
   get statblock(): string {
     const mech = this.mechSelect ? this.pilot.Mechs.find(x => x.ID === this.mechSelect) : null
-    if (this.buildSummary) {
+    if (this.genRadios == "mech") {
       return Statblock.GenerateBuildSummary(this.pilot, mech, this.discordEmoji)
     }
-    else return Statblock.Generate(this.pilot, mech, this.discordEmoji)
+    else if (this.genRadios == "full") {
+      return Statblock.Generate(this.pilot, mech, this.discordEmoji, true)
+    }
+    else return Statblock.Generate(this.pilot, mech, this.discordEmoji, false)
   }
 
   $refs!: {
@@ -52,7 +57,7 @@ export default class StatblockDialog extends Vue {
   }
 
   hide() {
-    this.$refs.dialog.hide()
+    this.$refs.dialog.hide() 
   }
 }
 </script>

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -14,7 +14,7 @@
       <v-radio-group v-model="genRadios" row mandatory label="Generate:">
         <v-radio label="Mech Build" value="mechBuild"></v-radio>
         <v-radio label="Pilot" value="pilotBuild"></v-radio>
-        <v-radio label="Both" value="full"></v-radio>
+        <v-radio label="Full" value="full"></v-radio>
       </v-radio-group>
       <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
       <v-textarea :value="statblock" auto-grow readonly outlined filled class="flavor-text" />

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -18,6 +18,12 @@
       </v-radio-group>
       <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
       <v-textarea :value="statblock" auto-grow readonly outlined filled class="flavor-text" />
+      <cc-tooltip simple inline content="Copy share code to clipboard">
+            <v-btn class="ml-n3" @click="copy()">
+              <v-icon>mdi-clipboard-text-outline</v-icon>
+              Copy to Clipboard
+            </v-btn>
+          </cc-tooltip>
     </v-card-text>
   </cc-solo-dialog>
 </template>
@@ -56,9 +62,14 @@ export default class StatblockDialog extends Vue {
   show() {
     this.$refs.dialog.show()
   }
-
   hide() {
     this.$refs.dialog.hide() 
+  }
+  copy() {
+    navigator.clipboard
+      .writeText(this.statblock)
+      .then(() => Vue.prototype.$notify('Stat block copied to clipboard.', 'confirmation'))
+      .catch(() => Vue.prototype.$notifyError('Unable to copy stat block'))
   }
 }
 </script>

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -40,7 +40,11 @@ export default class StatblockDialog extends Vue {
 
   selected_mech = null
   discordEmoji = false
-  genRadios = 'mechBuild'  
+  genRadios = 'mechBuild'
+
+  mounted() {
+    if (this.mechSelect == null) {this.genRadios='pilotBuild'} 
+  }
 
   get activeMechID(): string {
     return this.pilot.ActiveMech?.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1]?.ID ?? ''

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -19,11 +19,11 @@
       <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
       <v-textarea :value="statblock" auto-grow readonly outlined filled class="flavor-text" />
       <cc-tooltip simple inline content="Copy stat block to clipboard">
-            <v-btn class="ml-n3" @click="copy()">
-              <v-icon>mdi-clipboard-text-outline</v-icon>
-              Copy to Clipboard
-            </v-btn>
-          </cc-tooltip>
+        <v-btn class="mt-n4" color="accent" @click="copy()">
+          <v-icon>mdi-clipboard-text-outline</v-icon>
+          Copy to Clipboard
+        </v-btn>
+      </cc-tooltip>
     </v-card-text>
   </cc-solo-dialog>
 </template>
@@ -37,7 +37,7 @@ import CCSoloDialog from '@/ui/components/CCSoloDialog.vue'
 export default class StatblockDialog extends Vue {
   @Prop({type: Object, required: true})
   readonly pilot: Pilot
-  @Prop({type: Object, required: false})
+  @Prop({type: String, required: false})
   readonly mechID: string
 
   selected_mech = null

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -18,7 +18,7 @@
       </v-radio-group>
       <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
       <v-textarea :value="statblock" auto-grow readonly outlined filled class="flavor-text" />
-      <cc-tooltip simple inline content="Copy share code to clipboard">
+      <cc-tooltip simple inline content="Copy stat block to clipboard">
             <v-btn class="ml-n3" @click="copy()">
               <v-icon>mdi-clipboard-text-outline</v-icon>
               Copy to Clipboard

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -37,6 +37,8 @@ import CCSoloDialog from '@/ui/components/CCSoloDialog.vue'
 export default class StatblockDialog extends Vue {
   @Prop({type: Object, required: true})
   readonly pilot: Pilot
+  @Prop({type: Object, required: false})
+  readonly mechID: string
 
   selected_mech = null
   discordEmoji = false
@@ -46,12 +48,15 @@ export default class StatblockDialog extends Vue {
     if (this.mechSelect == null) {this.genRadios='pilotBuild'} 
   }
 
-  get activeMechID(): string {
-    return this.pilot.ActiveMech?.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1]?.ID ?? ''
+  get defaultMechID(): string {
+    if (this.$route.name=="mech-sheet") {
+      return this.mechID
+    }
+    else return this.pilot.ActiveMech?.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1]?.ID ?? ''
   }
 
   get mechSelect(): string {
-    return this.selected_mech ?? this.activeMechID
+    return this.selected_mech ?? this.defaultMechID
   }
 
   set mechSelect(mech_id: string) {

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -12,8 +12,8 @@
         hide-details
       />
       <v-radio-group v-model="genRadios" row mandatory label="Generate:">
-        <v-radio label="Mech Build" value="mech"></v-radio>
-        <v-radio label="Pilot" value="pilot"></v-radio>
+        <v-radio label="Mech Build" value="mechBuild"></v-radio>
+        <v-radio label="Pilot" value="pilotBuild"></v-radio>
         <v-radio label="Both" value="full"></v-radio>
       </v-radio-group>
       <v-checkbox v-model="discordEmoji" label="Include Pilot NET Discord damage type Emoji (Doesn't work in code block format)" />
@@ -24,7 +24,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop} from 'vue-property-decorator'
-import { Pilot, Statblock } from '@/class'
+import { Mech, Pilot, Statblock } from '@/class'
 import CCSoloDialog from '@/ui/components/CCSoloDialog.vue'
 
 @Component({ name: 'statblock-dialog' })
@@ -32,14 +32,18 @@ export default class StatblockDialog extends Vue {
   @Prop({type: Object, required: true})
   readonly pilot: Pilot
 
-  mechSelect =  this.pilot.ActiveMech.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1].ID ?? ''
+  mechSelect = ""
   discordEmoji = false
   codeBlock = false
-  genRadios = 'mech'
+  genRadios = 'mechBuild'
 
   get statblock(): string {
+    if (this.mechSelect == "") {
+      this.mechSelect = this.pilot.ActiveMech.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1].ID ?? ''
+    }
     const mech = this.mechSelect ? this.pilot.Mechs.find(x => x.ID === this.mechSelect) : null
-    if (this.genRadios == "mech") {
+    
+    if (this.genRadios == "mechBuild") {
       return Statblock.GenerateBuildSummary(this.pilot, mech, this.discordEmoji)
     }
     else if (this.genRadios == "full") {

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -34,7 +34,6 @@ export default class StatblockDialog extends Vue {
 
   mechSelect = ""
   discordEmoji = false
-  codeBlock = false
   genRadios = 'mechBuild'
 
   get statblock(): string {

--- a/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/StatblockDialog.vue
@@ -38,18 +38,15 @@ export default class StatblockDialog extends Vue {
   genRadios = 'mechBuild'
 
   get statblock(): string {
-    if (this.mechSelect == "") {
+    if (this.pilot.Mechs.length > 0) {
       this.mechSelect = this.pilot.ActiveMech.ID ?? this.pilot.Mechs[this.pilot.Mechs.length-1].ID ?? ''
     }
     const mech = this.mechSelect ? this.pilot.Mechs.find(x => x.ID === this.mechSelect) : null
     
-    if (this.genRadios == "mechBuild") {
-      return Statblock.GenerateBuildSummary(this.pilot, mech, this.discordEmoji)
+    if (this.genRadios != "mechBuild") {
+      return Statblock.Generate(this.pilot, mech, this.discordEmoji, this.genRadios)
     }
-    else if (this.genRadios == "full") {
-      return Statblock.Generate(this.pilot, mech, this.discordEmoji, true)
-    }
-    else return Statblock.Generate(this.pilot, mech, this.discordEmoji, false)
+    else return Statblock.GenerateBuildSummary(this.pilot, mech, this.discordEmoji)  
   }
 
   $refs!: {

--- a/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
@@ -132,7 +132,7 @@
       </v-list>
     </v-menu>
     <print-dialog ref="printDialog" class="unskew" :pilot="pilot" />
-    <statblock-dialog ref="statblockDialog" class="unskew" :pilot="pilot" />
+    <statblock-dialog ref="statblockDialog" class="unskew" :pilot="pilot" :mechID="mechID"/>
   </div>
 </template>
 
@@ -153,6 +153,10 @@ export default Vue.extend({
     selected: {
       type: Number,
       required: true,
+    },
+    mechID: {
+      type: String,
+      required: false,
     },
   },
   methods: {

--- a/src/features/pilot_management/PilotSheet/sections/mech/index.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="small ? 'mt-n3' : ''">
-    <mech-nav :selected="0" :pilot="pilot" :mech="mech" @delete="$refs.deleteDialog.show()" />
+    <mech-nav :selected="0" :pilot="pilot" :mech="mech" :mechID="mech.ID" @delete="$refs.deleteDialog.show()" />
     <v-row no-gutters>
       <v-col cols="auto">
         <cc-short-string-editor large before @set="mech.Name = $event">


### PR DESCRIPTION
# Description

Submitting as draft as I am once again stuck.

Changes made to remove friction from build sharing:
- Changed stat export type selection to radio buttons to simplify process.
- Made compact mech stats default option.
  - default mech is active mech > last created mech > blank in that order.
- Rearranged full mech+pilot stat block to group concerns better.
- Added caveat that emoji don't work with Discord code block formatting.

Also added Bonds to pilot stat share.

###HELP: 
Sticking point is getting s default mech set and read by the `get statblock()` function without either breaking the mech selection dropdown or having a bunch of errors thrown for pilots with no mechs, e.g. fresh  ones.

Finally getting the default mech to work broke the mech selection dropdown - it now only gives stats for the active mech, or none if one isn't available. I'm 90% sure this is due to setting the value in the `get statblock()` function, which then overwrites what's passed from the dropdown despite attempts to circumvent this. However I don't know enough about Typescript to know how to set it elsewhere and have it work properly. 

I suspect a more efficient way would be to rewrite how the mech is pulled for the stat sheet, but again wouldn't know where to start. Would appreciate any assistance on this.

## Issue Number
`#1887`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
