### PR TITLE
Fix mission runner page refresh race condition.

### DIFF
--- a/src/features/encounters/mission/runner/Active.vue
+++ b/src/features/encounters/mission/runner/Active.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid style="margin-top: 40px; overflow-y: hidden" class="pb-0">
+  <v-container v-if="activeMission" fluid style="margin-top: 40px; overflow-y: hidden" class="pb-0">
     <div class="overline my-n2">
       <b>{{ mission.Name }}</b>
       //{{ activeMission.Step.toString().padStart(2, '0') }}:{{
@@ -17,6 +17,11 @@
       :rest="activeMission.Encounter"
       @finish="next()"
     />
+  </v-container>
+  <v-container v-else-if="activeMissionCount > 0" fluid style="margin-top: 40px; overflow-y: hidden" class="pb-0">
+    <div class="overline my-nw">
+      Loading failed.  Please retry.
+    </div>
   </v-container>
 </template>
 
@@ -40,6 +45,11 @@ export default Vue.extend({
     activeMission() {
       const store = getModule(MissionStore, this.$store)
       return store.ActiveMissions.find(x => x.ID === this.id)
+    },
+    activeMissionCount() {
+      const store = getModule(MissionStore, this.$store)
+      console.log(store.ActiveMissions.length)
+      return store.ActiveMissions.length
     },
     mission() {
       return this.activeMission.Mission


### PR DESCRIPTION
# Description

The Vue container in Active.vue was trying to use the MissionStore before it fully loaded, resulting in it being undefined.  This adds a condition on the container to see if there is an active mission that is truthy and displays the content if it is.

If there are active missions in the store, but there are none found (e.g. the UUID for the active mission is invalid in the route path), then it will display an error message.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue Number

unknown if any

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
