### PR TITLE
FIX: enable npc search by class

### DIFF
--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -212,7 +212,7 @@ export default class NpcManager extends Vue {
   grouping = null
   headers = [
     { text: 'Name', value: 'Name', align: 'left' },
-    { text: 'Class', value: 'Class' },
+    { text: 'Class', value: 'Class.Name' },
     { text: 'Role', value: 'Role' },
     { text: 'Tier', value: 'Tier' },
   ]


### PR DESCRIPTION
# Description
The vuetify data table component already gives us searching by every column defined in the headers array. I just needed to point the Class column to the actual name property of the NpcClass object. So this is sort of a bug fix, but hey, I'm up for calling it an expanded feature.

## Issue Number
Closes #2102

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
