### PR TITLE
feat(UI): modify caps handling for mounts, CBs, Talents

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -159,7 +159,7 @@ class Statblock {
             pilot && pilot.has('CoreBonus', 'cb_improved_armament'),
             pilot && pilot.has('CoreBonus', 'cb_integrated_weapon')
           )) {
-            output += `  ${mount.Name}: `
+            output += `  ${mount.Name.toUpperCase()}: `
             if (mount.IsLocked) {
               output += 'SUPERHEAVY WEAPON BRACING'
             } else {
@@ -251,7 +251,7 @@ class Statblock {
         pilot.has('CoreBonus', 'cb_integrated_weapon')
       )
       .map(mount => {
-        let out = `${mount.Name}: `
+        let out = `${mount.Name.toUpperCase()}: `
         if (mount.IsLocked) out += 'SUPERHEAVY WEAPON BRACING'
         else
           out += mount.Weapons.filter(Boolean)

--- a/src/features/pilot_management/PilotSheet/components/PilotRegistrationCard.vue
+++ b/src/features/pilot_management/PilotSheet/components/PilotRegistrationCard.vue
@@ -97,7 +97,7 @@
                 small
               >
                 <v-icon left>cci-skill</v-icon>
-                {{ s.Skill.Trigger }}
+                {{ s.Skill.Trigger.toUpperCase() }}
               </v-chip>
             </v-col>
             <v-col cols="12" md="6">
@@ -117,7 +117,7 @@
                 small
               >
                 <v-icon left>cci-talent</v-icon>
-                {{ t.Talent.Name }} {{ 'I'.repeat(t.Rank) }}
+                {{ t.Talent.Name.toUpperCase() }} {{ 'I'.repeat(t.Rank) }}
               </v-chip>
             </v-col>
           </v-row>

--- a/src/ui/components/selectors/CCCoreBonusSelector.vue
+++ b/src/ui/components/selectors/CCCoreBonusSelector.vue
@@ -14,7 +14,7 @@
         <!-- <missing-item v-if="b.err" @remove="pilot.CoreBonusController.RemoveCoreBonus(b)" /> -->
         <div>
           <v-icon small color="accent">cci-corebonus</v-icon>
-          <strong>{{ b.Name }}</strong>
+          <strong>{{ b.Name.toUpperCase() }}</strong>
           <span class="overline">{{ b.Source }}</span>
         </div>
       </v-row>

--- a/src/ui/components/selectors/CCTalentSelector.vue
+++ b/src/ui/components/selectors/CCTalentSelector.vue
@@ -13,7 +13,7 @@
         <missing-item v-if="pTalent.Talent.err" @remove="remove(pTalent)" />
         <span v-else>
           <v-icon color="accent">cci-rank-{{ pTalent.Rank }}</v-icon>
-          <strong>{{ pTalent.Talent.Name }}</strong>
+          <strong>{{ pTalent.Talent.Name.toUpperCase() }}</strong>
           <v-icon right class="fadeSelect" @click="scroll(pTalent.Talent.ID)">
             mdi-chevron-right
           </v-icon>


### PR DESCRIPTION
# Description
This PR adds `.toUpperCase()` transformations to Talent and Core Bonus names in select places. It also capitalizes the names of mounts in printed, plaintext statblocks. This is part of a drive to make statblocks more readable, and make Lancer-Data easier to stylize for 3rd-party creators.

## Issue Number
None currently.

## Type of change
- [x] New feature (non-breaking change which adds functionality)