### PR TITLE
fix(Active Mode): dynamically determine overcharge pips

### DIFF
--- a/src/features/encounters/mission/runner/components/PlayerCard.vue
+++ b/src/features/encounters/mission/runner/components/PlayerCard.vue
@@ -266,7 +266,7 @@
             <cc-tick-bar
               :key="mech.CurrentOvercharge"
               :current="mech.CurrentOvercharge"
-              :max="3"
+              :max="mech.OverchargeTrack.length-1"
               large
               no-input
               clearable

--- a/src/features/pilot_management/ActiveSheet/layout/MedPipLayout.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/MedPipLayout.vue
@@ -155,7 +155,7 @@
         <cc-tick-bar
           :key="mech.CurrentOvercharge"
           :current="mech.CurrentOvercharge"
-          :max="3"
+          :max="mech.OverchargeTrack.length-1"
           large
           no-input
           clearable
@@ -169,7 +169,7 @@
           </span>
         </cc-tick-bar>
         <div class="caption overcharge--text font-weight-bold">
-          {{ overcharge[mech.CurrentOvercharge] }}
+          +{{ mech.OverchargeTrack[mech.CurrentOvercharge] }}
         </div>
       </v-col>
     </v-row>
@@ -189,13 +189,6 @@ export default Vue.extend({
     structRollover: { type: Boolean },
     stressRollover: { type: Boolean },
     hpResistance: { type: Boolean },
-  },
-  computed: {
-    overcharge(): string[] {
-      return this.mech.Pilot.has('corebonus', 'cb_heatfall_coolant_system')
-        ? [' +1 ', ' +1d3 ', ' +1d6 ', '+1d6']
-        : [' +1 ', ' +1d3 ', ' +1d6 ', '+1d6+4']
-    },
   },
 })
 </script>

--- a/src/features/pilot_management/ActiveSheet/layout/PipLayout.vue
+++ b/src/features/pilot_management/ActiveSheet/layout/PipLayout.vue
@@ -323,7 +323,7 @@
             <cc-tick-bar
               :key="mech.CurrentOvercharge"
               :current="mech.CurrentOvercharge"
-              :max="3"
+              :max="mech.OverchargeTrack.length-1"
               large
               no-input
               clearable


### PR DESCRIPTION
# Description
This PR removes some hardcoded "magic numbers" from the Active Mode overcharge logic. It relies upon the mech's OverchargeTrack property to determine maximum pips for the Overcharge selection. It removes hardcoded Overcharge logic from MedPipLayout.

## Issue Number
Inspired by #2030, though it doesn't directly close the issue.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)