### PR TITLE
Remove a discomfiting mech name

### DIFF
--- a/src/assets/generators/mechnames.txt
+++ b/src/assets/generators/mechnames.txt
@@ -142,7 +142,6 @@ Cold World
 Collateral Damage
 Colorless Life
 Come Closer
-Communist Wokery
 Complaint Department
 Concerning Syncretism
 Conflict of Interest


### PR DESCRIPTION
# Description

Removed mech name caused some raised eyebrows due to how the original words are used in real life politics and conspiracies. While it’s possible the name was used as a reversal or joke against those who use it, it may make users more comfortable to simply remove it from the generator. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
