### PR TITLE
use semver to compare versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "raw-loader": "^4.0.2",
     "register-service-worker": "^1.7.1",
     "sass-loader": "10.1.1",
+    "semver": "^7.5.1",
     "tiptap-vuetify": "^2.24.0",
     "typeit": "^6.0.3",
     "vue": "^2.6.11",

--- a/src/cloud/lcp_sync.ts
+++ b/src/cloud/lcp_sync.ts
@@ -3,6 +3,8 @@ import { Auth, Storage } from 'aws-amplify'
 import { getModule } from 'vuex-module-decorators'
 import { ContentPack } from '@/class'
 import { IContentPack } from '@/classes/ContentPack'
+const semverCompare = require('semver/functions/compare')
+const semverCoerce = require('semver/functions/coerce')
 
 const currentCognitoIdentity = async (): Promise<any> =>
   Auth.currentUserCredentials()
@@ -48,16 +50,16 @@ type LCPItem = {
 }
 
 function determineLatest(item: LCPItem): string {
-  if (item.localVersion === item.cloudVersion) return 'synced'
   if (!item.localVersion) return 'cloud'
   if (!item.cloudVersion) return 'local'
-  if (
-    parseFloat(item.cloudVersion.replace(/[^0-9]/g, '')) >
-    parseFloat(item.localVersion.replace(/[^0-9]/g, ''))
-  ) {
+
+  const versionCompare = semverCompare(semverCoerce(item.cloudVersion), semverCoerce(item.localVersion))
+  if (versionCompare === 1) {
     return 'cloud'
-  } else {
+  } else if (versionCompare === -1) {
     return 'local'
+  } else {
+    return 'synced'
   }
 }
 

--- a/src/features/nav/pages/ExtraContent/components/DirectoryTable.vue
+++ b/src/features/nav/pages/ExtraContent/components/DirectoryTable.vue
@@ -80,6 +80,8 @@
 import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
+const semverGte = require('semver/functions/gte')
+const semverCoerce = require('semver/functions/coerce')
 
 export default Vue.extend({
   name: 'content-pack-directory-table',
@@ -128,7 +130,7 @@ export default Vue.extend({
     packOutdated(item) {
       const installedPack = this.getPack(item)
       if (!installedPack) return true
-      return installedPack.Version !== item.version
+      return !semverGte(semverCoerce(installedPack.Version), semverCoerce(item.version))
     },
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10699,6 +10699,13 @@ semver@^7.1.2, semver@^7.3.2:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.2:
   version "0.17.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"


### PR DESCRIPTION
# Description
This PR uses the `semver` library to coerce and compare LCP versions to determine the latest LCP version. This is used both in the LCP Directory tab of the Content Manager and in the LCP Sync menu under Cloud Account Management. 

This was made in response to the current method of version comparison being simply removing the `.`s from a version and comparing the resulting string. This resulted in The Long Rim v1.2.0 appearing less recent than v1.0.11, since the versions would shorten to 120 and 1011, respectively, and thus the older 1.0.11 would appear "greater" in comparison. Ergo, when "Sync All" would be performed, Long Rim 1.0.11 would overwrite 1.2.0, which is undesirable behavior.

As a note: I was unable to properly test this in the Sync menu since backend updates have restricted CORS access for my local builds (which is an issue in and of itself lol). However, I was able to test it in the LCP Directory (which was an added bonus since version comparison in that part of compcon had been a longstanding issue). That said, **PLEASE TEST THE SYNC MENU BEHAVIOR BEFORE DEPLOYING THIS CHANGE,** as I cannot guarantee this change solves the issue within the Sync menu.

## Issue Number
More solidly closes #2235

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
