### PR TITLE
Unrestricted Weapon Mods

### DIFF
--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -251,6 +251,16 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
     })
   }
 
+  public HasCompatibleMods(): boolean {
+    for(const w of this.MechLoadoutController.ActiveLoadout.Weapons.filter(x => x.Mod != null)){
+      if (!w.Mod.AllowedTypes.includes(w.WeaponType) || !w.Mod.AllowedSizes.includes(w.Size) ||
+          w.Mod.RestrictedTypes.includes(w.WeaponType) || w.Mod.RestrictedSizes.includes(w.Size)) {
+        return false
+      }
+    }
+    return true
+  }
+
   // -- Attributes --------------------------------------------------------------------------------
   public get SizeIcon(): string {
     return `cci-size-${this.Size === 0.5 ? 'half' : this.Size}`
@@ -780,6 +790,7 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
     if (this.FreeSP > 0) out.push('underSP')
     if (this.MechLoadoutController.ActiveLoadout.HasEmptyMounts) out.push('unfinished')
     if (this.RequiredLicenses.filter(x => x.missing).length) out.push('unlicensed')
+    if (!this.HasCompatibleMods()) out.push('incompatiblemod')
     return out
   }
 

--- a/src/ui/components/CCMechStatusAlert.vue
+++ b/src/ui/components/CCMechStatusAlert.vue
@@ -8,6 +8,7 @@
       <span v-else-if="type === 'unfinished'">WARNING: EMPTY MOUNTS DETECTED</span>
       <span v-else-if="type === 'underSP'">WARNING: SYSTEM CAPACITY REMAINING</span>
       <span v-else-if="type === 'unlicensed'">WARNING: UNLICENSED EQUIPMENT DETECTED</span>
+      <span v-else-if="type === 'incompatiblemod'">WARNING: WEAPON MOD COMPATIBILITY ERROR</span>
     </div>
     <div v-if="!small && !hideClear" class="mt-1">
       <v-btn v-if="type === 'destroyed'" block small outlined dark @click="$emit('reprint')">
@@ -28,6 +29,9 @@
       <span v-else-if="type === 'unlicensed'" class="white--text flavor-text">
         Pilot is missing one or more licenses required to legally print or operate this
         configuration
+      </span>
+      <span v-else-if="type === 'incompatiblemod'" class="white--text flavor-text">
+        A weapon mod has been installed to an incompatible weapon.
       </span>
     </div>
   </v-alert>
@@ -56,6 +60,7 @@ export default class CCMechStatusAlert extends Vue {
       case 'underSP':
       case 'unfinished':
       case 'unlicensed':
+      case 'incompatiblemod':
         return false
       default:
         return true
@@ -85,6 +90,9 @@ export default class CCMechStatusAlert extends Vue {
       case 'unlicensed':
         return 'cci-license'
         break
+      case 'incompatiblemod':
+        return 'cci-status-downandout'
+        break
       default:
         return ''
         break
@@ -104,6 +112,9 @@ export default class CCMechStatusAlert extends Vue {
         break
       case 'overSP':
       case 'unlicensed':
+        return 'warning darken-1'
+        break
+      case 'incompatiblemod':
         return 'warning darken-1'
         break
       default:

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
@@ -85,6 +85,33 @@
             </cc-tooltip>
           </v-switch>
         </div>
+        <div class="mt-n4">
+          <v-switch
+              v-model="showIncompatible"
+              dense
+              inset
+              hide-details
+              color="warning"
+              class="mr-3 d-inline"
+          >
+            <cc-tooltip
+                slot="label"
+                simple
+                inline
+                :content="
+                showIncompatible
+                  ? 'Incompatible Mods: SHOWN'
+                  : 'Incompatible Mods: HIDDEN'
+              "
+            >
+              <v-icon
+                  class="ml-n2"
+                  :color="showIncompatible ? 'warning' : 'success'"
+                  v-html="'cci-status-downandout'"
+              />
+            </cc-tooltip>
+          </v-switch>
+        </div>
       </div>
     </cc-selector-table>
   </div>
@@ -121,6 +148,7 @@ export default Vue.extend({
     mods: [],
     showUnlicensed: false,
     showOverSP: false,
+    showIncompatible: false,
   }),
   computed: {
     freeSP(): number {
@@ -129,13 +157,15 @@ export default Vue.extend({
     availableMods(): MechSystem[] {
       let i = this.mods.filter(x => !x.IsHidden)
 
-      // filter by applied_to
-      i = i.filter(x => x.AllowedTypes && x.AllowedTypes.includes(this.weapon.WeaponType))
-      i = i.filter(x => x.AllowedSizes && x.AllowedSizes.includes(this.weapon.Size))
+      if(!this.showIncompatible){
+        // filter by applied_to
+        i = i.filter(x => x.AllowedTypes && x.AllowedTypes.includes(this.weapon.WeaponType))
+        i = i.filter(x => x.AllowedSizes && x.AllowedSizes.includes(this.weapon.Size))
 
-      // // filter out any mount restrictions
-      i = i.filter(x => !x.RestrictedTypes || !x.RestrictedTypes.includes(this.weapon.WeaponType))
-      i = i.filter(x => !x.RestrictedSizes || !x.RestrictedSizes.includes(this.weapon.Size))
+        // // filter out any mount restrictions
+        i = i.filter(x => !x.RestrictedTypes || !x.RestrictedTypes.includes(this.weapon.WeaponType))
+        i = i.filter(x => !x.RestrictedSizes || !x.RestrictedSizes.includes(this.weapon.Size))
+      }
 
       // filter already equipped
       if (this.weapon.Mod) i = i.filter(x => x.ID !== this.weapon.Mod.ID)


### PR DESCRIPTION
# Description

When unrestricted weapon toggle is active the regular checks are bypassed for the filtering in the _ModSelector. This allows users to select mods that would normally be incompatible that they have access to.

To inform the user that such a choice has been made, an additional status alert has been created to alert the player when modifying the mech in the Mech Hanger and at the Start Mission stage of the Pilot Roster

Please let me know if I should update any documentation.

## Issue Number
`#2180`

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
