### PR TITLE
fix(Active Mode):fixed indestructible tag typo

### DIFF
--- a/src/classes/mech/components/equipment/MechEquipment.ts
+++ b/src/classes/mech/components/equipment/MechEquipment.ts
@@ -57,7 +57,7 @@ abstract class MechEquipment extends LicensedItem {
       this.IsLoading = data.tags.some(x => x.id === 'tg_loading')
       this.IsAI = data.tags.some(x => x.id === 'tg_ai')
       this.NoCascade = data.tags.some(x => x.id === 'tg_no_cascade')
-      this.IsIndestructible = data.tags.some(x => x.id === 'tg_indestructable')
+      this.IsIndestructible = data.tags.some(x => x.id === 'tg_indestructible')
       this.IsOrdnance = data.tags.some(x => x.id === 'tg_ordnance')
       this.CanSetDamage = data.tags.some(x => x.id === 'tg_set_damage_type')
       this.CanSetUses = data.tags.some(x => x.id === 'tg_set_max_uses')

--- a/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
+++ b/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
@@ -48,7 +48,7 @@ abstract class PilotEquipment extends CompendiumItem {
       this.IsLoading = data.tags.some(x => x.id === 'tg_loading')
       this.IsAI = data.tags.some(x => x.id === 'tg_ai')
       this.NoCascade = data.tags.some(x => x.id === 'tg_no_cascade')
-      this.IsIndestructible = data.tags.some(x => x.id === 'tg_indestructable')
+      this.IsIndestructible = data.tags.some(x => x.id === 'tg_indestructible')
       this.IsOrdnance = data.tags.some(x => x.id === 'tg_ordnance')
       this.CanSetDamage = data.tags.some(x => x.id === 'tg_set_damage_type')
       this.CanSetUses = data.tags.some(x => x.id === 'tg_set_max_uses')


### PR DESCRIPTION
# Description
This PR fixes a typo in MechEquipment and PilotEquipment checking for `tg_indestructable` instead of `tg_indestructible`.

## Issue Number
Closes #2066 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
