### PR TITLE
feat(help): add help icon, FAQ links, some style

### DIFF
--- a/src/features/nav/index.vue
+++ b/src/features/nav/index.vue
@@ -46,7 +46,7 @@
       <span>Compendium</span>
     </v-tooltip>
 
-    <v-divider vertical dark class="ml-2 mr-2" />
+    <v-divider vertical dark class="mx-2" />
 
     <v-toolbar-title v-if="$vuetify.breakpoint.mdAndUp">
       <span class="heading">COMP/CON</span>
@@ -61,15 +61,23 @@
       <encounter-mode v-if="mode === 'encounter'" />
     </div>
 
-    <v-divider v-if="$vuetify.breakpoint.mdAndUp && isAuthed" vertical dark class="ml-2 mr-2" />
+    <v-divider v-if="$vuetify.breakpoint.mdAndUp && isAuthed" vertical dark class="mx-2" />
 
-    <cc-tooltip v-if="isAuthed" bottom content="Open cloud account menu">
+    <cc-tooltip v-if="$vuetify.breakpoint.mdAndUp && isAuthed" bottom content="Open cloud account menu">
       <v-btn icon dark @click="$refs.cloudModal.show()">
         <v-icon>mdi-cloud-sync-outline</v-icon>
       </v-btn>
     </cc-tooltip>
 
-    <v-divider v-if="$vuetify.breakpoint.mdAndUp" vertical dark class="ml-2 mr-2" />
+    <v-divider v-if="$vuetify.breakpoint.mdAndUp" vertical dark class="mx-2" />
+
+    <cc-tooltip bottom content="Help &amp; FAQ">
+      <v-btn icon dark @click="$refs.helpModal.show()">
+        <v-icon>mdi-help-circle-outline</v-icon>
+      </v-btn>
+    </cc-tooltip>
+
+    <v-divider vertical dark class="mx-2" />
 
     <v-menu nudge-bottom="40px">
       <template v-slot:activator="{ on }">

--- a/src/features/nav/pages/Help.vue
+++ b/src/features/nav/pages/Help.vue
@@ -1,16 +1,43 @@
 <template>
   <div>
     <v-row class="my-2" justify="center">
-      <v-col cols="8">
+      <v-col cols="4">
         <v-btn
           target="_blank"
-          href="https://forms.gle/pj6o8BzxCe4xGQ5M7"
+          href="https://github.com/massif-press/compcon/wiki/Frequently-Asked-Questions"
           x-large
           block
           color="secondary"
           class="white--text"
         >
-          request a feature / report a bug
+          Frequently Asked Questions
+        </v-btn>
+      </v-col>
+      <v-col cols="4">
+        <v-btn
+          target="_blank"
+          href="https://github.com/massif-press/compcon/wiki/FAQ%3A-Troubleshooting"
+          x-large
+          block
+          color="secondary"
+          class="white--text"
+        >
+          Troubleshooting FAQ
+        </v-btn>
+      </v-col>
+    </v-row>
+    <v-divider horizontal class="mx-2" />
+    <v-row class="my-2" justify="center">
+      <v-col cols="4">
+        <v-btn
+          target="_blank"
+          href="https://forms.gle/pj6o8BzxCe4xGQ5M7"
+          x-large
+          block
+          color="error"
+          class="white--text"
+        >
+          Report a Bug
         </v-btn>
       </v-col>
     </v-row>
@@ -20,7 +47,7 @@
       <br />
       // FEATURE IN DEVELOPMENT //
     </p>
-    <h3 class="heading accent--text">FAQ</h3>
+    <h3 class="heading accent--text">Quick FAQ</h3>
     <div class="body-text text--text">
       <b>Where are the NPCs?</b>
       <p>
@@ -31,7 +58,7 @@
         and selecting the Core Book item from the LCP Directory tab. You can use the Content
         Manager's Install LCP tab to import the package and start building and running encounters.
       </p>
-      <b>I see a Roll20 import function, how do I use it?</b>
+      <b>I see a Roll20 import function; how do I use it?</b>
       <p>The importer on Roll20's side is not available yet.</p>
     </div>
 

--- a/src/features/pilot_management/PilotSheet/components/PilotNav.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotNav.vue
@@ -42,12 +42,12 @@
       </v-list>
     </v-menu>
 
-    <v-btn icon fab x-small outlined :disabled="!lastLoaded" class="mx-4 unskew" @click="toMech()">
+    <v-btn icon fab x-small outlined :disabled="!lastLoaded" class="mx-4 unskew" dark @click="toMech()">
       <cc-tooltip inline delayed content="Active Mech Sheet">
         <v-icon large color="white">cci-frame</v-icon>
       </cc-tooltip>
     </v-btn>
-    <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
+    <v-btn icon fab x-small class="mr-4 unskew" dark @click="toActive()">
       <cc-tooltip inline delayed content="Active Mode">
         <v-icon large color="white">cci-activate</v-icon>
       </cc-tooltip>
@@ -173,6 +173,9 @@ export default Vue.extend({
   methods: {
     toMech() {
       this.$router.push(`../mech/${this.lastLoaded}`)
+    },
+    toActive() {
+      this.$router.push(`/active/${this.pilot.ID}`)
     },
     delete_pilot() {
       this.pilot.SaveController.delete()

--- a/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
+++ b/src/features/pilot_management/PilotSheet/sections/mech/components/MechNav.vue
@@ -19,7 +19,7 @@
         </v-btn>
       </cc-tooltip>
       <cc-tooltip inline delayed content="Active Mode">
-        <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
+        <v-btn icon fab x-small outlined class="mr-4 unskew" dark @click="toActive()">
           <v-icon large color="white">cci-activate</v-icon>
         </v-btn>
       </cc-tooltip>
@@ -29,7 +29,7 @@
       <v-btn icon fab x-small outlined class="mx-4 unskew" dark @click="toTacticalProfile()">
         <v-icon large>cci-pilot</v-icon>
       </v-btn>
-      <v-btn icon fab x-small outlined class="mr-4 unskew" dark :to="`/active/${pilot.ID}`">
+      <v-btn icon fab x-small class="mr-4 unskew" dark @click="toActive()">
         <v-icon large color="white">cci-activate</v-icon>
       </v-btn>
     </div>
@@ -158,6 +158,9 @@ export default Vue.extend({
   methods: {
     toTacticalProfile() {
       this.$router.push({ name: 'tactical_profile' })
+    },
+    toActive() {
+      this.$router.push(`/active/${this.pilot.ID}`)
     },
   },
 })


### PR DESCRIPTION
# Description
This PR adds a clear "Help & FAQ" button to the top navbar when away from the main page. It adds direct links to the COMP/CON FAQ to the top of the Help page. In addition, small styling tweaks have been made to the pilot/mech navbar.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
