### PR TITLE
feat: add detailed NPC statblock option

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -300,7 +300,7 @@ class Statblock {
     } else return '>> NO MECH SELECTED <<'
   }
 
-  public static GenerateNPC(npc: Npc): string {
+  public static GenerateNPC(npc: Npc, genRadio: string="compact"): string {
     let output = `// ${npc.Name} //\n`
     output += `${npc.Class.Name.toUpperCase()}`
     if (npc.Templates) output += ` ${npc.Templates.map(t => t.Name).join(' ')}`
@@ -312,11 +312,20 @@ class Statblock {
     output += `  STRESS: ${npc.CurrentStress}/${npc.Stats.Stress} | HEATCAP: ${npc.CurrentHeat}/${npc.Stats.HeatCapacity} | SPD: ${npc.Stats.Speed}\n`
     output += `  SAVE: ${npc.Stats.Save} | EVADE: ${npc.Stats.Evade} | EDEF: ${npc.Stats.EDefense}\n`
     output += `  SENS: ${npc.Stats.Sensor} | SIZE: ${npc.Stats.Size} | ACT: ${npc.Stats.Activations}\n`
-    output += '[ FEATURES ]\n  '
-    output += npc.Items.map(
-      (item, index) =>
-        `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
-    ).join('')
+    output += '[ FEATURES ]\n'
+    if (genRadio == "detailed"){
+      output += npc.Items.map(
+        (item) =>
+          `${item.generateStatblock()}`
+      ).join('\n')
+    }
+    if (genRadio == "compact"){
+      output += "  "
+      output += npc.Items.map(
+        (item, index) =>
+          `${item.Name} (${'I'.repeat(item.Tier)})${linebreak(index, npc.Items.length)}`
+      ).join('')
+    }
     return output
   }
 }

--- a/src/classes/npc/NpcFeature.ts
+++ b/src/classes/npc/NpcFeature.ts
@@ -93,6 +93,8 @@ export abstract class NpcFeature {
     return this._override
   }
 
+  abstract generateSummary(tier: number): string
+
   public get Effect(): string {
     if (!this._effect) return ''
     const perTier = /(\{.*?\})/

--- a/src/classes/npc/NpcItem.ts
+++ b/src/classes/npc/NpcItem.ts
@@ -127,6 +127,18 @@ export class NpcItem {
     this.Uses = 0
   }
 
+  public generateStatblock(): string {
+    let output = '  '
+    output += `${this.Name} (${'I'.repeat(this.Tier)})\n    `
+    output += `${this.Feature.Origin}\n    `
+    output += `${this.Feature.generateSummary(this.Tier)}\n`
+
+    output = output.replaceAll('<b class="accent--text">','')
+    output = output.replaceAll('</b>','')
+    output = output.replaceAll('<br>','\n    ')
+    return output
+  }
+
   public static Serialize(item: NpcItem): INpcItemSaveData {
     return {
       itemID: item._feature.ID,

--- a/src/classes/npc/NpcReaction.ts
+++ b/src/classes/npc/NpcReaction.ts
@@ -19,6 +19,21 @@ export class NpcReaction extends NpcFeature {
     return this._trigger
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+    
+    output += `Trigger: ${this.Trigger}\n    `
+    output += `Effect: ${this.EffectByTier(tier)}`
+    return output
+  }
+
   public get Color(): string {
     return 'npc--reaction'
   }

--- a/src/classes/npc/NpcSystem.ts
+++ b/src/classes/npc/NpcSystem.ts
@@ -23,6 +23,22 @@ export class NpcSystem extends NpcFeature {
     return this.Tags.find(x => x.IsRecharging).Value.toString()
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+    
+    if(this.EffectByTier(tier)){
+      output += `${this.EffectByTier(tier)}`
+    }
+    return output
+  }
+  
   public get Color(): string {
     return 'npc--system'
   }

--- a/src/classes/npc/NpcTech.ts
+++ b/src/classes/npc/NpcTech.ts
@@ -46,6 +46,35 @@ export class NpcTech extends NpcFeature {
     return this._attack_bonus[tier - 1]
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+
+    output += 'Attack Bonus: '
+    if(this.AttackBonus(tier)<0) {
+      output += `${this.AttackBonus(tier)}`
+    } else {
+      output += `+${this.AttackBonus(tier)}`
+    }
+    output += ', '
+    if(this.Accuracy(tier)<0) {
+      output += `${this.Accuracy(tier)} DIF`
+    } else if(this.Accuracy(tier)>0) {
+      output += `${this.Accuracy(tier)} ACC`
+    }
+
+    if(this.EffectByTier(tier)){
+      output += `\n    ${this.EffectByTier(tier)}`
+    }
+    return output
+  }
+  
   public get Color(): string {
     return 'npc--tech'
   }

--- a/src/classes/npc/NpcTrait.ts
+++ b/src/classes/npc/NpcTrait.ts
@@ -7,6 +7,22 @@ export class NpcTrait extends NpcFeature {
     this.type = NpcFeatureType.Trait
   }
 
+  public generateSummary(tier: number): string {
+    let output: string = ''
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+    
+    if(this.EffectByTier(tier)){
+      output += `${this.EffectByTier(tier)}`
+    }
+    return output
+  }
+  
   public get Color(): string {
     return 'npc--trait'
   }

--- a/src/classes/npc/NpcWeapon.ts
+++ b/src/classes/npc/NpcWeapon.ts
@@ -81,6 +81,49 @@ export class NpcWeapon extends NpcFeature {
     return this._attack_bonus[tier - 1]
   }
 
+  public generateSummary(tier: number): string {
+    let output = ''
+    output += `${this.WeaponType}\n    `
+
+    if(this.Tags.length){
+      output += this.Tags.map(
+        (item) => 
+          `${item.GetName()}`
+      ).join(', ')
+      output += '\n    '
+    }
+
+    output += this.Range.map(
+      (item) =>
+        `${item.Type} ${item.Value} `
+    ).join(' ')
+    output += '| '
+    output += this.Damage(tier).map(
+      (item) =>
+        `${item.Value} ${item.Type}`
+    ).join(' ')
+    output += ' | Attack Bonus: '
+    if(this.AttackBonus(tier)<0) {
+      output += `${this.AttackBonus(tier)}`
+    } else {
+      output += `+${this.AttackBonus(tier)}`
+    }
+    output += ', '
+    if(this.Accuracy(tier)<0) {
+      output += `${this.Accuracy(tier)} DIF`
+    } else if(this.Accuracy(tier)>0) {
+      output += `${this.Accuracy(tier)} ACC`
+    }
+
+    if(this.OnHit) {
+      output += `\n    On Hit: ${this.OnHit}`
+    }
+    if(this.EffectByTier(tier)){
+      output += `\n    ${this.EffectByTier(tier)}`
+    }
+    return output
+  }
+  
   public get Color(): string {
     return 'npc--weapon'
   }

--- a/src/features/encounters/npc/index.vue
+++ b/src/features/encounters/npc/index.vue
@@ -169,6 +169,10 @@
           </v-dialog>
           <v-dialog v-model="statblockDialog" width="50%">
             <cc-titled-panel title="NPC Statblock">
+              <v-radio-group v-model="genRadios" row mandatory label="Generate:">
+                <v-radio label="Compact" value="compact"></v-radio>
+                <v-radio label="Detailed" value="detailed"></v-radio>
+              </v-radio-group>
               <v-textarea
                 v-if="statblockNpc"
                 :value="statblock()"
@@ -227,6 +231,7 @@ export default class NpcManager extends Vue {
   npcImportFile: File = null
   importNpc: Npc = null
   statblockNpc = null
+  genRadios = 'compact'
 
   @Watch('selectedNpc')
   onSelectedNpcChanged() {
@@ -246,7 +251,7 @@ export default class NpcManager extends Vue {
   }
 
   statblock() {
-    return Statblock.GenerateNPC(this.statblockNpc)
+    return Statblock.GenerateNPC(this.statblockNpc, this.genRadios)
   }
 
   copyStatBlock() {


### PR DESCRIPTION
# Description
This adds two options when generating NPC statblock: ``compact`` and ``detailed``.
Compact mode is the exact same as the existing functionality, and is the default option.
Detailed mode is the new feature, providing description of each feature.

This feature can be accessed by
1. Go to Encounter Toolkit>NPC Roster
2. Click the gear icon next to NPC name. Select Generate NPC Statblock.
3. Right above the textbox, there are two radio buttons labeled Compact and Detailed. Select desired option.

## Potential uses
- Provide Scan results quickly
- Save time spent on checking rulebook
- Stepping stone for [Issue 535: Print Improvements](https://github.com/massif-press/compcon/issues/535#issue-557051707)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## Credit
@ApprenticeofEnder for providing guidance on implementing polymorphic method for subclasses of ``NPCFeature``.