### PR TITLE
[A11Y] Prevent screen readers from reading decorative images in GM Log

### DIFF
--- a/src/features/encounters/components/GMLog.vue
+++ b/src/features/encounters/components/GMLog.vue
@@ -4,7 +4,7 @@
       <v-col cols="auto" class="mr-2">
         <div class="sidebar" />
         <div>
-          <img src="../../../assets/ui/sb_l.png" />
+          <img src="../../../assets/ui/sb_l.png" alt="" />
         </div>
       </v-col>
       <v-col>
@@ -22,7 +22,7 @@
       <v-col cols="auto" class="ml-2">
         <div class="sidebar" />
         <div>
-          <img class="ml-n2" src="../../../assets/ui/sb_r.png" />
+          <img class="ml-n2" src="../../../assets/ui/sb_r.png" alt="" />
         </div>
       </v-col>
     </v-row>

--- a/src/features/main_menu/_components/CCLog.vue
+++ b/src/features/main_menu/_components/CCLog.vue
@@ -5,7 +5,7 @@
         <!-- <v-divider vertical /> -->
         <div class="sidebar" />
         <div>
-          <img src="../../../assets/ui/sb_l.png" />
+          <img src="../../../assets/ui/sb_l.png" alt="" />
         </div>
       </v-col>
       <v-col>
@@ -20,7 +20,7 @@
       <v-col cols="auto" class="ml-2">
         <div class="sidebar" />
         <div>
-          <img class="ml-n2" src="../../../assets/ui/sb_r.png" />
+          <img class="ml-n2" src="../../../assets/ui/sb_r.png" alt="" />
         </div>
       </v-col>
     </v-row>
@@ -111,7 +111,7 @@ export default Vue.extend({
         case 'ha':
           HaStart(this.typer)
         case 'galsim':
-          GalsimStart(this.typer) 
+          GalsimStart(this.typer)
         default:
           GmsStart(this.typer)
           break


### PR DESCRIPTION
# Description

Adds null alt text to the left and right images in the GM log to prevent screen readers from reading the source file name. This can be a bewildering experience for unsighted gamers. It's a violation of WCAG 1.1.1 and Section 508 1194.22.

For a detailed summary of the issue and solution, see [this page from Deque University on the subject of alt text requirements](https://dequeuniversity.com/rules/axe/4.9/image-alt).

## Issue Number
`#N/A`

This is low-hanging accessibility fruit-- I'll make some issues for more challenging problems.

## Type of change
Bug fix (non-breaking change which fixes an issue)
