### PR TITLE
allowed extended weapon mount functionality

### DIFF
--- a/src/classes/Interfaces.d.ts
+++ b/src/classes/Interfaces.d.ts
@@ -85,6 +85,7 @@ declare interface IHistoryItem {
 declare interface IMountData {
   mount_type: string
   lock: boolean
+  modifiable: boolean
   slots: IWeaponSlotData[]
   extra: IWeaponSlotData[]
   bonus_effects: string[]

--- a/src/classes/mech/Mech.ts
+++ b/src/classes/mech/Mech.ts
@@ -147,6 +147,7 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
     )
 
     this.MechLoadoutController.UpdateLoadouts()
+    this.CheckLoadoutExtendedMounts();
   }
 
   // -- Passthroughs ------------------------------------------------------------------------------
@@ -965,6 +966,10 @@ class Mech implements IActor, IPortraitContainer, ISaveable, IFeatureController 
   // -- Loadouts ----------------------------------------------------------------------------------
   public get ActiveMounts(): Mount[] {
     return this.MechLoadoutController.ActiveLoadout.AllActiveMounts(this)
+  }
+
+  public CheckLoadoutExtendedMounts(): void {
+    this.MechLoadoutController.CheckExtendedMounts(Bonus.getUneval("mount_modification" , this.Parent))
   }
 
   // -- Mountable CORE Bonuses --------------------------------------------------------------------

--- a/src/classes/mech/components/loadout/MechLoadoutController.ts
+++ b/src/classes/mech/components/loadout/MechLoadoutController.ts
@@ -3,6 +3,7 @@ import Vue from 'vue'
 import { Mech } from '../../Mech'
 import { MechLoadout } from './MechLoadout'
 import { IMechLoadoutData } from './MechLoadout'
+import { Bonus } from '@/classes/components/feature/bonus/Bonus'
 
 interface IMechLoadoutSaveData {
   loadouts: IMechLoadoutData[]
@@ -47,6 +48,7 @@ class MechLoadoutController implements IFeatureContainer {
     this._loadouts.push(newLoadout)
     this.ActiveLoadout = newLoadout
     this.Parent.SaveController.save()
+    this.Parent.CheckLoadoutExtendedMounts()
   }
 
   public RemoveLoadout(): void {
@@ -77,6 +79,11 @@ class MechLoadoutController implements IFeatureContainer {
     this._loadouts.forEach(x => {
       x.SetAllIntegrated()
     })
+  }
+
+  public CheckExtendedMounts(b: Bonus[]): void{
+    this.ActiveLoadout.CheckExtendedMounts(b)
+    this.Loadouts.forEach(x => x.CheckExtendedMounts(b))
   }
 
   public static Serialize(parent: Mech, target: any) {

--- a/src/classes/mech/components/mount/EquippableMount.ts
+++ b/src/classes/mech/components/mount/EquippableMount.ts
@@ -22,6 +22,17 @@ class EquippableMount extends Mount {
     this.save()
   }
 
+  public LockModification(): void {
+    this.modifiable = false
+    this._bonuses = []
+    this.save()
+  }
+
+  public unlockModification(): void{
+    this.modifiable = true
+    this.save()
+  }
+
   public get LockTarget(): Mount | null {
     return this._lock_target
   }
@@ -74,6 +85,7 @@ class EquippableMount extends Mount {
       slots: m.slots.map(x => WeaponSlot.Serialize(x)),
       extra: m.extra.map(x => WeaponSlot.Serialize(x)),
       bonus_effects: m.Bonuses.map(x => x.ID),
+      modifiable: m.IsModifiable,
     }
   }
 
@@ -83,6 +95,7 @@ class EquippableMount extends Mount {
     m.extra = mountData.extra.map(x => WeaponSlot.Deserialize(x, m))
     m._bonuses = mountData.bonus_effects.map(x => CoreBonus.Deserialize(x))
     m.lock = mountData.lock
+    m.modifiable = mountData.modifiable
     m.getID()
     return m
   }

--- a/src/classes/mech/components/mount/Mount.ts
+++ b/src/classes/mech/components/mount/Mount.ts
@@ -10,12 +10,14 @@ abstract class Mount {
   protected slots: WeaponSlot[]
   protected extra: WeaponSlot[]
   protected _name_override: string
+  protected modifiable: boolean
 
   public constructor(mountType: MountType, parent: MechLoadout) {
     this._parent = parent
     this._id = uuid()
     this._mount_type = mountType
     this.lock = false
+    this.modifiable = true
     this.extra = []
     this._name_override = ''
     this.slots = []
@@ -132,6 +134,10 @@ abstract class Mount {
 
   public get IsLocked(): boolean {
     return this.lock
+  }
+
+  public get IsModifiable(): boolean {
+    return this.modifiable
   }
 }
 

--- a/src/classes/pilot/Pilot.ts
+++ b/src/classes/pilot/Pilot.ts
@@ -548,6 +548,14 @@ class Pilot
     this._state.ActiveMech = mech
   }
 
+  public UpdateMechMounts(addons: Bonus, add: boolean) {
+    this.Mechs.forEach(mech => {
+      mech.MechLoadoutController.Loadouts.forEach(loadout => {
+        loadout.ExtendedMountChanges(addons, add)
+      })
+    })
+  }
+
   // -- Active Mode -------------------------------------------------------------------------------
   public SpecialEval(val: number | string): number {
     if (typeof val === 'number') return val

--- a/src/classes/pilot/components/corebonus/CoreBonusController.ts
+++ b/src/classes/pilot/components/corebonus/CoreBonusController.ts
@@ -48,6 +48,9 @@ class CoreBonusController implements IFeatureContainer {
 
   public AddCoreBonus(coreBonus: CoreBonus): void {
     this._core_bonuses.push(coreBonus)
+    coreBonus.Bonuses.filter(x => x.ID === "mount_modification").forEach(
+      x => this.Parent.UpdateMechMounts(x, true)
+    )
     this.Parent.SaveController.save()
   }
 
@@ -85,6 +88,9 @@ class CoreBonusController implements IFeatureContainer {
         loadout.AllEquippableMounts(true).forEach(mount => {
           mount.RemoveCoreBonus(coreBonus)
         })
+        coreBonus.Bonuses.filter(x => x.ID === "mount_modification").forEach(bonus =>
+              loadout.ExtendedMountChanges(bonus, false)
+        )
       })
     })
   }

--- a/src/classes/pilot/components/reserves/ReservesController.ts
+++ b/src/classes/pilot/components/reserves/ReservesController.ts
@@ -37,11 +37,17 @@ class ReservesController implements IFeatureContainer {
 
   public AddReserve(reserve: Reserve): void {
     this._reserves.push(reserve)
+    reserve.Bonuses.filter(x => x.ID === "mount_modification").forEach(
+      x => this.Parent.UpdateMechMounts(x, true)
+    )
     this.Parent.SaveController.save()
   }
 
   public RemoveReserve(index: number): void {
-    this._reserves.splice(index, 1)
+    const removedReserve = this._reserves.splice(index, 1)[0]
+    removedReserve.Bonuses.filter(
+      x => x.ID === "mount_modification").forEach(
+      x => this.Parent.UpdateMechMounts(x, false))
     this.Parent.SaveController.save()
   }
 

--- a/src/classes/pilot/components/talent/PilotTalent.ts
+++ b/src/classes/pilot/components/talent/PilotTalent.ts
@@ -24,16 +24,16 @@ class PilotTalent {
     return allRanks
   }
 
-  public Increment(): boolean {
-    if (this.Talent.Ranks.length === this._rank) return false
+  public Increment(): TalentRank {
+    if (this.Talent.Ranks.length === this._rank) return null
     this._rank += 1
-    return true
+    return this.Talent.Ranks[this._rank-1]
   }
 
-  public Decrement(): boolean {
-    if (this._rank <= 1) return false
+  public Decrement(): TalentRank {
+    if (this._rank <= 0) return null
     this._rank -= 1
-    return false
+    return this.Talent.Ranks[this._rank]
   }
 
   public static Serialize(item: PilotTalent): IRankedData {

--- a/src/classes/pilot/components/talent/TalentsController.ts
+++ b/src/classes/pilot/components/talent/TalentsController.ts
@@ -68,9 +68,17 @@ class TalentsController implements IFeatureContainer {
   public AddTalent(talent: Talent): void {
     const index = this._talents.findIndex(x => x.Talent.ID === talent.ID)
     if (index === -1) {
-      this._talents.push(new PilotTalent(talent))
+      var currentTalent = new PilotTalent(talent)
+      currentTalent.UnlockedRanks.forEach(tal =>     
+        tal.Bonuses.filter(x => x.ID === "mount_modification").forEach(
+        x => this.Parent.UpdateMechMounts(x, true)
+      ))
+      this._talents.push(currentTalent)
     } else {
-      this._talents[index].Increment()
+      const addedTalentRank = this._talents[index].Increment()
+      addedTalentRank.Bonuses.filter(x => x.ID === "mount_modification").forEach(
+        x => this.Parent.UpdateMechMounts(x, true)
+      )
     }
     this.talentSort()
     this.updateIntegratedTalents()
@@ -83,8 +91,12 @@ class TalentsController implements IFeatureContainer {
       console.error(`Talent "${talent.Name}" does not exist on Pilot ${this.Parent.Callsign}`)
     } else {
       if (this._talents[index].Rank > 1) {
-        this._talents[index].Decrement()
+        const removedTalentRank = this._talents[index].Decrement()
+        removedTalentRank.Bonuses.filter(x => x.ID === "mount_modification").forEach(
+          x => this.Parent.UpdateMechMounts(x, false))
       } else {
+        this._talents[index].Talent.Ranks[0].Bonuses.filter(x => x.ID === "mount_modification").forEach(
+          x => this.Parent.UpdateMechMounts(x, false))
         this._talents.splice(index, 1)
       }
     }

--- a/src/ui/components/panels/loadout/mech_loadout/CCMechLoadout.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/CCMechLoadout.vue
@@ -22,7 +22,7 @@
 
         <mount-block
           v-if="mech.Pilot.has('CoreBonus', 'cb_integrated_weapon')"
-          int-weapon
+          notModifiable
           :readonly="readonly"
           :mount="mech.MechLoadoutController.ActiveLoadout.IntegratedWeaponMount"
           :mech="mech"
@@ -49,6 +49,25 @@
           superheavy
           :readonly="readonly"
           :mount="mech.MechLoadoutController.ActiveLoadout.SuperheavyMount"
+          :mech="mech"
+          :color="color"
+        />
+                
+        <mount-block 
+          v-for="(Em, Ek) in mech.MechLoadoutController.ActiveLoadout.ExtraMounts"
+          :key="`Em_${Ek}`"
+          :readonly="readonly"
+          :mount="Em"
+          :mech="mech"
+          :color="color"
+        />
+
+        <mount-block 
+          v-for="(Eim, Eik) in mech.MechLoadoutController.ActiveLoadout.ExtraIntegratedMounts"
+          :key="`Eim_${Eik}`"
+          :readonly="readonly"
+          integrated
+          :mount="Eim"
           :mech="mech"
           :color="color"
         />

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/_MountBlock.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/_MountBlock.vue
@@ -12,7 +12,7 @@
         </cc-tooltip>
       </legend>
       <cb-mount-menu
-        v-if="!intWeapon && !integrated && !readonly"
+        v-if="!integrated && !readonly && modifiable"
         :key="mech.AvailableBonuses.length"
         :mech="mech"
         :mount="mount"
@@ -28,7 +28,7 @@
             :mech="mech"
             :mount="mount"
             :readonly="integrated || readonly"
-            :int-weapon="intWeapon"
+            :modifiable="modifiable"
           />
         </v-col>
       </v-row>
@@ -63,9 +63,6 @@ export default Vue.extend({
     integrated: {
       type: Boolean,
     },
-    intWeapon: {
-      type: Boolean,
-    },
     impArm: {
       type: Boolean,
     },
@@ -74,6 +71,11 @@ export default Vue.extend({
     },
     readonly: {
       type: Boolean,
+    },
+  },
+  computed: {
+    modifiable() {
+      return this.mount.IsModifiable
     },
   },
 })

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSlotCard.vue
@@ -78,7 +78,7 @@
           :color="color"
           :use-bonus="mech.LimitedBonus"
         >
-          <div v-if="!intWeapon && !readonly" slot="left">
+          <div v-if="!readonly && modifiable" slot="left">
             <v-btn
               v-if="!item.Mod && !item.NoMods"
               outlined
@@ -209,7 +209,7 @@ export default Vue.extend({
     readonly: {
       type: Boolean,
     },
-    intWeapon: {
+    modifiable: {
       type: Boolean,
     },
   },


### PR DESCRIPTION
# Description

added some functionality for generalized mount bonuses (issue #1992 )

## Issue Number
`#1992

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

The new functionality allows any Reserve, Talent, or Core Bonus to add the following bonus details and it should add an appropriate mount to all available mechs on the pilot that received them:

"bonuses": [
      {
        "id": "mount_modification",
        "val": [
          "A",
          "B",
          "C",
          "D",
	  "E"
       	]
      }

where:
A- a MountType enum, the kind of mount that will be added (I.E whether it is a main mount, aux/aux, heavy, etc.) this much match the capitalization  and style of a mount type enum.
B- whether or not this is an integrated mount (true or false should be the only inputs, no capital letters)
C- whether or not this mount should be modifiable (true or false)
D- the number of mounts to check against (must be a number 0-3)
E- whether to check greater than or less than (true or false)

D and E work together to replicate the functionality of core bonuses like Improved Armament. if E is false, then it sees if the mech has greater than the number of mounts listed by D. if E is true, it checks if the mech has fewer than D mounts. This currently only checks the mounts listed in the regular loadout, and not any other extra mounts granted by base book core bonuses, or any granted by this bonus. if E is zero, then all mechs get the resulting mount.