### PR TITLE
NPC statblock with the ability descriptions

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -300,6 +300,26 @@ class Statblock {
     } else return '>> NO MECH SELECTED <<'
   }
 
+  // public static GenerateNPC(npc: Npc): string {
+  //   let output = `// ${npc.Name} //\n`
+  //   output += `${npc.Class.Name.toUpperCase()}`
+  //   if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`
+  //   output += typeof npc.Tier === 'number' ? `, Tier ${npc.Tier} ` : ', Custom '
+  //   output += `${npc.Tag}\n`
+  //   output += '[ STATS ]\n'
+  //   output += `  H: ${npc.Stats.Hull} | A: ${npc.Stats.Agility} | S: ${npc.Stats.Systems} | E: ${npc.Stats.Engineering}\n`
+  //   output += `  STRUCT: ${npc.CurrentStructure}/${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.CurrentHP}/${npc.Stats.HP}\n`
+  //   output += `  STRESS: ${npc.CurrentStress}/${npc.Stats.Stress} | HEATCAP: ${npc.CurrentHeat}/${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
+  //   output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
+  //   output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
+  //   output += '[ FEATURES ]\n  '
+  //   output += npc.Items.map(
+  //     (item, index) =>
+  //       `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
+  //   ).join('')
+  //   return output
+  // }
+
   public static GenerateNPC(npc: Npc): string {
     let output = `// ${npc.Name} //\n`
     output += `${npc.Class.Name.toUpperCase()}`
@@ -312,11 +332,11 @@ class Statblock {
     output += `  STRESS: ${npc.CurrentStress}/${npc.Stats.Stress} | HEATCAP: ${npc.CurrentHeat}/${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
     output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
     output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
-    output += '[ FEATURES ]\n  '
+    output += '[ FEATURES ]\n'
     output += npc.Items.map(
-      (item, index) =>
-        `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
-    ).join('')
+      (item) =>
+      `${item.Statblock}`
+    ).join('\n')
     return output
   }
 }

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -300,27 +300,7 @@ class Statblock {
     } else return '>> NO MECH SELECTED <<'
   }
 
-  // public static GenerateNPC(npc: Npc): string {
-  //   let output = `// ${npc.Name} //\n`
-  //   output += `${npc.Class.Name.toUpperCase()}`
-  //   if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`
-  //   output += typeof npc.Tier === 'number' ? `, Tier ${npc.Tier} ` : ', Custom '
-  //   output += `${npc.Tag}\n`
-  //   output += '[ STATS ]\n'
-  //   output += `  H: ${npc.Stats.Hull} | A: ${npc.Stats.Agility} | S: ${npc.Stats.Systems} | E: ${npc.Stats.Engineering}\n`
-  //   output += `  STRUCT: ${npc.CurrentStructure}/${npc.Stats.Structure} | ARMOR: ${npc.Stats.Armor} | HP: ${npc.CurrentHP}/${npc.Stats.HP}\n`
-  //   output += `  STRESS: ${npc.CurrentStress}/${npc.Stats.Stress} | HEATCAP: ${npc.CurrentHeat}/${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
-  //   output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
-  //   output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
-  //   output += '[ FEATURES ]\n  '
-  //   output += npc.Items.map(
-  //     (item, index) =>
-  //       `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
-  //   ).join('')
-  //   return output
-  // }
-
-  public static GenerateNPC(npc: Npc): string {
+  public static GenerateNPC(npc: Npc, genRadio: string): string {
     let output = `// ${npc.Name} //\n`
     output += `${npc.Class.Name.toUpperCase()}`
     if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`
@@ -333,10 +313,18 @@ class Statblock {
     output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
     output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
     output += '[ FEATURES ]\n'
-    output += npc.Items.map(
-      (item) =>
-      `${item.Statblock}`
-    ).join('\n')
+    if (genRadio == "compact"){
+      output += "  "
+      output += npc.Items.map(
+        (item, index) =>
+          `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
+      ).join('')
+    } else if (genRadio == "detailed"){
+      output += npc.Items.map(
+        (item) =>
+          `${item.Statblock}`
+      ).join('\n')
+    }
     return output
   }
 }

--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -300,7 +300,7 @@ class Statblock {
     } else return '>> NO MECH SELECTED <<'
   }
 
-  public static GenerateNPC(npc: Npc, genRadio: string): string {
+  public static GenerateNPC(npc: Npc, genRadio?: string): string {
     let output = `// ${npc.Name} //\n`
     output += `${npc.Class.Name.toUpperCase()}`
     if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -93,6 +93,8 @@ export abstract class NpcFeature {
     return this._override
   }
 
+  abstract generateSummary(tier: number): string
+
   public get Effect(): string {
     if (!this._effect) return ''
     const perTier = /(\{.*?\})/

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -106,7 +106,7 @@ export abstract class NpcFeature {
     return this._effect
   }
 
-  public EffectByTier(tier: number, htmltag: boolean = true): string {
+  public EffectByTier(tier: number): string {
     if (!this._effect) return ''
     let fmt = this._effect
     const perTier = /(\{.*?\})/g
@@ -114,12 +114,7 @@ export abstract class NpcFeature {
     if (m) {
       m.forEach(x => {
         const tArr = x.replace('{', '').replace('}', '').split('/')
-        if (htmltag) {
-          fmt = fmt.replace(x, `<b class="accent--text">${tArr[tier - 1]}</b>`)
-        }
-        else {
-          fmt = fmt.replace(x, `${tArr[tier - 1]}`)
-        }
+        fmt = fmt.replace(x, `<b class="accent--text">${tArr[tier - 1]}</b>`)
       })
     }
     return fmt

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -106,7 +106,7 @@ export abstract class NpcFeature {
     return this._effect
   }
 
-  public EffectByTier(tier: number): string {
+  public EffectByTier(tier: number, htmltag: boolean = true): string {
     if (!this._effect) return ''
     let fmt = this._effect
     const perTier = /(\{.*?\})/g
@@ -114,7 +114,12 @@ export abstract class NpcFeature {
     if (m) {
       m.forEach(x => {
         const tArr = x.replace('{', '').replace('}', '').split('/')
-        fmt = fmt.replace(x, `<b class="accent--text">${tArr[tier - 1]}</b>`)
+        if (htmltag) {
+          fmt = fmt.replace(x, `<b class="accent--text">${tArr[tier - 1]}</b>`)
+        }
+        else {
+          fmt = fmt.replace(x, `${tArr[tier - 1]}`)
+        }
       })
     }
     return fmt

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -132,10 +132,11 @@ export class NpcItem {
   private generateStatblock(): string {
     let output = '  '
     output += `${this.Name} (${'I'.repeat(this.Tier)})\n    `
-    output += `${this.Feature.Origin}: ${this.Feature.Name}\n    `
+    output += `${this.Feature.Origin}\n    `
     
-    if(this.Feature.ItemType=='NpcWeapon'){
-      output += `This is where weapon stat goes\n    `
+    if(this.Feature.ItemType=='NpcWeapon'||'NpcTech'){
+      output += `This is where weapon/tech stat goes\n    `
+      // output += `${this.Feature.Name}`
     }
 
     output += `${this.Feature.EffectByTier(this.Tier)}\n    `

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -139,7 +139,7 @@ export class NpcItem {
       // output += `${this.Feature.Name}`
     }
 
-    output += `${this.Feature.EffectByTier(this.Tier, false)}\n    `
+    output += `${this.Feature.EffectByTier(this.Tier)}\n    `
     return output
   }
 

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -140,6 +140,11 @@ export class NpcItem {
     }
 
     output += `${this.Feature.EffectByTier(this.Tier)}\n    `
+    
+    output = output.replaceAll('<b class="accent--text">','')
+    output = output.replaceAll('</b>','')
+    output = output.replaceAll('<br>','\n')
+    
     return output
   }
 

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -139,7 +139,7 @@ export class NpcItem {
       // output += `${this.Feature.Name}`
     }
 
-    output += `${this.Feature.EffectByTier(this.Tier)}\n    `
+    output += `${this.Feature.EffectByTier(this.Tier, false)}\n    `
     return output
   }
 

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -133,15 +133,7 @@ export class NpcItem {
     let output = '  '
     output += `${this.Name} (${'I'.repeat(this.Tier)})\n    `
     output += `${this.Feature.Origin}\n    `
-    
-    if(this.Feature.ItemType=='NpcWeapon'){
-      let weapon: NpcWeapon = this.Feature as NpcWeapon
-      output += weapon.generateSummary(this.Tier)
-    }
-
-    if(this.Feature.EffectByTier(this.Tier)){
-      output += `${this.Feature.EffectByTier(this.Tier)}\n    `
-  }
+    output += `${this.Feature.generateSummary(this.Tier)}\n`
     
     output = output.replaceAll('<b class="accent--text">','')
     output = output.replaceAll('</b>','')

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -137,7 +137,7 @@ export class NpcItem {
     
     output = output.replaceAll('<b class="accent--text">','')
     output = output.replaceAll('</b>','')
-    output = output.replaceAll('<br>','\n')
+    output = output.replaceAll('<br>','\n    ')
     
     return output
   }

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -24,6 +24,7 @@ export class NpcItem {
   private _charged: boolean
   private _uses: number
   private _max_uses: number
+  private _statblock: string
 
   public constructor(feature: NpcFeature, tier: number, parent: Npc) {
     this.Parent = parent
@@ -33,6 +34,7 @@ export class NpcItem {
     this._destroyed = false
     this._charged = true
     this._uses = 0
+    this._statblock = this.generateStatblock()
     const f = feature as any
     if (f.IsLimited) {
       const ltd = f.Tags.find(x => x.IsLimited)
@@ -125,6 +127,28 @@ export class NpcItem {
     this.Destroyed = false
     this.IsCharged = true
     this.Uses = 0
+  }
+
+  private generateStatblock(): string {
+    let output = '  '
+    output += `${this.Name} (${'I'.repeat(this.Tier)})\n    `
+    output += `${this.Feature.Origin}: ${this.Feature.Name}\n    `
+    
+    if(this.Feature.ItemType=='NpcWeapon'){
+      output += `This is where weapon stat goes\n    `
+    }
+
+    output += `${this.Feature.EffectByTier(this.Tier)}\n    `
+    return output
+  }
+
+  public get Statblock(): string {
+    return this._statblock
+  }
+
+  public set Statblock(val: string) {
+    this._statblock = val
+    this.save()
   }
 
   public static Serialize(item: NpcItem): INpcItemSaveData {

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -1,6 +1,6 @@
 // Wrapper class for items assigned to an NPC
 
-import { NpcFeature } from './'
+import { NpcFeature, NpcWeapon } from './'
 import { store } from '@/store'
 import { Npc } from './Npc'
 
@@ -134,12 +134,14 @@ export class NpcItem {
     output += `${this.Name} (${'I'.repeat(this.Tier)})\n    `
     output += `${this.Feature.Origin}\n    `
     
-    if(this.Feature.ItemType=='NpcWeapon'||'NpcTech'){
-      output += `This is where weapon/tech stat goes\n    `
-      // output += `${this.Feature.Name}`
+    if(this.Feature.ItemType=='NpcWeapon'){
+      let weapon: NpcWeapon = this.Feature as NpcWeapon
+      output += weapon.generateSummary(this.Tier)
     }
 
-    output += `${this.Feature.EffectByTier(this.Tier)}\n    `
+    if(this.Feature.EffectByTier(this.Tier)){
+      output += `${this.Feature.EffectByTier(this.Tier)}\n    `
+  }
     
     output = output.replaceAll('<b class="accent--text">','')
     output = output.replaceAll('</b>','')

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -1,6 +1,6 @@
 // Wrapper class for items assigned to an NPC
 
-import { NpcFeature, NpcWeapon } from './'
+import { NpcFeature } from './'
 import { store } from '@/store'
 import { Npc } from './Npc'
 

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -20,7 +20,6 @@ export class NpcReaction extends NpcFeature {
   }
 
   public generateSummary(tier: number): string {
-    console.log(this)
     let output: string = ''
     if(this.Tags.length){
       output += this.Tags.map(

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -20,8 +20,20 @@ export class NpcReaction extends NpcFeature {
   }
 
   public generateSummary(tier: number): string {
+    console.log(this)
     let output: string = ''
-    output += `Reaction summary goes here`
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+
+    output += `Trigger: ${this.Trigger}\n    `
+
+
+    output += `Effect: ${this.EffectByTier(tier)}`
     return output
   }
 

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -19,6 +19,12 @@ export class NpcReaction extends NpcFeature {
     return this._trigger
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    output += `Reaction summary goes here`
+    return output
+  }
+
   public get Color(): string {
     return 'npc--reaction'
   }

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -23,6 +23,12 @@ export class NpcSystem extends NpcFeature {
     return this.Tags.find(x => x.IsRecharging).Value.toString()
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    output += `System summary goes here`
+    return output
+  }
+
   public get Color(): string {
     return 'npc--system'
   }

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -25,7 +25,16 @@ export class NpcSystem extends NpcFeature {
 
   public generateSummary(tier: number): string {
     let output: string = ''
-    output += `System summary goes here`
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+    if(this.EffectByTier(tier)){
+      output += `${this.EffectByTier(tier)}`
+    }
     return output
   }
 

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -47,7 +47,6 @@ export class NpcTech extends NpcFeature {
   }
 
   public generateSummary(tier: number): string {
-    console.log(this)
     let output: string = ''
     if(this.Tags.length){
       output += this.Tags.map(

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -47,8 +47,31 @@ export class NpcTech extends NpcFeature {
   }
 
   public generateSummary(tier: number): string {
+    console.log(this)
     let output: string = ''
-    output += `Tech summary goes here`
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+
+    output += 'Attack Bonus: '
+    if(this.AttackBonus(tier)<0) {
+      output += this.AttackBonus(tier)
+    } else {
+      output += `+${this.AttackBonus(tier)}`
+    }
+    if(this.Accuracy(tier)<0) {
+      output += `, ${this.Accuracy(tier)} DIF`
+    } else if(this.Accuracy(tier)>0) {
+      output += `, ${this.Accuracy(tier)} ACC`
+    }
+
+    if(this.EffectByTier(tier)){
+      output += `\n    ${this.EffectByTier(tier)}`
+    }
     return output
   }
 

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -46,6 +46,12 @@ export class NpcTech extends NpcFeature {
     return this._attack_bonus[tier - 1]
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    output += `Tech summary goes here`
+    return output
+  }
+
   public get Color(): string {
     return 'npc--tech'
   }

--- a/src/classes/npc/NpcTrait.ts
+++ b/src/classes/npc/NpcTrait.ts
@@ -9,7 +9,16 @@ export class NpcTrait extends NpcFeature {
 
   public generateSummary(tier: number): string {
     let output: string = ''
-    output += `Trait summary goes here`
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+    if(this.EffectByTier(tier)){
+      output += `${this.EffectByTier(tier)}`
+    }
     return output
   }
 

--- a/src/classes/npc/NpcTrait.ts
+++ b/src/classes/npc/NpcTrait.ts
@@ -7,6 +7,12 @@ export class NpcTrait extends NpcFeature {
     this.type = NpcFeatureType.Trait
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    output += `Trait summary goes here`
+    return output
+  }
+
   public get Color(): string {
     return 'npc--trait'
   }

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -104,7 +104,7 @@ export class NpcWeapon extends NpcFeature {
         `${item.Value} ${item.Type}`
     ).join(' ')
 
-    output += '| Attack Bonus: '
+    output += ' | Attack Bonus: '
     if(this.AttackBonus(tier)<0) {
       output += this.AttackBonus(tier)
     } else {

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -81,6 +81,39 @@ export class NpcWeapon extends NpcFeature {
     return this._attack_bonus[tier - 1]
   }
 
+  public generateSummary(tier: number): string {
+    let output = ''
+    output += `${this.WeaponType}\n    `
+    this.Range.forEach(
+      item => {
+        output += `${item.Type} ${item.Value} `
+        console.log(`${item.Type} ${item.Value} `)
+      }
+    )
+    output += '| '
+    this.Damage(tier).forEach(
+      item => {
+        output += `${item.Value} ${item.Type} `
+        console.log(`${item.Value} ${item.Type} `)
+      }
+    )
+
+    output += '| Attack Bonus: '
+    if(this.AttackBonus(tier)<0) {
+      output += this.AttackBonus(tier)
+    } else {
+      output += `+${this.AttackBonus(tier)}`
+    }
+    if(this.Accuracy(tier)<0) {
+      output += `, ${this.Accuracy(tier)} DIF`
+    } else if(this.Accuracy(tier)>0) {
+      output += `, ${this.Accuracy(tier)} ACC`
+    }
+    output+='\n'
+    
+    return output
+  }
+
   public get Color(): string {
     return 'npc--weapon'
   }

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -84,19 +84,25 @@ export class NpcWeapon extends NpcFeature {
   public generateSummary(tier: number): string {
     let output = ''
     output += `${this.WeaponType}\n    `
-    this.Range.forEach(
-      item => {
-        output += `${item.Type} ${item.Value} `
-        console.log(`${item.Type} ${item.Value} `)
-      }
-    )
+    
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+
+    output += this.Range.map(
+      (item) =>
+        `${item.Type} ${item.Value} `
+    ).join(' ')
+
     output += '| '
-    this.Damage(tier).forEach(
-      item => {
-        output += `${item.Value} ${item.Type} `
-        console.log(`${item.Value} ${item.Type} `)
-      }
-    )
+    output += this.Damage(tier).map(
+      (item) =>
+        `${item.Value} ${item.Type}`
+    ).join(' ')
 
     output += '| Attack Bonus: '
     if(this.AttackBonus(tier)<0) {
@@ -109,8 +115,13 @@ export class NpcWeapon extends NpcFeature {
     } else if(this.Accuracy(tier)>0) {
       output += `, ${this.Accuracy(tier)} ACC`
     }
-    output+='\n'
-    
+    if(this.OnHit) {
+      output += `\n    On Hit: ${this.OnHit}`
+    }
+    if(this.EffectByTier(tier)){
+      output += `\n    ${this.EffectByTier(tier)}`
+    }
+
     return output
   }
 

--- a/src/features/encounters/mission/runner/components/EncounterNav.vue
+++ b/src/features/encounters/mission/runner/components/EncounterNav.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
       this.close()
     },
     statBlock() {
-      return Statblock.GenerateNPC(this.statBlockNpc)
+      return Statblock.GenerateNPC(this.statBlockNpc,"compact")
     },
     copyStatBlock() {
       navigator.clipboard

--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -170,8 +170,8 @@
           <v-dialog v-model="statblockDialog" width="50%">
             <cc-titled-panel title="NPC Statblock">
               <v-radio-group v-model="genRadios" row mandatory label="Generate:">
-                <v-radio label="Basic" value="basic"></v-radio>
-                <v-radio label="Full" value="full"></v-radio>
+                <v-radio label="Compact" value="compact"></v-radio>
+                <v-radio label="Detailed" value="detailed"></v-radio>
               </v-radio-group>
               <v-textarea
                 v-if="statblockNpc"
@@ -231,7 +231,7 @@ export default class NpcManager extends Vue {
   npcImportFile: File = null
   importNpc: Npc = null
   statblockNpc = null
-  genRadios = 'basic'
+  genRadios = 'compact'
 
   @Watch('selectedNpc')
   onSelectedNpcChanged() {

--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -251,7 +251,7 @@ export default class NpcManager extends Vue {
   }
 
   statblock() {
-    return Statblock.GenerateNPC(this.statblockNpc)
+    return Statblock.GenerateNPC(this.statblockNpc,this.genRadios)
   }
 
   copyStatBlock() {

--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -169,6 +169,10 @@
           </v-dialog>
           <v-dialog v-model="statblockDialog" width="50%">
             <cc-titled-panel title="NPC Statblock">
+              <v-radio-group v-model="genRadios" row mandatory label="Generate:">
+                <v-radio label="Basic" value="basic"></v-radio>
+                <v-radio label="Full" value="full"></v-radio>
+              </v-radio-group>
               <v-textarea
                 v-if="statblockNpc"
                 :value="statblock()"
@@ -227,6 +231,7 @@ export default class NpcManager extends Vue {
   npcImportFile: File = null
   importNpc: Npc = null
   statblockNpc = null
+  genRadios = 'basic'
 
   @Watch('selectedNpc')
   onSelectedNpcChanged() {


### PR DESCRIPTION
# Description
This adds two options when generating NPC statblock: ``compact`` and ``detailed``.
Compact mode is the exact same as the existing functionality, and is the default option.
Detailed mode is the new feature, providing description of each feature.

This feature can be accessed by
1. Go to Encounter Toolkit>NPC Roster
2. Click the gear icon next to NPC name. Select Generate NPC Statblock.
3. Right above the textbox, there are two radio buttons labeled Compact and Detailed. Select desired option.

## Potential uses
- Provide Scan results quickly
- Save time spent on checking rulebook
- Stepping stone for [Issue 535: Print Improvements](https://github.com/massif-press/compcon/issues/535#issue-557051707)

## Type of change
- [ ] New feature (non-breaking change which adds functionality.

## Credit
@ApprenticeofEnder for providing guidance on implementing polymorphic method for subclasses of ``NPCFeature``.