### PR TITLE
feat(compendium): filter on license_id when present

### DIFF
--- a/src/classes/pilot/components/license/License.ts
+++ b/src/classes/pilot/components/license/License.ts
@@ -21,12 +21,20 @@ class License {
     this.FrameID = frame.ID
     this.Brew = frame.Brew || 'Core'
 
+    function licenseMatch(licenseItem: LicensedItem, licenseFrame: Frame): boolean {
+      if (!!licenseItem.LicenseID) {
+        return licenseItem.LicenseID === licenseFrame.ID
+      } else {
+        return (licenseItem.License.toUpperCase() === licenseFrame.Name.toUpperCase()) && (licenseItem.Source.toUpperCase() === licenseFrame.Source.toUpperCase())
+      }
+    }
+
     const items: LicensedItem[] = _.cloneDeep(store.getters.getItemCollection('MechWeapons'))
       .concat(
         store.getters.getItemCollection('WeaponMods'),
         store.getters.getItemCollection('MechSystems')
       )
-      .filter((x: LicensedItem) => (x.License.toUpperCase() === frame.Name.toUpperCase()) && x.Source.toUpperCase() === frame.Source.toUpperCase())
+      .filter((x: LicensedItem) => licenseMatch(x, frame))
 
     const lls = [...items].map(i => i.LicenseLevel)
 

--- a/src/classes/pilot/components/license/LicensedItem.ts
+++ b/src/classes/pilot/components/license/LicensedItem.ts
@@ -14,17 +14,20 @@ interface ILicensedItemData extends ICompendiumItemData {
   source: string
   license: string
   license_level: number
+  license_id?: string
 }
 
 abstract class LicensedItem extends CompendiumItem {
   public readonly Source: string
   public readonly LicenseLevel: number
   private _license: string
+  private _license_id: string
 
   public constructor(data: ILicensedItemData, packTags?: ITagCompendiumData[], packName?: string) {
     super(data, packTags, packName)
     this.Source = data.source ? data.source.toUpperCase() : ''
     this._license = data.license || ''
+    this._license_id = data.license_id || ''
     this.LicenseLevel = parseInt(data.license_level as any) || 0
   }
 
@@ -39,6 +42,10 @@ abstract class LicensedItem extends CompendiumItem {
   public get LicenseString(): string {
     if (this._license) return `${this._license} ${this.LicenseLevel}`
     return this.Source
+  }
+
+  public get LicenseID(): string {
+    return this._license_id
   }
 
   public get RequiredLicense(): ILicenseRequirement {

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -166,8 +166,15 @@ export class CompendiumStore extends VuexModule {
   }
 
   get Licenses(): License[] {
+    function variantLicenseMatch(variantFrame: Frame, licenseFrame: Frame): boolean {
+      if (!!variantFrame.Variant && !!variantFrame.LicenseID) {
+        return variantFrame.LicenseID === licenseFrame.ID
+      } else {
+        return (variantFrame.Variant.toUpperCase() === licenseFrame.Name.toUpperCase()) && (variantFrame.Source.toUpperCase() === licenseFrame.Source.toUpperCase())
+      }
+    }
     return this.Frames.filter(x => x.Source !== 'GMS' && !x.IsHidden).map(frame => {
-      const variants = this.Frames.filter(f => (f.Variant.toUpperCase() === frame.Name.toUpperCase()) && (f.Source.toUpperCase() === frame.Source.toUpperCase()))
+      const variants = this.Frames.filter(f => variantLicenseMatch(f, frame))
       return new License(frame, variants)
     })
   }


### PR DESCRIPTION
# Description
This PR leverages the new `license_id` data for `LicensedItem` objects to more directly assign licensed equipment to the parent license.  Any content that doesn't have a `license_id` will fallback to the original logic of combining license Frame Name + license Frame Source (e.g. SSC, HA, etc.).

## Issue Number
Closes #1981

## Type of change
- [x] New feature (non-breaking change which adds functionality)