### PR TITLE
fix: add integrated weapons to Mounts getter for MechLoadout

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -123,7 +123,7 @@ class MechLoadout extends Loadout {
   }
 
   public get Mounts(): Mount[] {
-    return (this._integratedMounts as Mount[]).concat(this._equippableMounts)
+    return (this._integratedMounts as Mount[]).concat(this._equippableMounts).concat(this._integratedWeapon)
   }
 
   public get HasEmptyMounts(): boolean {


### PR DESCRIPTION
# Description

Updated the Mounts getter for MechLoadout to include integrated weapons.

Adding example before and after images for Barrage action from the Actions footer, but similar results are shown for Skirmish and Overwatch from this change.

Before change(the mech has a GMS Pistol as an Integrated Weapon):
![image](https://github.com/massif-press/compcon/assets/9093363/05a73b30-a44d-48b2-9570-db8ddfd6639c)

After change:
![image](https://github.com/massif-press/compcon/assets/9093363/4bc24d74-08b8-42d0-b3a5-75e7a127569b)


## Issue Number
#2254

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
