### PR TITLE
feat: return fire automation

### DIFF
--- a/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_ItemSelectorRow.vue
@@ -36,9 +36,6 @@ export default Vue.extend({
     disabled: {
       type: Boolean,
     },
-    overwatch: {
-      type: Boolean,
-    },
     color: {
       type: String,
       required: false,

--- a/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
+++ b/src/ui/components/panels/loadout/active_loadout/components/_WeaponAttack.vue
@@ -252,7 +252,7 @@
                   Attack
                 </v-btn>
               </v-col>
-              <v-col v-else-if="overwatch" cols="auto" align-self="center">
+              <v-col v-else-if="reaction" cols="auto" align-self="center">
                 <v-btn
                   large
                   tile
@@ -625,7 +625,7 @@ export default Vue.extend({
     aux: { type: Boolean },
     improv: { type: Boolean },
     barrage: { type: Boolean },
-    overwatch: { type: Boolean },
+    reaction: { type: Boolean },
   },
   data: () => ({
     tab: 0,

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_OverwatchDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_OverwatchDialog.vue
@@ -12,7 +12,6 @@
             )"
             :key="`weap_${j}`"
             :item="w"
-            overwatch
             color="action--reaction"
             @click="overwatch(w, m)"
           />

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+    <v-card-text v-if="mech.Pilot.State.IsMounted" class="pt-3">
+      <cc-active-synergy :locations="['returnFire']" :mech="mech" />
+      <action-detail-expander :action="action" />
+      <v-divider class="my-3" />
+      <v-container style="max-width: 800px">
+        <div v-for="(m, i) in mech.MechLoadoutController.ActiveLoadout.Mounts" :key="`bar_${i}`">
+          <item-selector-row
+            v-for="(w, j) in m.Weapons.filter(
+              x => x.Size === 'Auxiliary' && !x.Destroyed && !x.NoAttack
+            )"
+            :key="`weap_${j}`"
+            :item="w"
+            overwatch
+            color="action--reaction"
+            @click="returnFire(w, m)"
+          />
+        </div>
+      </v-container>
+    </v-card-text>
+    <v-card-text v-else class="pt-3">
+      <action-detail-expander :action="action" />
+      <v-divider class="my-3" />
+      <v-container style="max-width: 800px">
+        <item-selector-row
+          v-for="(w, j) in mech.Pilot.Loadout.Weapons"
+          :key="`weap_${j}`"
+          :item="w"
+          color="action--reaction"
+          @click="pilotReturnFire(w)"
+        />
+      </v-container>
+    </v-card-text>
+
+    <w-skirmish-dialog
+      ref="s_dialog"
+      :mech="mech"
+      :item="selected"
+      :mount="selectedMount"
+      returnFire
+      @confirm="completeReturnFire($event)"
+    />
+
+    <sel-fight-dialog
+      ref="f_dialog"
+      :pilot="mech.Pilot"
+      :item="selected"
+      returnFire
+      @confirm="completeReturnFire($event)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import ActionDetailExpander from '../../components/_ActionDetailExpander.vue'
+import ItemSelectorRow from '../../components/_ItemSelectorRow.vue'
+import WSkirmishDialog from './_SelSkirmishDialog.vue'
+import SelFightDialog from './_SelFightDialog.vue'
+
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'return-fire-dialog',
+  components: {
+    ActionDetailExpander,
+    ItemSelectorRow,
+    WSkirmishDialog,
+    SelFightDialog,
+  },
+  props: {
+    used: { type: Boolean },
+    mech: {
+      type: Object,
+      required: true,
+    },
+    action: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: () => ({
+    selected: null,
+    selectedMount: null,
+  }),
+  computed: {
+    state() {
+      return this.mech.Pilot.State
+    },
+  },
+  methods: {
+    completeReturnFire(free) {
+      this.state.CommitAction(this.action, free)
+    },
+    pilotReturnFire(item) {
+      this.selected = item
+      this.$refs.f_dialog.show()
+    },
+    returnFire(item, mount) {
+      this.selected = item
+      this.selectedMount = mount
+      this.$refs.s_dialog.show()
+    },
+  },
+})
+</script>

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
@@ -8,7 +8,7 @@
         <div v-for="(m, i) in mech.MechLoadoutController.ActiveLoadout.Mounts" :key="`bar_${i}`">
           <item-selector-row
             v-for="(w, j) in m.Weapons.filter(
-              x => x.Size === 'Auxiliary' && !x.Destroyed && !x.NoAttack
+              x => x.Size === 'Auxiliary' && !x.Destroyed && !x.NoAttack && x.WeaponType !== 'Melee'
             )"
             :key="`weap_${j}`"
             :item="w"

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_ReturnFireDialog.vue
@@ -12,24 +12,10 @@
             )"
             :key="`weap_${j}`"
             :item="w"
-            overwatch
             color="action--reaction"
             @click="returnFire(w, m)"
           />
         </div>
-      </v-container>
-    </v-card-text>
-    <v-card-text v-else class="pt-3">
-      <action-detail-expander :action="action" />
-      <v-divider class="my-3" />
-      <v-container style="max-width: 800px">
-        <item-selector-row
-          v-for="(w, j) in mech.Pilot.Loadout.Weapons"
-          :key="`weap_${j}`"
-          :item="w"
-          color="action--reaction"
-          @click="pilotReturnFire(w)"
-        />
       </v-container>
     </v-card-text>
 
@@ -41,14 +27,6 @@
       returnFire
       @confirm="completeReturnFire($event)"
     />
-
-    <sel-fight-dialog
-      ref="f_dialog"
-      :pilot="mech.Pilot"
-      :item="selected"
-      returnFire
-      @confirm="completeReturnFire($event)"
-    />
   </div>
 </template>
 
@@ -56,7 +34,6 @@
 import ActionDetailExpander from '../../components/_ActionDetailExpander.vue'
 import ItemSelectorRow from '../../components/_ItemSelectorRow.vue'
 import WSkirmishDialog from './_SelSkirmishDialog.vue'
-import SelFightDialog from './_SelFightDialog.vue'
 
 import Vue from 'vue'
 
@@ -66,7 +43,6 @@ export default Vue.extend({
     ActionDetailExpander,
     ItemSelectorRow,
     WSkirmishDialog,
-    SelFightDialog,
   },
   props: {
     used: { type: Boolean },
@@ -91,10 +67,6 @@ export default Vue.extend({
   methods: {
     completeReturnFire(free) {
       this.state.CommitAction(this.action, free)
-    },
-    pilotReturnFire(item) {
-      this.selected = item
-      this.$refs.f_dialog.show()
     },
     returnFire(item, mount) {
       this.selected = item

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelBarrageDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelBarrageDialog.vue
@@ -91,7 +91,7 @@ export default Vue.extend({
   },
   methods: {
     hasAux(mount, primary) {
-      const auxes = mount.Weapons.filter(x => x.Size === WeaponSize.Aux)
+      const auxes = mount.Weapons.filter(x => x.Size === WeaponSize.Aux && x.Loaded)
       if (!auxes.length) return false
       const unusedAux = auxes.filter(x => x !== primary)
       if (!unusedAux.length) return false

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
@@ -127,7 +127,7 @@ export default Vue.extend({
       if (!unusedAux.length) return false
       const candidate = unusedAux[0]
       if (this.item === candidate) return false
-      return !this.overwatch && !this.returnFire && (candidate || false)
+      return !this.returnFire && (candidate || false)
     },
     confirmAttack(free) {
       this.confirmedFree = free

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
@@ -4,6 +4,7 @@
     :fullscreen="$vuetify.breakpoint.mdAndDown"
     :style="$vuetify.breakpoint.mdAndDown ? `x-overflow: hidden` : ''"
     width="90vw"
+    @click:outside="hide"
   >
     <v-card tile class="background">
       <cc-titlebar v-if="overwatch" large color="action--reaction">

--- a/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
+++ b/src/ui/components/panels/loadout/active_loadout/dialogs/action/_SelSkirmishDialog.vue
@@ -13,6 +13,13 @@
           <v-icon large left>close</v-icon>
         </v-btn>
       </cc-titlebar>
+      <cc-titlebar v-else-if="returnFire" large color="action--reaction">
+        <v-icon x-large>cci-reaction</v-icon>
+        Return Fire
+        <v-btn slot="items" dark icon @click="hide">
+          <v-icon large left>close</v-icon>
+        </v-btn>
+      </cc-titlebar>
       <cc-titlebar v-else large color="action--quick">
         <v-icon x-large color="white">mdi-hexagon-slice-3</v-icon>
         Skirmish
@@ -24,12 +31,24 @@
       <v-spacer v-if="$vuetify.breakpoint.mdAndDown" class="titlebar-margin" />
 
       <v-card-text v-if="item && mount" class="mb-0 pb-2">
-        <weapon-attack
+        <weapon-attack v-if="overwatch || returnFire"
           ref="main"
           :item="item"
           :mech="mech"
           :mount="mount"
-          :overwatch="overwatch"
+          reaction
+          @confirm="confirmAttack($event)"
+        >
+          <div class="heading h2 mt-3 mb-n3">
+            <v-icon x-large class="mt-n2 mr-n1">cci-mech-weapon</v-icon>
+            {{ item.Name }}
+          </div>
+        </weapon-attack>
+        <weapon-attack v-else
+          ref="main"
+          :item="item"
+          :mech="mech"
+          :mount="mount"
           @confirm="confirmAttack($event)"
         >
           <div class="heading h2 mt-3 mb-n3">
@@ -91,6 +110,9 @@ export default Vue.extend({
     overwatch: {
       type: Boolean,
     },
+    returnFire: {
+      type: Boolean,
+    },
   },
   data: () => ({
     dialog: false,
@@ -98,13 +120,13 @@ export default Vue.extend({
   }),
   methods: {
     hasAux(mount, primary) {
-      const auxes = mount.Weapons.filter(x => x.Size === WeaponSize.Aux)
+      const auxes = mount.Weapons.filter(x => x.Size === WeaponSize.Aux && x.Loaded)
       if (!auxes.length) return false
       const unusedAux = auxes.filter(x => x !== primary)
       if (!unusedAux.length) return false
       const candidate = unusedAux[0]
       if (this.item === candidate) return false
-      return candidate || false
+      return !this.overwatch && !this.returnFire && (candidate || false)
     },
     confirmAttack(free) {
       this.confirmedFree = free


### PR DESCRIPTION
# Description
Added automation of the Return Fire reaction.

Usage:
- Click "Return Fire" reaction
  - ![image](https://github.com/massif-press/compcon/assets/9093363/4ec0be2a-045d-4bc2-acb0-2f66b57a31df)
- Weapon selection dialog will show.  It will only show Auxiliary Ranged weapons.
  - ![image](https://github.com/massif-press/compcon/assets/9093363/77d6d003-79a9-46da-8a31-75b693dfad82)
- After selecting the weapon, the Weapon Attack dialog will show, allowing to automatically roll attack and damage
  - ![image](https://github.com/massif-press/compcon/assets/9093363/3df193f3-2f82-4494-bc51-2206b5ef3149)
- In this example, since we are using Hand Cannons, we can see the attack even unloaded the weapon used, as expected
  - ![image](https://github.com/massif-press/compcon/assets/9093363/371065ff-7983-4f9f-b33f-ba0f60721032)

Additional changes:
- Removed unused overwatch property from _ItemSelectorRow
- If an Aux Weapon is not loaded, it won't show in the _SelBarrageDialog or _SelSirmishDialog to attack with
  - Image example, where one Hand Cannon is loaded, and the other isn't
    - ![image](https://github.com/massif-press/compcon/assets/9093363/44058aaa-4ded-4c06-b970-c2be5ff96d89)
  - After clicking "Skirmish" on the first Hand Cannon, only is shows in the attack dialog
    - ![image](https://github.com/massif-press/compcon/assets/9093363/c3ffce9d-0487-457b-9383-288a0925cf58)
- Updated hasAux function so _SelSirmishDialog won't show aux weapons during "Overwatch" or "Return Fire"
- Made the _SelSkirmishDialog run hide if clicking outside the dialog

## Issue Number
#2260 
#2072 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
