### PR TITLE
fix 2267: Integrated Systems now show in Print

### DIFF
--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -296,7 +296,7 @@
     <fieldset>
       <legend class="heading ml-1 px-2">Systems</legend>
       <div
-        v-for="(s, i) in mech.MechLoadoutController.ActiveLoadout.Systems"
+        v-for="(s, i) in mech.MechLoadoutController.ActiveLoadout.AllActiveSystems"
         :key="`mms_${i}`"
         class="bordered-block"
       >


### PR DESCRIPTION
# Description

This [issue](https://github.com/massif-press/compcon/issues/2267) highlighted that certain systems were missing from the Mech Print out, namely systems like Walking Armory. Taking a look, I found that [it](https://github.com/massif-press/compcon/blob/012b7ee3b8e1460218aa8d29e07aa23177dabd7f/src/features/pilot_management/Print/MechPrint.vue#L299) was using `mech.MechLoadoutController.ActiveLoadout.Systems` which does not include `IntegratedSystems`, so I updated it to use `AllActiveSystems` instead.

## Issue Number
`#2267`

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
