### PR TITLE
fix(help): redirect Troubleshooting to new wiki page

### DIFF
--- a/src/features/nav/pages/Help.vue
+++ b/src/features/nav/pages/Help.vue
@@ -17,14 +17,14 @@
       <v-col cols="4">
         <v-btn
           target="_blank"
-          href="https://github.com/massif-press/compcon/wiki/FAQ%3A-Troubleshooting"
+          href="https://github.com/massif-press/compcon/wiki/Troubleshooting-Issues"
           x-large
           block
           color="secondary"
           class="white--text"
           tabindex="0"
         >
-          Troubleshooting FAQ
+          Troubleshooting
         </v-btn>
       </v-col>
     </v-row>


### PR DESCRIPTION
# Description
Quick fix to redirect the Troubleshooting link in the Help menu to the new wiki page.

## Issue Number
Closes #2110 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
