### PR TITLE
Implemented NPC Class table sorting

### DIFF
--- a/src/features/compendium/Views/NpcClasses.vue
+++ b/src/features/compendium/Views/NpcClasses.vue
@@ -48,6 +48,7 @@
       multi-sort
       show-select
       single-select
+      :custom-sort="customSort"
     >
       <template v-slot:item.data-table-select="{ item }">
         <v-btn x-small fab color="primary" dark @click="$refs[`modal_${item.ID}`].show()">
@@ -139,6 +140,15 @@ export default class NpcClasses extends Vue {
   public get fItems(): NpcClass[] {
     if (this.search) return this.classes.filter(x => accentInclude(x.Name, this.search))
     return this.classes
+  }
+
+  private customSort(items, sortBy, sortDesc): NpcClass[] {
+    if (sortBy === null || !sortBy.length) return items;
+
+    return items.sort((a, b) => sortBy.map(val => val === "Evasion" ? "evade" : val.toLowerCase()).reduce((acc, val, idx) => {
+      if (acc || val === "structure" || val === "stress") return acc;
+      return ((val === "name" || val === "role") ? a[`_${val}`].localeCompare(b[`_${val}`]) : (a._stats._stats[val][this.tier-1] - b._stats._stats[val][this.tier-1])) * (sortDesc[idx] ? -1 : 1);
+    }, 0));
   }
 
   onResize(): void {


### PR DESCRIPTION
# Description

Originally, only names and roles could be sorted in the NPC class list within the compendium. Now, classes can be sorted by their other stats as well. I had to make a special exception for the evasion stat because it is referenced as both "evasion" and "evade" through out the code base. Another exception had to be made for the structure and stress stats as they are the same across all classes and tiers, therefore they are not factored into the sorting process.

## Issue Number
Closes #840

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)