### PR TITLE
fix(ui): remove ui references to Roll20

### DIFF
--- a/src/features/nav/pages/Help.vue
+++ b/src/features/nav/pages/Help.vue
@@ -93,8 +93,8 @@
         and selecting the Core Book item from the LCP Directory tab. You can use the Content
         Manager's Install LCP tab to import the package and start building and running encounters.
       </p>
-      <b>I see a Roll20 import function; how do I use it?</b>
-      <p>The importer on Roll20's side is not available yet.</p>
+      <b>Can I import my COMP/CON pilot to Roll20?</b>
+      <p>Roll20 does not support imports from COMP/CON at this time.</p>
     </div>
 
     <h3 class="heading accent--text">Additional Help</h3>

--- a/src/features/pilot_management/PilotSheet/components/ExportDialog.vue
+++ b/src/features/pilot_management/PilotSheet/components/ExportDialog.vue
@@ -26,14 +26,14 @@
       <v-row>
         <v-col>
           <v-btn large block tile outlined color="accent" @click="copyPilot()">
-            Copy Pilot Data to Clipboard (Roll20 Import)
+            Copy Pilot Data to Clipboard
           </v-btn>
         </v-col>
         <v-col cols="auto" class="ml-n1">
           <cc-tooltip
             simple
             inline
-            content="This will copy your pilot's data into your computer's clipboard, suitable for importing into the LANCER Character Sheet on Roll20"
+            content="This will copy your pilot's data into your computer's clipboard."
           >
             <v-icon class="mt-2 ml-n3">mdi-information-outline</v-icon>
           </cc-tooltip>
@@ -79,7 +79,7 @@ export default Vue.extend({
     copyPilot() {
       this.pilot.BrewController.SetBrewData()
       navigator.clipboard.writeText(JSON.stringify(Pilot.Serialize(this.pilot)))
-      Vue.prototype.$notify('Roll20 data copied to clipboard')
+      Vue.prototype.$notify('Pilot data copied to clipboard')
       this.hide()
     },
     async copyCode() {


### PR DESCRIPTION
# Description
This PR removes references to Roll20 in the UI. The mention of Roll20 often leads users to ask how to import their pilots to Roll20, so this change is to clarify the state of the world between COMP/CON and Roll20.

## Issue Number
None yet.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
