### PR TITLE
FIX: tech attacks card visibility from Full Tech

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -30,7 +30,7 @@
       </v-card-text>
       <tech-attack
         v-if="action.IsTechAttack"
-        :used="action.IsItemAction ? action.Used : techAttack"
+        :used="techAttack"
         :action="action"
         :mech="mech"
         @techAttackComplete="techAttackComplete($event)"


### PR DESCRIPTION
# Description

The problem here was that the "used" property (which is what is supposed to trigger the roll component to show up) was not being updated on the Hurl Into the Duat ability,  or any ability that was used through the Full Tech dialog due to "used" being tied to the action.Used property, which is only updated on commit. That doesn't happen in the Full Tech dialog until that dialog's confirm button is pressed.

So I changed it to only ever look at the Tech Attack property. I can't find a reason why we should be using something else, since that ternary in CCCombatDialog.vue was explicitly controlling the tech-attack component visibility. I did as much testing as I could, but maybe I missed a case where the action.Used should be checked instead?

Finally, I made changes to the _FullTechDialog to make your selected Full Tech actions visible and cancelable like the quick tech.

## Issue Number
Closes #2088 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
