### PR TITLE
fix(login): prevent refresh on v-form submit

### DIFF
--- a/src/features/main_menu/_components/login/SignIn.vue
+++ b/src/features/main_menu/_components/login/SignIn.vue
@@ -3,7 +3,7 @@
     <v-row dense class="panel" justify="center" align="center">
       <v-col cols="auto" style="letter-spacing: 5px">SIGN IN</v-col>
     </v-row>
-    <v-form @submit="signIn()">
+    <v-form @submit="signIn()" @submit.prevent>
       <v-row class="mt-2">
         <v-col lg="6" cols="12">
           <v-text-field v-model="email" label="E-Mail Address" dense outlined hide-details />

--- a/src/features/main_menu/_components/login/SignUp.vue
+++ b/src/features/main_menu/_components/login/SignUp.vue
@@ -34,7 +34,7 @@
       </div>
     </div> -->
     <div class="mt-2">
-      <v-form @submit="createAccount">
+      <v-form @submit="createAccount" @submit.prevent>
         <v-row justify="center" align="center">
           <v-col lg="4" cols="12">
             <v-text-field


### PR DESCRIPTION
# Description
This PR fixes a bug introduced in #2038, where the default behavior for an HTML form is to refresh the page upon a submit. This prevents the usual submit action on login/signup and thus prevents the refresh, while still letting a user sign in as usual and preserving the "press Enter to submit" functionality of the HTML forms.

## Issue Number
Closes #2122

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
