### PR TITLE
feat(deployable): add redeploy action to redeployables

### DIFF
--- a/src/classes/components/feature/deployable/Deployable.ts
+++ b/src/classes/components/feature/deployable/Deployable.ts
@@ -1,7 +1,7 @@
 import { ActivationType, Mech, Pilot } from '@/class'
 import { ICounterData, ISynergyData } from '@/interface'
 import uuid from 'uuid/v4'
-import { IActionData } from '../../../Action'
+import { IActionData, Action } from '../../../Action'
 import { Bonus, IBonusData } from '../bonus/Bonus'
 import { ICompendiumItemData, CompendiumItem } from '../../../CompendiumItem'
 
@@ -86,6 +86,17 @@ class Deployable extends CompendiumItem {
     this.Detail = data.detail
     this.Recall = data.recall || null
     this.Redeploy = data.redeploy || null
+    if (this.Redeploy) {
+      this.Actions.push(
+        new Action(
+          {
+            name: "Redeploy",
+            activation: this.Redeploy,
+            detail: `Redeploy this ${this.Type}.`
+          }
+        )
+      )
+    }
     this.Size = this.collect(data.size, owner, 'size')
     this.MaxHP = this.collect(data.hp, owner, 'hp')
     this._missing_hp = 0


### PR DESCRIPTION
# Description
According to rules helpers on Pilot NET, deployables that can be "redeployed" can be redeployed without being recalled (i.e., "redeploy" combines the "recall" + "deploy" actions into a single action). This PR adds a "Redeploy" action to deployables with "redeploy" set, for action tracking purposes. It retains the original "Redeploy" functionality since it facilitates stat tracking for the deployables once they are recalled.

Known issues: The "Redeploy" action doesn't appear in the Compendium, but does appear in Active Mode. Also, Jericho Portable Cover will have the "Redeploy" button, though it is inappropriate. If anyone has feedback on how to make this work more effectively, please leave a comment!

~~Also, if it turns out that the interpretation of the rules above is incorrect, please disregard this PR entirely.~~ I confirmed with Tom that the interpretation above is the intended one.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
