### PR TITLE
fix(lcp filtering): filter Actions based on lcp active status

### DIFF
--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -93,19 +93,7 @@ export class CompendiumStore extends VuexModule {
   public get Bonds(): Bond[] {
     return this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Bonds)
   }
-  public get Backgrounds(): Background[] {
-    return lancerData.backgrounds
-      .map((x: IBackgroundData) => new Background(x))
-      .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Backgrounds))
-  }
-  public get Actions(): PlayerAction.Action[] {
-    return lancerData.actions
-      .map((x: PlayerAction.IActionData) => new PlayerAction.Action(x))
-      .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Actions))
-  }
 
-  @Brewable(() => lancerData.tags.map((x: ITagCompendiumData) => new Tag(x))) 
-  Tags: Tag[]
   @Brewable(() => lancerData.talents.map((x: ITalentData) => new Talent(x)))
   Talents: Talent[]
   @Brewable(() => lancerData.core_bonuses.map((x: ICoreBonusData) => new CoreBonus(x)))
@@ -134,10 +122,31 @@ export class CompendiumStore extends VuexModule {
     })
   )
   PilotGear: PilotEquipment[]
-  @Brewable(() => lancerData.reserves.map((x: IReserveData) => new Reserve(x)))
-  Reserves: Reserve[]
   @Brewable(() => lancerData.skills.map((x: ISkillData) => new Skill(x)))
   Skills: Skill[]
+
+  public get Backgrounds(): Background[] {
+    return lancerData.backgrounds
+      .map((x: IBackgroundData) => new Background(x))
+      .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Backgrounds))
+  }
+  public get Actions(): PlayerAction.Action[] {
+    return lancerData.actions
+      .map((x: PlayerAction.IActionData) => new PlayerAction.Action(x))
+      .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Actions))
+  }
+
+  public get Tags(): Tag[]{
+    return lancerData.tags
+    .map((x: ITagCompendiumData) => new Tag(x))
+    .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Tags))
+  }
+
+  public get Reserves(): Reserve[]{
+    return lancerData.reserves
+    .map((x: IReserveData) => new Reserve(x))
+    .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Reserves))
+  }
 
   public get Statuses(): Status[] {
     return lancerData.statuses.concat(

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -98,11 +98,14 @@ export class CompendiumStore extends VuexModule {
       .map((x: IBackgroundData) => new Background(x))
       .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Backgrounds))
   }
-  @Brewable(() => lancerData.tags.map((x: ITagCompendiumData) => new Tag(x))) Tags: Tag[]
-  @Brewable(() =>
-    lancerData.actions.map((x: PlayerAction.IActionData) => new PlayerAction.Action(x))
-  )
-  Actions: PlayerAction.Action[]
+  public get Actions(): PlayerAction.Action[] {
+    return lancerData.actions
+      .map((x: PlayerAction.IActionData) => new PlayerAction.Action(x))
+      .concat(this.ContentPacks.filter(pack => pack.Active).flatMap(pack => pack.Actions))
+  }
+
+  @Brewable(() => lancerData.tags.map((x: ITagCompendiumData) => new Tag(x))) 
+  Tags: Tag[]
   @Brewable(() => lancerData.talents.map((x: ITalentData) => new Talent(x)))
   Talents: Talent[]
   @Brewable(() => lancerData.core_bonuses.map((x: ICoreBonusData) => new CoreBonus(x)))

--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -186,7 +186,7 @@ export class CompendiumStore extends VuexModule {
       }
     }
     return this.Frames.filter(x => x.Source !== 'GMS' && !x.IsHidden).map(frame => {
-      const variants = this.Frames.filter(f => variantLicenseMatch(f, frame))
+      const variants = this.Frames.filter(f => !f.IsHidden && variantLicenseMatch(f, frame))
       return new License(frame, variants)
     })
   }


### PR DESCRIPTION
# Description

Changed the way that the Actions are retrieved from the store. The built in filtering in the "@Brewable" method decorator didn't seem to working, and my guess is it's because Action does not inherit the CompendiumItem class. I switched the get method to use the same pattern as Backgrounds, which also don't inherit CompendiumItem.

There are a couple of other classes being retrieved by "@Brewable" that also don't inherit from CompendiumItem: Tags, Manufacturers, and Reserves. I will be testing those next, but I need to whip up a custom LCP that adds some custom items of that type in (unless there's one available that someone knows about already).

After that I do plan on looking into adding LCP source tags.

## Issue Number
Closes #2025
Closes #2076

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

