### PR TITLE
fix(compendium): collect packnames directly + Lancer Core

### DIFF
--- a/src/features/compendium/store/index.ts
+++ b/src/features/compendium/store/index.ts
@@ -323,6 +323,12 @@ export class CompendiumStore extends VuexModule {
     }
   }
 
+  get lcpNames(): string[] {
+    let frame_packs = this.Frames.map(x => x.LcpName)
+    let lcp_packs = this.ContentPacks.map(x => x.Name)
+    return _.unionWith(frame_packs, lcp_packs, _.isEqual)
+  }
+
   get getVersion(): string {
     return this.CCVersion
   }

--- a/src/ui/components/panels/filters/_FrameFilter.vue
+++ b/src/ui/components/panels/filters/_FrameFilter.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
         .sort() as MountType[]
     },
     lcps(): string[] {
-      return getModule(CompendiumStore).Frames.map(x => x.LcpName)
+      return getModule(CompendiumStore).lcpNames
     },
   },
   methods: {

--- a/src/ui/components/panels/filters/_MechSystemFilter.vue
+++ b/src/ui/components/panels/filters/_MechSystemFilter.vue
@@ -150,7 +150,7 @@ export default Vue.extend({
       )
     },
     lcps(): string[] {
-      return getModule(CompendiumStore).Frames.map(x => x.LcpName)
+      return getModule(CompendiumStore).lcpNames
     },
   },
   methods: {
@@ -165,7 +165,7 @@ export default Vue.extend({
     updateFilters() {
       const fObj = {} as any
       if (this.lcpFilter && this.lcpFilter.length) fObj.LcpName = [this.lcpFilter]
-      if (this.spType && parseInt(this.sp) !== NaN) fObj[`SP_${this.spType}`] = parseInt(this.sp)
+      if (this.spType && !isNaN(parseInt(this.sp))) fObj[`SP_${this.spType}`] = parseInt(this.sp)
       if (this.sourceFilter && this.sourceFilter.length) fObj.Source = [this.sourceFilter]
       if (this.tagFilter && this.tagFilter.length) fObj.Tags = this.tagFilter
       if (this.systemTypeFilter && this.systemTypeFilter.length) fObj.Type = [this.systemTypeFilter]

--- a/src/ui/components/panels/filters/_MechWeaponFilter.vue
+++ b/src/ui/components/panels/filters/_MechWeaponFilter.vue
@@ -219,7 +219,7 @@ export default Vue.extend({
       )
     },
     lcps(): string[] {
-      return getModule(CompendiumStore).Frames.map(x => x.LcpName)
+      return getModule(CompendiumStore).lcpNames
     },
   },
   methods: {
@@ -237,7 +237,7 @@ export default Vue.extend({
     updateFilters() {
       const fObj = {} as any
       if (this.lcpFilter && this.lcpFilter.length) fObj.LcpName = [this.lcpFilter]
-      if (this.spType && parseInt(this.sp) !== NaN) fObj[`SP_${this.spType}`] = parseInt(this.sp)
+      if (this.spType && !isNaN(parseInt(this.sp))) fObj[`SP_${this.spType}`] = parseInt(this.sp)
       if (this.sourceFilter && this.sourceFilter.length) fObj.Source = [this.sourceFilter]
       if (this.tagFilter && this.tagFilter.length) fObj.Tags = this.tagFilter
       if (this.weaponTypeFilter && this.weaponTypeFilter.length)

--- a/src/ui/components/panels/filters/_WeaponModFilter.vue
+++ b/src/ui/components/panels/filters/_WeaponModFilter.vue
@@ -93,7 +93,7 @@ export default Vue.extend({
       )
     },
     lcps(): string[] {
-      return getModule(CompendiumStore).Frames.map(x => x.LcpName)
+      return getModule(CompendiumStore).lcpNames
     },
   },
   methods: {


### PR DESCRIPTION
# Description
The compendium filters for content packs defaulted to grabbing pack names from available Frames in the compendium, instead of directly from the compendium's ContentPacks. This means that an LCP that has *no frames* will lack a content pack filter in the Compendium (e.g. for an LCP that only has non-frame Exotic Gear). This PR adds a method to retrieve LCP Names based upon ContentPacks in the compendium.

However, since Lancer Core Data isn't treated as a Content Pack, we still need an alternative way of adding the Lancer Core Data as an option for the filters. We could hardcode the packname, but I felt more comfortable performing a union of the pack names derived from Frames and ContentPacks. Perhaps one day in the future, the Lancer Core Data will be considered its own Content Pack, obviating the redundancy added here.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
