### PR TITLE
Don't override ra-quiet color to white on all themes

### DIFF
--- a/src/ui/style/typography.css
+++ b/src/ui/style/typography.css
@@ -186,7 +186,6 @@
 }
 
 .ra-quiet {
-  color: #eeeeee;
   font-family: 'Consolas', monospace;
   font-size: 12pt;
   font-weight: bolder;


### PR DESCRIPTION
It's being set to #EEE for no good reason. That's not correct. This just removes that so it inherits the correct text color from the theme's settings.

Yay for single line PRs.
