### PR TITLE
feat: allow generating npc stat block in encounter

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -306,8 +306,8 @@ class Statblock {
     output += `${npc.Tag}\n`
     output += '[ STATS ]\n'
     output += `  H: ${npc.Stats.Hull} | A: ${npc.Stats.Agility} | S: ${npc.Stats.Systems} | E: ${npc.Stats.Engineering}\n`
-    output += `  STRUCT: ${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.Stats.HP}\n`
-    output += `  STRESS: ${npc.Stats.Stress} | HEATCAP: ${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
+    output += `  STRUCT: ${npc.CurrentStructure}/${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.CurrentHP}/${npc.Stats.HP}\n`
+    output += `  STRESS: ${npc.CurrentStress}/${npc.Stats.Stress} | HEATCAP: ${npc.CurrentHeat}/${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
     output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
     output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
     output += '[ FEATURES ]\n  '

--- a/src/features/encounters/mission/runner/components/EncounterNav.vue
+++ b/src/features/encounters/mission/runner/components/EncounterNav.vue
@@ -57,6 +57,14 @@
               <v-list-item-title>Full Repair</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
+          <v-list-item v-if="actor.Tier" @click="setStatBlock(actor)">
+            <v-list-item-icon class="ma-0 mr-2 mt-2">
+              <v-icon>mdi-file-document-outline</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>Generate NPC Statblock</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
           <v-divider />
           <v-list-item @click="deleteDialog = true">
             <v-list-item-icon class="ma-0 mr-2 mt-2">
@@ -92,6 +100,17 @@
           <v-btn block large tile color="success darken-1" @click="repair()">
             Confirm Full Repair
           </v-btn>
+        </cc-titled-panel>
+      </v-dialog>
+      <v-dialog v-model="statBlockDialog" width="50%" @click:outside="close()">
+        <cc-titled-panel title="NPC Statblock">
+          <v-textarea v-if="statBlockNpc" :value="statBlock()" auto-grow readonly outlined filled class="flavor-text"/>
+          <cc-tooltip simple inline content="Copy stat block to clipboard">
+            <v-btn class="mt-n4" color="accent" @click="copyStatBlock()">
+              <v-icon>mdi-clipboard-text-outline</v-icon>
+              Copy to Clipboard
+            </v-btn>
+          </cc-tooltip>
         </cc-titled-panel>
       </v-dialog>
       <v-dialog v-model="deleteDialog" width="50%">
@@ -137,6 +156,7 @@
 import Vue from 'vue'
 import InfoModal from './InfoModal.vue'
 import ReinforcementsModal from './ReinforcementsModal.vue'
+import { Npc, Statblock } from '@/class'
 
 export default Vue.extend({
   name: 'encounter-nav',
@@ -162,15 +182,30 @@ export default Vue.extend({
     reactionDialog: false,
     removeDialog: false,
     repairDialog: false,
+    statBlockDialog: false,
     deleteDialog: false,
     reinforcementDialog: false,
     noteSheet: false,
+    statBlockNpc: null,
   }),
   methods: {
     react() {
       this.actor.AddReaction(this.reaction)
       this.reaction = ''
       this.close()
+    },
+    statBlock() {
+      return Statblock.GenerateNPC(this.statBlockNpc)
+    },
+    copyStatBlock() {
+      navigator.clipboard
+        .writeText(this.statBlock())
+        .then(() => Vue.prototype.$notify('Stat block copied to clipboard.', 'confirmation'))
+        .catch(() => Vue.prototype.$notifyError('Unable to copy stat block'))
+    },
+    setStatBlock(npc: Object) {
+      this.statBlockNpc = npc
+      this.statBlockDialog = true
     },
     removeActor() {
       this.actor.Defeat = this.reason
@@ -189,6 +224,7 @@ export default Vue.extend({
       this.reactionDialog = false
       this.removeDialog = false
       this.repairDialog = false
+      this.statBlockDialog = false
       this.deleteDialog = false
     },
   },

--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -178,6 +178,12 @@
                 filled
                 class="flavor-text"
               />
+              <cc-tooltip simple inline content="Copy stat block to clipboard">
+                <v-btn class="mt-n4" color="accent" @click="copyStatBlock()">
+                  <v-icon>mdi-clipboard-text-outline</v-icon>
+                  Copy to Clipboard
+                </v-btn>
+              </cc-tooltip>
             </cc-titled-panel>
           </v-dialog>
         </v-col>
@@ -241,6 +247,13 @@ export default class NpcManager extends Vue {
 
   statblock() {
     return Statblock.GenerateNPC(this.statblockNpc)
+  }
+
+  copyStatBlock() {
+    navigator.clipboard
+      .writeText(this.statblock())
+      .then(() => Vue.prototype.$notify('Stat block copied to clipboard.', 'confirmation'))
+      .catch(() => Vue.prototype.$notifyError('Unable to copy stat block'))
   }
 
   delete_npc(npc: Npc) {


### PR DESCRIPTION
# Description
Added an option while running a combat encounter to generate a text stat block for the currently selected NPC.  Also added additional info to the current NPC stat block generation to include current HP, Heat, Structure, and Stress.  The dialog that shows the NPC statblock in both the NPC Roster page and the Encounter page both have a "Copy to Clipboard" option too.

Tried adding feature effect text to the stat block, but found it was far too much with how simplified the plaintext stat generation is.  I'd suggest screenshots to share full effect information for NPC features when applicable.  I could see a separate dialog for full NPC feature information if that's desired by someone in the future.

Generate NPC Statblock option
![image](https://github.com/massif-press/compcon/assets/9093363/f15db672-3a02-45f5-95b7-bd53628962ec)

Statblock example from Encounter:
![image](https://github.com/massif-press/compcon/assets/9093363/e246e61b-04e8-428b-9f35-7c44a9bfe20f)

Statblock example from NPC Roster:
![image](https://github.com/massif-press/compcon/assets/9093363/55fb93e3-5570-4a8b-a943-7e19b1584f03)

## Issue Number
#2179 

This work item doesn't address the full feature request because the stat block doesn't provide full NPC feature effect information, but I think this is a good first step.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
