### PR TITLE
fix(pilot/mech): Loadouts, mounts, weapons inherit parent & save

### DIFF
--- a/src/classes/Loadout.ts
+++ b/src/classes/Loadout.ts
@@ -1,5 +1,6 @@
 import { store } from '@/store'
 import uuid from 'uuid/v4'
+import { ISaveable } from './components'
 
 const ordArr = [
   'Primary',
@@ -16,16 +17,18 @@ const ordArr = [
 
 abstract class Loadout {
   private _id: string
+  protected Parent: ISaveable
   protected _name: string
 
-  public constructor(count?: number, id?: string) {
+  public constructor(parent: ISaveable, count?: number, id?: string) {
+    this.Parent = parent
     this._id = id ? id : uuid()
     if (!count) this._name = 'Primary'
     else this._name = ordArr[count]
   }
 
   protected save(): void {
-    store.dispatch('set_pilot_dirty')
+    this.Parent.SaveController.save()
   }
 
   public get ID(): string {

--- a/src/classes/components/save/ISaveable.ts
+++ b/src/classes/components/save/ISaveable.ts
@@ -2,11 +2,12 @@ import { SaveController } from './SaveController'
 
 interface ISaveable {
   SaveController: SaveController
-
+  
   Name: string
   ID: string
   ItemType: string
 
+  Parent?: ISaveable
 }
 
 export { ISaveable }

--- a/src/classes/components/save/SaveController.ts
+++ b/src/classes/components/save/SaveController.ts
@@ -18,7 +18,7 @@ class SaveController {
   public DeleteTime: string
   public ExpireTime: string
 
-  public IsDirty = false
+  public _isDirty = false
   private _isLoaded = false
 
   public constructor(parent: ISaveable) {
@@ -50,6 +50,17 @@ class SaveController {
   public restore() {
     this.IsDeleted = false
     store.dispatch(`restore_${this.Parent.ItemType}`, this.Parent)
+  }
+
+  public get IsDirty(): boolean {
+    return this._isDirty
+  }
+
+  public set IsDirty(dirty: boolean) {
+    this._isDirty = dirty
+    if (dirty && !!this.Parent.Parent) {
+      this.Parent.Parent.SaveController.IsDirty = dirty
+    }
   }
 
   public get IsDeleted(): boolean {

--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -1044,7 +1044,8 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
 
     SaveController.Deserialize(m, data)
     PortraitController.Deserialize(m, data)
-
+    
+    m.SaveController.SetLoaded()
     return m
   }
 }

--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -26,7 +26,7 @@ interface IMechLoadoutData {
 }
 
 class MechLoadout extends Loadout {
-  private Parent: Mech
+  protected Parent: Mech
   private _integratedMounts: IntegratedMount[]
   private _equippableMounts: EquippableMount[]
   private _improvedArmament: EquippableMount
@@ -35,20 +35,19 @@ class MechLoadout extends Loadout {
   private _integratedSystems: MechSystem[]
 
   public constructor(mech: Mech) {
-    super(mech.MechLoadoutController ? mech.MechLoadoutController.Loadouts.length : 0)
-    this.Parent = mech
-    this._equippableMounts = mech.Frame.Mounts.map(x => new EquippableMount(x))
+    super(mech, mech.MechLoadoutController ? mech.MechLoadoutController.Loadouts.length : 0)
+    this._equippableMounts = mech.Frame.Mounts.map(x => new EquippableMount(this.Parent, x))
     this._integratedMounts = []
     this._systems = []
     this._integratedSystems = []
-    this._improvedArmament = new EquippableMount(MountType.Flex)
-    this._integratedWeapon = new EquippableMount(MountType.Aux)
+    this._improvedArmament = new EquippableMount(this.Parent, MountType.Flex)
+    this._integratedWeapon = new EquippableMount(this.Parent, MountType.Aux)
   }
 
   public SetAllIntegrated(save?: boolean) {
     const im = [
-      ...this.Parent.FeatureController.IntegratedWeapons.map(x => new IntegratedMount(x)),
-      ...this.Parent.Pilot.FeatureController.IntegratedWeapons.map(x => new IntegratedMount(x)),
+      ...this.Parent.FeatureController.IntegratedWeapons.map(x => new IntegratedMount(this.Parent, x)),
+      ...this.Parent.Pilot.FeatureController.IntegratedWeapons.map(x => new IntegratedMount(this.Parent, x)),
     ]
     const is = [
       ...this.Parent.FeatureController.IntegratedSystems,
@@ -273,14 +272,14 @@ class MechLoadout extends Loadout {
     ml._integratedSystems = !loadoutData.integratedSystems
       ? mech.Frame.IntegratedSystems
       : loadoutData.integratedSystems.map(x => MechSystem.Deserialize(x))
-    ml._equippableMounts = loadoutData.mounts.map(x => EquippableMount.Deserialize(x))
+    ml._equippableMounts = loadoutData.mounts.map(x => EquippableMount.Deserialize(mech, x))
     ml._integratedMounts = !loadoutData.integratedMounts
-      ? mech.Frame.IntegratedWeapons.map(x => new IntegratedMount(x))
-      : loadoutData.integratedMounts.map(x => IntegratedMount.Deserialize(x))
-    ml._improvedArmament = EquippableMount.Deserialize(loadoutData.improved_armament)
+      ? mech.Frame.IntegratedWeapons.map(x => new IntegratedMount(mech, x))
+      : loadoutData.integratedMounts.map(x => IntegratedMount.Deserialize(mech, x))
+    ml._improvedArmament = EquippableMount.Deserialize(mech, loadoutData.improved_armament)
     ml._integratedWeapon = !loadoutData.integratedWeapon
-      ? new EquippableMount(MountType.Aux)
-      : EquippableMount.Deserialize(loadoutData.integratedWeapon)
+      ? new EquippableMount(mech, MountType.Aux)
+      : EquippableMount.Deserialize(mech, loadoutData.integratedWeapon)
     if (!loadoutData.integratedSystems) ml.SetAllIntegrated()
     return ml
   }

--- a/src/classes/mech/components/mount/EquippableMount.ts
+++ b/src/classes/mech/components/mount/EquippableMount.ts
@@ -1,12 +1,12 @@
 import _ from 'lodash'
-import { Mount, WeaponSlot, CoreBonus, MountType, FittingSize } from '@/class'
+import { Mech, Mount, WeaponSlot, CoreBonus, MountType, FittingSize } from '@/class'
 
 class EquippableMount extends Mount {
   private _bonuses: CoreBonus[]
   private _lock_target?: Mount
 
-  public constructor(mtype: MountType) {
-    super(mtype)
+  public constructor(parent: Mech, mtype: MountType) {
+    super(parent, mtype)
     this._bonuses = []
   }
 
@@ -37,7 +37,7 @@ class EquippableMount extends Mount {
     this._bonuses.push(cb)
     if (cb.ID === 'cb_mount_retrofitting') {
       this._name_override = 'Retrofitted Mount'
-      this.slots = [new WeaponSlot(FittingSize.Main), new WeaponSlot(FittingSize.Auxiliary)]
+      this.slots = [new WeaponSlot(this.Parent, FittingSize.Main), new WeaponSlot(this.Parent, FittingSize.Auxiliary)]
     }
     this.save()
   }
@@ -74,10 +74,10 @@ class EquippableMount extends Mount {
     }
   }
 
-  public static Deserialize(mountData: IMountData): EquippableMount {
-    const m = new EquippableMount(mountData.mount_type as MountType)
-    m.slots = mountData.slots.map(x => WeaponSlot.Deserialize(x))
-    m.extra = mountData.extra.map(x => WeaponSlot.Deserialize(x))
+  public static Deserialize(parent: Mech, mountData: IMountData): EquippableMount {
+    const m = new EquippableMount(parent, mountData.mount_type as MountType)
+    m.slots = mountData.slots.map(x => WeaponSlot.Deserialize(parent, x))
+    m.extra = mountData.extra.map(x => WeaponSlot.Deserialize(parent, x))
     m._bonuses = mountData.bonus_effects.map(x => CoreBonus.Deserialize(x))
     m.lock = mountData.lock
     m.getID()

--- a/src/classes/mech/components/mount/IntegratedMount.ts
+++ b/src/classes/mech/components/mount/IntegratedMount.ts
@@ -1,8 +1,8 @@
-import { Mount, MechWeapon, MountType } from '@/class'
+import { Mech, Mount, MechWeapon, MountType } from '@/class'
 
 class IntegratedMount extends Mount {
-  public constructor(intWeapon: MechWeapon) {
-    super(MountType.Integrated)
+  public constructor(parent: Mech, intWeapon: MechWeapon) {
+    super(parent, MountType.Integrated)
     this.slots[0].EquipWeapon(intWeapon, false)
   }
 
@@ -16,8 +16,8 @@ class IntegratedMount extends Mount {
     }
   }
 
-  public static Deserialize(mountData: any): IntegratedMount {
-    const im = new IntegratedMount(MechWeapon.Deserialize(mountData.weapon))
+  public static Deserialize(parent: Mech, mountData: any): IntegratedMount {
+    const im = new IntegratedMount(parent, MechWeapon.Deserialize(mountData.weapon))
     im.getID()
     return im
   }

--- a/src/classes/mech/components/mount/Mount.ts
+++ b/src/classes/mech/components/mount/Mount.ts
@@ -1,17 +1,19 @@
 import uuid from 'uuid/v4'
 import { store } from '@/store'
-import { MechWeapon, WeaponSlot, MountType, FittingSize, WeaponSize } from '@/class'
+import { Mech, MechWeapon, WeaponSlot, MountType, FittingSize, WeaponSize } from '@/class'
 
 abstract class Mount {
   private _mount_type: MountType
   private _id: string
+  protected Parent: Mech
   protected lock: boolean
   protected slots: WeaponSlot[]
   protected extra: WeaponSlot[]
   protected _name_override: string
 
-  public constructor(mountType: MountType) {
+  public constructor(parent: Mech, mountType: MountType) {
     this._id = uuid()
+    this.Parent = parent
     this._mount_type = mountType
     this.lock = false
     this.extra = []
@@ -22,28 +24,28 @@ abstract class Mount {
 
   protected generateSlots(mountType: MountType): void {
     if (mountType === MountType.Integrated) {
-      this.slots = [new WeaponSlot(FittingSize.Integrated)]
+      this.slots = [new WeaponSlot(this.Parent, FittingSize.Integrated)]
     } else {
       if (mountType === MountType.AuxAux) {
-        this.slots = [new WeaponSlot(FittingSize.Auxiliary), new WeaponSlot(FittingSize.Auxiliary)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Auxiliary), new WeaponSlot(this.Parent, FittingSize.Auxiliary)]
       } else if (mountType === MountType.Aux) {
-        this.slots = [new WeaponSlot(FittingSize.Auxiliary)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Auxiliary)]
         this._name_override = 'Integrated Weapon'
       } else if (mountType === MountType.MainAux) {
-        this.slots = [new WeaponSlot(FittingSize.Main), new WeaponSlot(FittingSize.Auxiliary)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Main), new WeaponSlot(this.Parent, FittingSize.Auxiliary)]
       } else if (mountType === MountType.Flex) {
-        this.slots = [new WeaponSlot(FittingSize.Flex)]
-        this.extra = [new WeaponSlot(FittingSize.Auxiliary)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Flex)]
+        this.extra = [new WeaponSlot(this.Parent, FittingSize.Auxiliary)]
       } else if (mountType === MountType.Main) {
-        this.slots = [new WeaponSlot(FittingSize.Main)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Main)]
       } else {
-        this.slots = [new WeaponSlot(FittingSize.Heavy)]
+        this.slots = [new WeaponSlot(this.Parent, FittingSize.Heavy)]
       }
     }
   }
 
   protected save(): void {
-    store.dispatch('set_pilot_dirty')
+    this.Parent.SaveController.save()
   }
 
   protected getID(): void {

--- a/src/classes/mech/components/mount/WeaponSlot.ts
+++ b/src/classes/mech/components/mount/WeaponSlot.ts
@@ -1,20 +1,22 @@
 import Vue from 'vue'
-import { MechWeapon, FittingSize } from '@/class'
+import { Mech, MechWeapon, FittingSize } from '@/class'
 import _ from 'lodash'
 import { store } from '@/store'
 import { WeaponMod } from '@/class'
 
 class WeaponSlot {
+  private Parent: Mech
   private _size: FittingSize
   private _weapon: MechWeapon | null
 
-  public constructor(size: FittingSize) {
+  public constructor(parent: Mech, size: FittingSize) {
+    this.Parent = parent
     this._size = size
     this._weapon = null
   }
 
   private save(): void {
-    store.dispatch('set_pilot_dirty')
+    this.Parent.SaveController.save()
   }
 
   public get Size(): FittingSize {
@@ -47,8 +49,8 @@ class WeaponSlot {
     }
   }
 
-  public static Deserialize(slotData: IWeaponSlotData): WeaponSlot {
-    const ws = new WeaponSlot(slotData.size as FittingSize)
+  public static Deserialize(parent: Mech, slotData: IWeaponSlotData): WeaponSlot {
+    const ws = new WeaponSlot(parent, slotData.size as FittingSize)
     if (slotData.weapon) {
       const w = MechWeapon.Deserialize(slotData.weapon)
       if (w) ws.EquipWeapon(w, false)

--- a/src/classes/pilot/components/Loadout/PilotLoadout.ts
+++ b/src/classes/pilot/components/Loadout/PilotLoadout.ts
@@ -1,5 +1,6 @@
 import {
   Rules,
+  Pilot,
   PilotEquipment,
   PilotArmor,
   PilotWeapon,
@@ -9,14 +10,15 @@ import {
 } from '@/class'
 
 class PilotLoadout extends Loadout {
+  protected Parent: Pilot
   private _armor: (PilotArmor | null)[]
   private _gear: (PilotGear | null)[]
   private _weapons: (PilotWeapon | null)[]
   private _extendedWeapons: (PilotWeapon | null)[]
   private _extendedGear: (PilotGear | null)[]
 
-  public constructor(count?: number, id?: string) {
-    super(count, id)
+  public constructor(pilot: Pilot, count?: number, id?: string) {
+    super(pilot, count, id)
     this._armor = Array(Rules.MaxPilotArmor).fill(null)
     this._gear = Array(Rules.MaxPilotGear).fill(null)
     this._weapons = Array(Rules.MaxPilotWeapons).fill(null)
@@ -131,8 +133,8 @@ class PilotLoadout extends Loadout {
     }
   }
 
-  public static Deserialize(loadoutData: IPilotLoadoutData): PilotLoadout {
-    const loadout = new PilotLoadout(0, loadoutData.id)
+  public static Deserialize(parent: Pilot, loadoutData: IPilotLoadoutData): PilotLoadout {
+    const loadout = new PilotLoadout(parent, 0, loadoutData.id)
     loadout.ID = loadoutData.id
     loadout._name = loadoutData.name
     loadout._armor = loadoutData.armor.map(x => PilotEquipment.Deserialize(x) as PilotArmor)

--- a/src/classes/pilot/components/Loadout/PilotLoadoutController.ts
+++ b/src/classes/pilot/components/Loadout/PilotLoadoutController.ts
@@ -12,7 +12,7 @@ class PilotLoadoutController implements IFeatureContainer {
 
   constructor(parent: Pilot) {
     this.Parent = parent
-    this._loadout = new PilotLoadout()
+    this._loadout = new PilotLoadout(parent)
   }
 
   public get FeatureSource(): any[] {
@@ -39,8 +39,8 @@ class PilotLoadoutController implements IFeatureContainer {
       )
 
     parent.PilotLoadoutController._loadout = data.loadout
-      ? PilotLoadout.Deserialize(data.loadout)
-      : new PilotLoadout()
+      ? PilotLoadout.Deserialize(parent, data.loadout)
+      : new PilotLoadout(parent)
   }
 }
 


### PR DESCRIPTION
# Description
This PR sets up Loadouts, Mounts, and WeaponSlots to inherit a parent ISaveable class (Pilots and Mechs for Loadouts, Mechs only for Mounts and WeaponSlots).  Rework the `save` methods for these three classes to use the parent's SaveController.  Let ISaveables have Parents, and bubble up `isDirty` from SaveControllers to all parents if `isDirty` is set to `true`.

Please please PLEASE check this on your own machine before approving.  I'm concerned that the changes made here may be affecting the performance of loading pilots from the Cloud data, and I'm uncertain if it's my local machine being sluggish or the code changes I made slowing things down.

## Issue Number
Closes #1989

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
