### PR TITLE
added feature #1747 unhardcoded gear slots

### DIFF
--- a/src/classes/pilot/components/Loadout/PilotLoadout.ts
+++ b/src/classes/pilot/components/Loadout/PilotLoadout.ts
@@ -146,6 +146,32 @@ class PilotLoadout extends Loadout {
       : Array(2).fill(null)
     return loadout
   }
+
+  public redoExtendedGear(newGearSlots : number) : PilotGear[]{
+      if(newGearSlots > 0 ) {
+        const currentExtraSlots = this.ExtendedGear.length
+        if(newGearSlots < currentExtraSlots){
+          this.ExtendedGear = this.ExtendedGear.slice(0, newGearSlots)
+        } else if (newGearSlots > currentExtraSlots){
+          const excessGearSlots =  newGearSlots - currentExtraSlots
+          this.ExtendedGear = this.ExtendedGear.concat(Array(excessGearSlots).fill(null))
+        }
+      }
+      return this.ExtendedGear
+  }
+
+  public redoExtendedWeapons(newWeaponSlots : number) : PilotWeapon[]{
+    if(newWeaponSlots > 0 ) {
+      const currentExtraSlots = this.ExtendedWeapons.length
+      if(newWeaponSlots < currentExtraSlots){
+        this.ExtendedWeapons = this.ExtendedWeapons.slice(0, newWeaponSlots)
+      } else if (newWeaponSlots > currentExtraSlots){
+        const excessGearSlots =  newWeaponSlots - currentExtraSlots
+        this.ExtendedWeapons = this.ExtendedWeapons.concat(Array(excessGearSlots).fill(null))
+      }
+    }
+    return this.ExtendedWeapons
+  }
 }
 
 export default PilotLoadout

--- a/src/ui/components/panels/loadout/pilot_loadout/CCPilotLoadout.vue
+++ b/src/ui/components/panels/loadout/pilot_loadout/CCPilotLoadout.vue
@@ -68,6 +68,7 @@ import Vue from 'vue'
 import PilotArmorCard from './_PLArmorCard.vue'
 import PilotWeaponCard from './_PLWeaponCard.vue'
 import PilotGearCard from './_PLGearCard.vue'
+import { Bonus } from '@/classes/components/feature/bonus/Bonus'
 import { PilotArmor, PilotWeapon, PilotGear } from '@/class'
 
 export default Vue.extend({
@@ -87,14 +88,16 @@ export default Vue.extend({
       return this.pilot.Loadout.Gear
     },
     extendedGear() {
-      if (this.pilot.has('reserve', 'extended_harness')) return this.pilot.Loadout.ExtendedGear
+      const extraGearSlots = Bonus.Int(0, "pilot_gear", this.pilot)
+      if(extraGearSlots > 0 ) return this.pilot.Loadout.redoExtendedGear(extraGearSlots)
       return []
     },
     weapons() {
       return this.pilot.Loadout.Weapons
     },
     extendedWeapons() {
-      if (this.pilot.has('reserve', 'extended_harness')) return this.pilot.Loadout.ExtendedWeapons
+      const extraWeaponSlots = Bonus.Int(0, "pilot_weapon_slot", this.pilot)
+      if(extraWeaponSlots > 0 ) return this.pilot.Loadout.redoExtendedWeapons(extraWeaponSlots)
       return []
     },
   },


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

the gear slots granted by the extended harness were hardcoded so any similar homebrew additions wouldn't be functional, this adds that feature. 

## Issue Number
`#1747`

## Type of change
small changes to the main codebase, allowing non-extended harness options to be used while keeping most of the functionality as before. there will need to be a change to the documentation and usage of the base lancer-data, which I have already fixed and made a pull request on that git page.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
