### PR TITLE
fix #2347 optional effect-field to pilot equipment

### DIFF
--- a/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
+++ b/src/classes/pilot/components/Loadout/equipment/PilotEquipment.ts
@@ -5,6 +5,7 @@ import { ICompendiumItemData, ITagCompendiumData } from '@/interface'
 interface IPilotEquipmentData extends ICompendiumItemData {
   type?: string
   tags: ITagData[]
+  effect?: string
 }
 
 abstract class PilotEquipment extends CompendiumItem {
@@ -35,6 +36,7 @@ abstract class PilotEquipment extends CompendiumItem {
     packName?: string
   ) {
     super(data, packTags, packName)
+    this.Effect = data.effect || ''
     this._used = false
     this._destroyed = false
     this._cascading = false

--- a/src/classes/pilot/components/Loadout/equipment/PilotWeapon.ts
+++ b/src/classes/pilot/components/Loadout/equipment/PilotWeapon.ts
@@ -4,19 +4,16 @@ import { IPilotEquipmentData, IRangeData, IDamageData, ITagCompendiumData } from
 interface IPilotWeaponData extends IPilotEquipmentData {
   range: IRangeData[]
   damage: IDamageData[]
-  effect?: string
 }
 
 class PilotWeapon extends PilotEquipment {
   public readonly Range: Range[]
   public readonly Damage: Damage[]
-  public readonly Effect: string
 
   public constructor(data: IPilotWeaponData, packTags?: ITagCompendiumData[], packName?: string) {
     super(data, packTags, packName)
     this.Range = data.range.map(x => new Range(x))
     this.Damage = data.damage.map(x => new Damage(x))
-    this.Effect = data.effect || ''
     this.ItemType = ItemType.PilotWeapon
   }
 


### PR DESCRIPTION
# Description

moved the effect data higher up from weapon level to pilot equipment level bc the effect field is used/needed in all: armor, gear and weapons
now all those pilot equipments can render an effect field if the data provides it (should therefore be backwards compatible)
`[
  {
    "id": "effected_gear",
    "name": "Test Reserve",
    "type": "Gear",
    "effect": "nananana",
    ...
  }
]`

gear
![image](https://github.com/massif-press/compcon/assets/108127897/68174ccc-1271-48b4-9ac8-4c6d07dcc7c2)

weapon
![image](https://github.com/massif-press/compcon/assets/108127897/1190c5a8-f35e-4d8a-b320-f54e4f724e8d)

armor
![image](https://github.com/massif-press/compcon/assets/108127897/5ae5dac2-379c-454b-ae7e-7d312e56bf81)

## Issue Number
`#2347`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (old lcps can be updated see issue #2347 and new can use the field in all equipment)
