### PR TITLE
fix(ui): cardview space b/t name & type

### DIFF
--- a/src/features/compendium/components/views/components/_cCardBase.vue
+++ b/src/features/compendium/components/views/components/_cCardBase.vue
@@ -18,7 +18,7 @@
     <v-toolbar dense :color="hover ? 'primary lighten-1' : 'primary'" dark>
       <div>
         <div class="overline mb-n2">
-          <span v-if="item.Source">{{ item.Source }}</span>
+          <span v-if="item.Source">{{ item.Source }}&nbsp;</span>
           <slot name="overline" />
         </div>
         <div

--- a/src/ui/components/selectors/views/_SelectorCardsView.vue
+++ b/src/ui/components/selectors/views/_SelectorCardsView.vue
@@ -39,7 +39,7 @@ import { CompendiumStore } from '@/store'
 import CompendiumCard from './components/CompendiumCard.vue'
 
 export default Vue.extend({
-  name: 'compendium-cards-view',
+  name: 'selector-cards-view',
   components: { CompendiumCard },
   props: {
     items: {

--- a/src/ui/components/selectors/views/components/_cCardBase.vue
+++ b/src/ui/components/selectors/views/components/_cCardBase.vue
@@ -22,7 +22,7 @@
     <v-toolbar dense :color="hover ? 'primary lighten-1' : 'primary'" dark>
       <span>
         <div class="overline mb-n2">
-          <span v-if="item.Source">{{ item.Source }}</span>
+          <span v-if="item.Source">{{ item.Source }}&nbsp;</span>
           <slot name="overline" />
         </div>
         <div


### PR DESCRIPTION
# Description
This PR includes a `&nbsp;` after a CompendiumItem's Source (if present) to provide better readability on Compendium/Selector Cards view.  Also renames the SelectorCardsView's component for easier dev navigation using Vue webtools.

## Issue Number
Closes #1986

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)