### PR TITLE
FIX: Full tech fixes

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -30,7 +30,7 @@
       </v-card-text>
       <tech-attack
         v-if="action.IsTechAttack"
-        :used="action.IsItemAction ? action.Used : techAttack"
+        :used="techAttack"
         :action="action"
         :mech="mech"
         @techAttackComplete="techAttackComplete($event)"

--- a/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/CCCombatDialog.vue
@@ -114,15 +114,24 @@ export default Vue.extend({
   },
   methods: {
     use(free) {
-      if (!this.fulltech) this.mech.Pilot.State.CommitAction(this.action, free)
+      if (!this.fulltech){
+        this.mech.Pilot.State.CommitAction(this.action, free)
+      }
       if (this.action.IsTechAttack) {
         this.techAttack = true
-      } else {
-        this.displayLog = this.action.AnyUsed
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const self = this
-        this.$emit('use', free)
-        Vue.nextTick().then(() => self.$forceUpdate())
+      } 
+      else {
+        if(this.fulltech){
+          this.$emit('fulltech-used', this.action)
+          this.hide()
+        }
+        else{
+          this.displayLog = this.action.AnyUsed
+          // eslint-disable-next-line @typescript-eslint/no-this-alias
+          const self = this
+          this.$emit('use', free)
+          Vue.nextTick().then(() => self.$forceUpdate())
+        }
       }
     },
     undo() {

--- a/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters class="my-1">
     <v-col>
-      <v-btn x-large block dark tile :color="btnColor" :disabled="disabled" @click="$emit('click')">
+      <v-btn x-large block tile :color="btnColor" :disabled="disabled" @click="$emit('click')" class="white--text">
         <span style="position: absolute; left: 0">
           <v-icon large left>{{ item.Icon }}</v-icon>
           {{ item.Name }}

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
@@ -9,7 +9,8 @@
           v-for="(a, j) in quickActions[k]"
           :key="`action_${j}`"
           :item="a"
-          :disabled="quick.length === 2 || full.length > 0"
+          :disabled="quick.length === MAX_QUICK || full.length > 0"
+          color="action--quick"
           @click="addQuick(a)"
         />
         <cc-combat-dialog
@@ -26,12 +27,15 @@
         <item-selector-row
           v-if="i === 0"
           :item="invadeAction"
-          :disabled="quick.length === 2 || full.length > 0"
+          :disabled="quick.length === MAX_QUICK || full.length > 0"
+          color="action--quick"
           @click="openInvade()"
         />
       </div>
     </v-container>
+
     <v-divider v-if="Object.keys(fullActions).length" class="my-3" />
+
     <v-container v-if="Object.keys(fullActions).length" style="max-width: 800px">
       <div v-for="(k, i) in Object.keys(fullActions)" :key="`sys_act_${i}`">
         <div class="flavor-text mb-n2 mt-1">{{ k }}</div>
@@ -40,6 +44,7 @@
           :key="`action_${j}`"
           :item="a"
           :disabled="quick.length > 0 || full.length > 0"
+          color="action--full"
           @click="doFullTech(a)"
         />
         <cc-combat-dialog
@@ -65,14 +70,13 @@
           align="center"
         >
           <v-col cols="12" md="">
-            <v-alert v-if="q === 'invade-fail'" dense outlined color="white" class="text-center">
+            <v-alert v-if="q === 'invade-fail'" dense outlined class="text-center">
               <span class="heading h3 text-disabled">INVASION ATTEMPT FAILED</span>
             </v-alert>
             <v-alert
               v-else-if="typeof q === 'string' && q.startsWith('attack-fail-')"
               dense
               outlined
-              color="white"
               class="text-center"
             >
               <span class="heading h3 text-disabled">{{ systemFromFailure(q) }} FAILED</span>
@@ -101,7 +105,7 @@
         >
           <v-col cols="12" md="">
             <v-alert
-              v-if="typeof f === 'string' && q.startsWith('attack-fail-')"
+              v-if="typeof f === 'string' && f.startsWith('attack-fail-')"
               dense
               outlined
               class="text-center"
@@ -123,7 +127,7 @@
       </v-slide-x-reverse-transition>
 
       <v-slide-x-reverse-transition>
-        <v-row v-if="quick.length === 2 || full.length > 0" dense justify="center">
+        <v-row v-if="quick.length === MAX_QUICK || full.length > 0" dense justify="center">
           <v-col lg="6" md="10" xs="12">
             <v-btn block x-large color="primary" :disabled="used" @click="$emit('use')">
               {{ !used ? 'CONFIRM' : 'ACTION CONFIRMED' }}
@@ -169,6 +173,7 @@ export default Vue.extend({
   data: () => ({
     quick: [],
     full: [],
+    MAX_QUICK: 2,
   }),
   computed: {
     state() {
@@ -209,7 +214,7 @@ export default Vue.extend({
     },
     addQuick(action) {
       if (action.IsTechAttack) this.doFullTech(action)
-      else if (this.quick.length < 2) this.quick.push(action)
+      else if (this.quick.length < this.MAX_QUICK) this.quick.push(action)
     },
     removeQuick(idx) {
       this.quick.splice(idx, 1)

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_FullTechDialog.vue
@@ -54,8 +54,9 @@
           :action="a"
           :mech="mech"
           fulltech
-          @add-invade="full.push($event)"
-          @add-fail="full.push('attack-fail-' + $event)"
+          @fulltech-used="addFull($event)"
+          @add-invade="addFull($event)"
+          @add-fail="addFull('attack-fail-' + $event)"
         />
       </div>
     </v-container>
@@ -218,6 +219,10 @@ export default Vue.extend({
     },
     removeQuick(idx) {
       this.quick.splice(idx, 1)
+    },
+    addFull(action){
+      if(this.full.length === 0)
+        this.full.push(action)
     },
     removeFull(){
       this.full = []


### PR DESCRIPTION
# Description
**Fix for #2088** 
The problem here was that the "used" property (which is what is supposed to trigger the roll component to show up) was not being updated on the Hurl Into the Duat ability, or any ability that was used through the Full Tech dialog due to "used" being tied to the action.Used property, which is only updated on commit. That doesn't happen in the Full Tech dialog until that dialog's confirm button is pressed.

So I changed it to only ever look at the Tech Attack property. I can't find a reason why we should be using something else, since that ternary in CCCombatDialog.vue was explicitly controlling the tech-attack component visibility. I did as much testing as I could, but maybe I missed a case where the action.Used should be checked instead?

Finally, I made changes to the _FullTechDialog to make your selected Full Tech actions visible and cancelable like the quick tech.

**Fix for #2093, #2094**
This PR also addresses some readability issues that occur in the Full Tech dialog, especially in the default GMS theme.
What's happening with the disappearing Quick Tech options, is that they were being disabled, and this Vuetify issue was occurring:

![image](https://user-images.githubusercontent.com/64377838/189782951-8bf7e91d-44e9-4b5a-ac35-fa1f3d82322f.png)

Details found here: https://vuetifyjs.com/en/components/buttons/#caveats

So I just took the steps suggested, and added the Quick and Full action colorings that were missing from this dialog, but present in the other areas that use the ItemSelectorRow component. I did check those other areas in all 3 themes, and they appear to look and read correctly now.


## Issue Number
Closes #2088
Closes #2093
Closes #2094

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
