### PR TITLE
Add support for email subaddresses (plus aliases)

### DIFF
--- a/src/features/main_menu/_components/login/SignUp.vue
+++ b/src/features/main_menu/_components/login/SignUp.vue
@@ -88,13 +88,13 @@ export default Vue.extend({
       required: value => !!value || 'Required.',
       min: v => v.length >= 6 || 'Min 6 characters',
       emailMatch: v =>
-        !v || /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,6})+$/.test(v) || 'E-mail must be valid',
+        !v || /^\w+([.-]?\w+)*(\+\w+([.-]?\w+)*)?@\w+([.-]?\w+)*(\.\w{2,6})+$/.test(v) || 'E-mail must be valid',
     },
   }),
   computed: {
     submitOk() {
       return (
-        /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,6})+$/.test(this.email) && this.password.length >= 6
+        /^\w+([.-]?\w+)*(\+\w+([.-]?\w+)*)?@\w+([.-]?\w+)*(\.\w{2,6})+$/.test(this.email) && this.password.length >= 6
       )
     },
     test() {


### PR DESCRIPTION
# Description

This PR updates the RegEx pattern used for emails to include support for subaddressing. This was added with [RFC5233](https://datatracker.ietf.org/doc/html/rfc5233).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
