### PR TITLE
FIX: email validation regex is inefficient

### DIFF
--- a/src/features/main_menu/_components/login/SignIn.vue
+++ b/src/features/main_menu/_components/login/SignIn.vue
@@ -130,7 +130,8 @@ export default Vue.extend({
         })
     },
     emailValid(){
-      return /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(this.email)
+      return this.email.indexOf('.') > -1 
+        && this.email.indexOf('@') > -1;
     }
   },
 })


### PR DESCRIPTION
# Description
Replaces the regex email validation with just the bare minimum of checking for a valid email address. That's all I wanted, and thought the regex would be a bit more full featured. Didn't realize how inefficient it was.

## Issue Number
Closes #2119
Closes #2128

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
