### PR TITLE
FIX: Full Tech Dialog cross theme readability

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters class="my-1">
     <v-col>
-      <v-btn x-large block dark tile :color="btnColor" :disabled="disabled" @click="$emit('click')">
+      <v-btn x-large block tile :color="btnColor" :disabled="disabled" @click="$emit('click')" class="white--text">
         <span style="position: absolute; left: 0">
           <v-icon large left>{{ item.Icon }}</v-icon>
           {{ item.Name }}

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
@@ -9,7 +9,8 @@
           v-for="(a, j) in quickActions[k]"
           :key="`action_${j}`"
           :item="a"
-          :disabled="quick.length === 2"
+          :disabled="quick.length === MAX_QUICK"
+          color="action--quick"
           @click="addQuick(a)"
         />
         <cc-combat-dialog
@@ -26,12 +27,15 @@
         <item-selector-row
           v-if="i === 0"
           :item="invadeAction"
-          :disabled="quick.length === 2"
+          :disabled="quick.length === MAX_QUICK"
+          color="action--quick"
           @click="openInvade()"
         />
       </div>
     </v-container>
+
     <v-divider v-if="Object.keys(fullActions).length" class="my-3" />
+
     <v-container v-if="Object.keys(fullActions).length" style="max-width: 800px">
       <div v-for="(k, i) in Object.keys(fullActions)" :key="`sys_act_${i}`">
         <div class="flavor-text mb-n2 mt-1">{{ k }}</div>
@@ -40,6 +44,7 @@
           :key="`action_${j}`"
           :item="a"
           :disabled="quick.length > 0"
+          color="action--full"
           @click="fulltech(a)"
         />
         <cc-combat-dialog
@@ -62,7 +67,7 @@
           align="center"
         >
           <v-col cols="12" md="">
-            <v-alert v-if="q === 'invade-fail'" dense outlined color="white" class="text-center">
+            <v-alert v-if="q === 'invade-fail'" dense outlined class="text-center">
               <span class="heading h3 text-disabled">INVASION ATTEMPT FAILED</span>
             </v-alert>
             <v-alert
@@ -89,7 +94,7 @@
       </v-slide-x-reverse-transition>
 
       <v-slide-x-reverse-transition>
-        <v-row v-if="quick.length === 2" dense justify="center">
+        <v-row v-if="quick.length === MAX_QUICK" dense justify="center">
           <v-col lg="6" md="10" xs="12">
             <v-btn block x-large color="primary" :disabled="used" @click="$emit('use')">
               {{ !used ? 'CONFIRM' : 'ACTION CONFIRMED' }}
@@ -134,6 +139,7 @@ export default Vue.extend({
   },
   data: () => ({
     quick: [],
+    MAX_QUICK: 2,
   }),
   computed: {
     state() {
@@ -174,7 +180,7 @@ export default Vue.extend({
     },
     addQuick(action) {
       if (action.IsTechAttack) this.fulltech(action)
-      else if (this.quick.length < 2) this.quick.push(action)
+      else if (this.quick.length < this.MAX_QUICK) this.quick.push(action)
     },
     removeQuick(idx) {
       this.quick.splice(idx, 1)


### PR DESCRIPTION
# Description

This PR addresses some readability issues that occur in the Full Tech dialog, especially in the default GMS theme.
What's happening with the disappearing Quick Tech options, is that they were being disabled, and this Vuetify issue was occurring:  

![image](https://user-images.githubusercontent.com/64377838/187995877-65828dc9-2145-49f5-b755-b7eda0be5ebf.png)

Details found here:  https://vuetifyjs.com/en/components/buttons/#caveats

So I just took the steps suggested, and added the Quick and Full action colorings that were missing from this dialog, but present in the other areas that use the ItemSelectorRow component. I did check those other areas in all 3 themes, and they appear to look and read correctly now.

## Issue Number
Closes #2093 
Closes #2094 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
