### PR TITLE
Fix/mod system trauma

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -140,6 +140,10 @@ class MechLoadout extends Loadout {
       .filter(x => x != null)
   }
 
+  public get WeaponMods(): WeaponMod[] {
+    return this.Weapons.map(x => x.Mod).filter(x => x != null)
+  }
+
   public ReloadAll(): void {
     this.Weapons.forEach(w => {
       if (w.IsLoading) w.Loaded = true
@@ -165,6 +169,12 @@ class MechLoadout extends Loadout {
 
   public get AllActiveSystems(): MechSystem[] {
     return this.IntegratedSystems.concat(this.Systems)
+  }
+
+  public get AllActiveSystemsMods(): MechEquipment[] {
+    const systems = this.AllActiveSystems as MechEquipment[]
+    const mods = this.WeaponMods as MechEquipment[]
+    return systems.concat(mods)
   }
 
   public HasSystem(systemID: string): boolean {

--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -125,7 +125,7 @@ class MechLoadout extends Loadout {
   }
 
   public get Equipment(): MechEquipment[] {
-    const mods = this.Weapons.map(x => x.Mod).filter(x => x != null)
+    const mods = this.WeaponMods
     const equip = (this.Weapons as MechEquipment[])
       .concat(this.Systems as MechEquipment[])
       .concat(this.IntegratedSystems as MechEquipment[])
@@ -141,7 +141,7 @@ class MechLoadout extends Loadout {
   }
 
   public get WeaponMods(): WeaponMod[] {
-    return this.Weapons.map(x => x.Mod).filter(x => x != null)
+    return this.Weapons.map(x => x.Mod).filter(x => x !== null)
   }
 
   public ReloadAll(): void {
@@ -205,7 +205,7 @@ class MechLoadout extends Loadout {
   public get RequiredLicenses(): ILicenseRequirement[] {
     const requirements = [] as ILicenseRequirement[]
     const equippedWeapons = (this.Weapons as LicensedItem[]).concat(
-      this.Weapons.map(x => x.Mod).filter(x => x !== null) as LicensedItem[]
+      this.WeaponMods as LicensedItem[]
     )
     const equippedSystems = this._systems as LicensedItem[]
 
@@ -256,7 +256,7 @@ class MechLoadout extends Loadout {
   }
 
   public get UniqueMods(): WeaponMod[] {
-    return this.Weapons.map(x => x.Mod).filter(y => y && y.IsUnique)
+    return this.WeaponMods.filter(y => y && y.IsUnique)
   }
 
   public get UniqueItems(): MechEquipment[] {

--- a/src/ui/components/panels/loadout/active_loadout/components/_ActiveModInset.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_ActiveModInset.vue
@@ -6,7 +6,7 @@
         style="height: 24px!important"
       >
         <v-row class="mt-n1" no-gutters>
-          <equipment-options v-if="!action" slot="options" :item="mod" />
+          <equipment-options v-if="!action" readonly active slot="options" :item="mod" />
           <span v-if="mod.Destroyed" class="error" style="text-decoration: line-through">
             DESTROYED
           </span>

--- a/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentOptions.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/_EquipmentOptions.vue
@@ -121,7 +121,7 @@
         </v-list-item>
         <div v-if="!item.IsIntegrated && !readonly">
           <v-divider />
-          <v-list-item @click="$emit('remove')">
+          <v-list-item @click="removeItem()">
             <v-list-item-icon class="ma-0 mr-2 mt-2">
               <v-icon color="error">mdi-delete</v-icon>
             </v-list-item-icon>
@@ -181,6 +181,9 @@ export default Vue.extend({
     save(prop, newName) {
       this.$set(this.item, prop, newName)
     },
+    removeItem() {
+      this.$emit('remove')
+    }
   },
 })
 </script>

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModInset.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModInset.vue
@@ -6,7 +6,7 @@
         style="height: 24px!important"
       >
         <v-row class="mt-n1" no-gutters>
-          <equipment-options slot="options" :item="mod" />
+          <equipment-options slot="options" :item="mod" @remove="$emit('remove-mod')"/>
           <span v-if="mod.Destroyed" class="error" style="text-decoration: line-through">
             DESTROYED
           </span>

--- a/src/ui/components/panels/loadout/mech_loadout/components/system/_ModEquippedCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/system/_ModEquippedCard.vue
@@ -3,7 +3,7 @@
     <slot-card-base ref="base" :item="mod" :mech="mech" :readonly="readonly" style="height: 100%">
       <div slot="header">
         <span v-if="mod">
-          <equipment-options :item="mod" :readonly="readonly" :active="readonly" />
+          <equipment-options :item="mod" :readonly="readonly" :active="readonly" @remove="$emit('remove')" />
           <span v-if="!mod.Destroyed" class="ml-n2">
             {{ mod.Name }}
             <span v-if="mod.FlavorName" class="caption ml-2 my-n1">//{{ mod.TrueName }}</span>

--- a/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSlotCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSlotCard.vue
@@ -31,7 +31,7 @@
       <div slot="header">
         <v-row v-if="item" no-gutters>
           <v-col cols="auto">
-            <equipment-options :item="item" :readonly="readonly" />
+            <equipment-options :item="item" :readonly="readonly" @remove="remove(item)" />
           </v-col>
           <v-col cols="auto">
             <span

--- a/src/ui/components/tables/CCStructureTable.vue
+++ b/src/ui/components/tables/CCStructureTable.vue
@@ -220,7 +220,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 import TableWindowItem from './_TableWindowItem.vue'
 import CascadeCheck from './_CascadeCheck.vue'
 import ResultData from './_structure_results.json'
-import { Mech, MechLoadout, MechSystem } from '@/class'
+import { Mech, MechLoadout, MechSystem, MechEquipment } from '@/class'
 
 @Component({
   name: 'structure-table',
@@ -291,10 +291,10 @@ export default class CCSidebarView extends Vue {
       .map((m, i) => ({ name: m.Name, index: i }))
   }
 
-  get destroyableSystems(): MechSystem[] {
-    return this.loadout.AllActiveSystems.filter(
+  get destroyableSystems(): MechEquipment[] {
+    return this.loadout.AllActiveSystemsMods.filter(
       x => !x.IsIndestructible && !x.Destroyed && !(x.IsLimited && x.Uses === 0)
-    )
+    )   
   }
 
   rollRandom(): number {
@@ -318,10 +318,7 @@ export default class CCSidebarView extends Vue {
 
   applySystemTrauma(): void {
     if (this.systemTraumaRoll > 3) {
-      let s = this.loadout.Systems.find(x => x.ID === this.destroyedSystem)
-      if (!s) {
-        s = this.loadout.IntegratedSystems.find(x => x.ID === this.destroyedSystem)
-      }
+      let s = this.loadout.AllActiveSystemsMods.find(x => x.ID === this.destroyedSystem)
       s.Destroy()
     } else {
       const m = this.loadout.AllMounts(


### PR DESCRIPTION
# Description
This PR introduces "WeaponMods" and "AllActiveSystemsMods" to ensure WeaponMods are included in the System Trauma list.

Additionally, bubble up "Remove Item" equipment options for all systems and mods.

## Issue Number
Closes #2065

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
