### PR TITLE
fix: updating mech stat block generation to output all integrated mounts

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -152,10 +152,12 @@ class Statblock {
         output += `  SPD:${mech.Speed} EVA:${mech.Evasion} EDEF:${mech.EDefense} SENS:${mech.SensorRange} SAVE:${mech.SaveTarget}\n`
 
         output += '[ WEAPONS ]\n'
-        for (const im of mech.FeatureController.IntegratedWeapons) {
+        for (const im of mech.MechLoadoutController.ActiveLoadout.IntegratedMounts) {
+          for (const mw of im.Weapons) {
           output += '  INTEGRATED MOUNT: '
-          output = addWeaponToOutput(output, discordEmoji, im)
+          output = addWeaponToOutput(output, discordEmoji, mw)
           output += '\n'
+          }
         }
         const loadout = mech.MechLoadoutController.ActiveLoadout
           ? mech.MechLoadoutController.ActiveLoadout
@@ -235,24 +237,24 @@ class Statblock {
         mech.SaveTarget
       }
 [ WEAPONS ]
-  ${mech.FeatureController.IntegratedWeapons.map(
-    weapon =>
-      `Integrated: ${weapon ? weapon.TrueName : 'N/A  '}${
-        discordEmoji && weapon && weapon.Range
+  ${mech.MechLoadoutController.ActiveLoadout.IntegratedMounts.map(
+    mount =>
+      `Integrated: ${mount.Weapon ? mount.Weapon.TrueName : 'N/A  '}${
+        discordEmoji && mount.Weapon && mount.Weapon.Range
           ? ' ' +
-            weapon.Range.filter(Boolean)
+          mount.Weapon.Range.filter(Boolean)
               .map(r => `${r.DiscordEmoji}${r.Value}`)
               .join(' ')
           : ''
       }${
-        discordEmoji && weapon && weapon.Damage
+        discordEmoji && mount.Weapon && mount.Weapon.Damage
           ? ' ' +
-            weapon.Damage.filter(Boolean)
+          mount.Weapon.Damage.filter(Boolean)
               .map(d => `${d.DiscordEmoji}${d.Value}`)
               .join(' ')
           : ''
       }\n  `
-  )}${mechLoadout
+  ).join('')}${mechLoadout
         .AllEquippableMounts(
           pilot.has('CoreBonus', 'cb_improved_armament'),
           pilot.has('CoreBonus', 'cb_integrated_weapon'),


### PR DESCRIPTION
# Description

This fixes an issue where generating a "Mech Build" or "Full" stat block would only output one Integrated Mount if there are multiple.

Example of Mech Build output after changes:
![image](https://github.com/massif-press/compcon/assets/9093363/0482a586-5488-4132-a7d3-f0ca8bd238a5)

Example of Full output after changes:
![image](https://github.com/massif-press/compcon/assets/9093363/b5327459-fe32-4489-92d5-8249db1846e7)

I think there could be a future issue to clean up the stat block generation logic.  There is code that generates the same info two different ways between "Mech Build" and "Full" stat block generation, but didn't want to refactor as part of this, just wanted to fix the specific issue for now.

## Issue Number
#2161

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)