### PR TITLE
fix(lcp): humanize reserves and factions in LCP import

### DIFF
--- a/src/features/nav/pages/ExtraContent/PackInfo.vue
+++ b/src/features/nav/pages/ExtraContent/PackInfo.vue
@@ -82,6 +82,7 @@ export default class PackInfo extends Vue {
     pilotGear: ['pilot gear item', 'pilot gear items'],
     backgrounds: ['background', 'backgrounds'],
     bonds: ['bond', 'bonds'],
+    reserves: ['reserve', 'reserves'],
     talents: ['pilot talent', 'pilot talents'],
     tags: ['equipment tag', 'equipment tags'],
     npcClasses: ['NPC class', 'NPC classes'],
@@ -90,6 +91,7 @@ export default class PackInfo extends Vue {
     actions: ['Player action', 'Player actions'],
     statuses: ['Status/Condition', 'Statuses/Conditions'],
     environments: ['Combat Environment', 'Combat Environments'],
+    factions: ['faction', 'factions'],
     sitreps: ['SITREP', 'SITREPs'],
     tables: ['Data Table', 'Data Tables'],
   }


### PR DESCRIPTION
# Description
Hopefully the final one for a while: Adding humanized text fields for LCP Installation for Reserves and Factions that could be included in an LCP (factions seem to have been deprecated but I'm including them in case they make a comeback).

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)