### PR TITLE
Fixed combat log tracking hp/heat properly

### DIFF
--- a/src/classes/mech/ActiveState.ts
+++ b/src/classes/mech/ActiveState.ts
@@ -730,22 +730,22 @@ class ActiveState {
   public SetStructure(val: number) {
     this._stats.structure_damage += this.ActiveMech.CurrentStructure - val
     this.ActiveMech.CurrentStructure = val
-    const pct = (this.ActiveMech.CurrentStructure / this.ActiveMech.MaxStructure).toFixed(2)
+    const pct = Math.floor((this.ActiveMech.CurrentStructure / this.ActiveMech.MaxStructure) * 100)
     this.SetLog({
       id: `set_str`,
       event: 'STRUCTURE DAMAGE',
-      detail: `!CRITICAL! FRAME.STR::INTEGRITY COMPROMISED ++${pct}++`,
+      detail: `!CRITICAL! FRAME.STR::INTEGRITY COMPROMISED ++${pct}%++`,
     })
   }
 
   public SetStress(val: number) {
     this._stats.reactor_damage += this.ActiveMech.CurrentStress - val
     this.ActiveMech.CurrentStress = val
-    const pct = (this.ActiveMech.CurrentStress / this.ActiveMech.MaxStress).toFixed(2)
+    const pct = Math.floor((this.ActiveMech.CurrentStress / this.ActiveMech.MaxStress) * 100)
     this.SetLog({
       id: `set_stress`,
       event: 'REACTOR STRESS',
-      detail: `!CRITICAL! FRAME.REACTOR::INTEGRITY COMPROMISED ++${pct}++`,
+      detail: `!CRITICAL! FRAME.REACTOR::INTEGRITY COMPROMISED ++${pct}%++`,
     })
   }
 
@@ -760,42 +760,44 @@ class ActiveState {
   }
 
   public SetHp(val: number) {
-    this._stats.hp_damage += this.ActiveMech.CurrentHP - val
-    if (val > this.ActiveMech.CurrentHP) {
-      this.ActiveMech.CurrentHP = val
+    const dif = val - this.ActiveMech.CurrentHP
+    const str = this.ActiveMech.CurrentStructure
+    this.ActiveMech.CurrentHP = val
+    if (dif < 0) {
       this.SetLog({
         id: `rep_dmg`,
         event: 'REPAIR',
-        detail: `FRAME/REP.PROCESS:: ${val} HP RESTORED`,
+        detail: `FRAME/REP.PROCESS:: ${-dif} HP RESTORED`,
       })
     } else {
-      const str = this.ActiveMech.CurrentStructure
-      this.ActiveMech.CurrentHP = val
+      this._stats.hp_damage += dif
       this.SetLog({
         id: `add_dmg`,
         event: 'DAMAGE',
-        detail: `!WARN! INC:: ${val} HP DAMAGE`,
+        detail: `!WARN! INC:: ${dif} HP DAMAGE`,
       })
       if (this.ActiveMech.CurrentStructure < str) {
-        const pct = (this.ActiveMech.CurrentStructure / this.ActiveMech.MaxStructure).toFixed(2)
+        this._stats.reactor_damage += this.ActiveMech.CurrentStress - str
+        const pct = Math.floor((this.ActiveMech.CurrentStructure / this.ActiveMech.MaxStructure) * 100 )
         this.SetLog({
           id: `set_str`,
           event: 'STRUCTURE DAMAGE',
-          detail: `!CRITICAL! FRAME.STR::INTEGRITY COMPROMISED ++${pct}++`,
+          detail: `!CRITICAL! FRAME.STR::INTEGRITY COMPROMISED ++${pct}%++`,
         })
       }
     }
   }
 
   public SetHeat(val: number) {
-    this._stats.heat_damage += val
-    if (val < this.ActiveMech.CurrentHeat) {
-      const dz = this.ActiveMech.IsInDangerZone
-      this.ActiveMech.CurrentHeat = val
+    const dz = this.ActiveMech.IsInDangerZone
+    const dif = val - this.ActiveMech.CurrentHeat
+    const str = this.ActiveMech.CurrentStress
+    this.ActiveMech.CurrentHeat = val
+    if (dif < 0) {
       this.SetLog({
         id: `clear_heat`,
         event: 'CLEAR HEAT',
-        detail: `FRAME/REACTOR.VENT:: ${val} HEAT CLEARED`,
+        detail: `FRAME/REACTOR.VENT:: ${-dif} HEAT CLEARED`,
       })
       if (dz && !this.ActiveMech.IsInDangerZone) {
         this.SetLog({
@@ -805,12 +807,11 @@ class ActiveState {
         })
       }
     } else {
-      const str = this.ActiveMech.CurrentStress
-      this.ActiveMech.CurrentHeat = val
+      this._stats.heat_damage += dif
       this.SetLog({
         id: `add_heat`,
         event: 'HEAT',
-        detail: `!WARN! FRAME/REACTOR.HEAT_LVL:: ${val} HEAT`,
+        detail: `!WARN! FRAME/REACTOR.HEAT_LVL:: ${dif} HEAT`,
       })
       if (this.ActiveMech.IsInDangerZone) {
         this.SetLog({
@@ -820,11 +821,12 @@ class ActiveState {
         })
       }
       if (this.ActiveMech.CurrentStress < str) {
-        const pct = (this.ActiveMech.CurrentStress / this.ActiveMech.MaxStress).toFixed(2)
+        this._stats.reactor_damage += str - this.ActiveMech.CurrentStress
+        const pct = Math.floor((this.ActiveMech.CurrentStress / this.ActiveMech.MaxStress) * 100)
         this.SetLog({
           id: `set_stress`,
           event: 'REACTOR STRESS',
-          detail: `!CRITICAL! FRAME.REACTOR::INTEGRITY COMPROMISED ++${pct}++`,
+          detail: `!CRITICAL! FRAME.REACTOR::INTEGRITY COMPROMISED ++${pct}%++`,
         })
       }
     }


### PR DESCRIPTION
# Description
When in Active Mode, changing your mech's HP or Heat will now properly record the *difference* by which it changed. Additionally, the mission stats will only change when when taking damage/heat, not when they are restored/cleared.

Structure Lost and Reactor Stress are also now recorded when HP is lost and the Heat Cap is exceeded. To make things easier to read, messages reporting current Structure and Reactor percentages now display values as percents rather than decimals.

## Issue Number
Closes #1994 & #1995

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)