### PR TITLE
fix: correct typo in feature collection comparison

### DIFF
--- a/src/classes/components/feature/FeatureCollector.ts
+++ b/src/classes/components/feature/FeatureCollector.ts
@@ -12,7 +12,7 @@ abstract class FeatureCollector {
       if (candidate['Destroyed'] !== undefined && (candidate as any).Destroyed) return
       if (candidate['IsCascading'] !== undefined && (candidate as any).IsCascading) return
       if (
-        collection.toLowerCase() !== 'action' &&
+        collection.toLowerCase() !== 'actions' &&
         candidate['Used'] !== undefined &&
         (candidate as any).Used
       )


### PR DESCRIPTION
# Description

Fixing an issue where using an action from a pilot talent during an encounter would make it disappear from the list of actions for the rest of a combat encounter instead of just becoming unusable until it is able to be used again based on frequency.

## Issue Number
N/A

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
