### PR TITLE
fix(mech): update loadout systems on loadout change

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadoutController.ts
+++ b/src/classes/mech/components/loadout/MechLoadoutController.ts
@@ -1,4 +1,5 @@
 import { IFeatureContainer } from '@/classes/components/feature/IFeatureContainer'
+import Vue from 'vue'
 import { Mech } from '../../Mech'
 import { MechLoadout } from './MechLoadout'
 import { IMechLoadoutData } from './MechLoadout'
@@ -37,13 +38,14 @@ class MechLoadoutController implements IFeatureContainer {
   }
 
   public set ActiveLoadout(loadout: MechLoadout) {
-    this._active_loadout = loadout
+    Vue.set(this, '_active_loadout', loadout)
     this.Parent.SaveController.save()
   }
 
   public AddLoadout(): void {
-    this._loadouts.push(new MechLoadout(this.Parent))
-    this.ActiveLoadout = this._loadouts[this._loadouts.length - 1]
+    const newLoadout = new MechLoadout(this.Parent)
+    this._loadouts.push(newLoadout)
+    this.ActiveLoadout = newLoadout
     this.Parent.SaveController.save()
   }
 
@@ -67,7 +69,7 @@ class MechLoadoutController implements IFeatureContainer {
     newLoadout.RenewID()
     newLoadout.Name += ' (Copy)'
     this._loadouts.splice(index + 1, 0, newLoadout)
-    this._active_loadout = this._loadouts[index + 1]
+    this._active_loadout = newLoadout
     this.Parent.SaveController.save()
   }
 

--- a/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemsBlock.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemsBlock.vue
@@ -77,10 +77,18 @@ export default Vue.extend({
       type: Boolean,
     },
   },
+  watch: {
+    activeSystems() {
+      this.systems = this.activeSystems
+    },
+  },
   computed: {
     moddedWeapons() {
       return this.mech.MechLoadoutController.ActiveLoadout.Weapons.filter(x => x.Mod)
     },
+    activeSystems() {
+      return this.mech.MechLoadoutController.ActiveLoadout.Systems
+    }
   },
   methods:{
     moveSystem(event){


### PR DESCRIPTION
# Description
This PR introduces a `watch` on the `activeSystems` computed property from a given Mech Loadout, and updates the SystemsBlock data appropriately (this is pulled from the pattern on the pilot roster `Roster/index.vue` when the `plength` would change). It also adds a Vue.set update on loadouts changes for safety, and cleans up how loadouts are assigned when added or copied.

## Issue Number
Closes #2138

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)