### PR TITLE
add GMS Dark theme

### DIFF
--- a/src/ui/style/themes/index.ts
+++ b/src/ui/style/themes/index.ts
@@ -1,4 +1,5 @@
 import gms from './theme_gms'
+import gmsdark from './theme_gms_dark'
 import horus from './theme_horus'
 import msmc from './theme_msmc'
 import ssc from './theme_ssc'
@@ -6,4 +7,4 @@ import ipsn from './theme_ipsn'
 import ha from './theme_ha'
 import galsim from './theme_galsim'
 
-export default { gms, horus, ssc, ipsn, ha, msmc, galsim }
+export default { gms, gmsdark, horus, ssc, ipsn, ha, msmc, galsim }

--- a/src/ui/style/themes/theme_gms_dark.ts
+++ b/src/ui/style/themes/theme_gms_dark.ts
@@ -1,0 +1,44 @@
+import themeDefaults from './common'
+
+const theme = {
+  type: 'dark',
+  id: 'gmsdark',
+  name: 'GMS Red (Dark)',
+  colors: {
+    ...themeDefaults,
+    primary: '#991E2A',
+    exotic: '#673AB7',
+    active: '#d93f4e',
+    accent: '#8c1420',
+    secondary: '#283593',
+    pilot: '#424242',
+    error: '#F44336',
+    info: '#1565C0',
+    success: '#00C853',
+    warning: '#FFAB00',
+
+    weapon: '#e2e2e2',
+    'mech-weapon': '#e2e2e2',
+    'pilot-weapon': '#e2e2e2',
+
+    text: '#c1c1c1',
+    subtle: '#c1c1c1',
+    stark: '#991E2A',
+    anti: '#fff',
+    'light-text': '#b5b5b5',
+    'stark-text': '#991E2A',
+
+    background: '#151515',
+    panel: '#151515',
+    tooltip: '#151515',
+    'light-panel': '#575757',
+    'dark-panel': '#151515',
+    'panel-border': '#310000',
+    'stark-panel': '#151515',
+
+    'action--downtime': '#37474F',
+    'reserve--organization': '#455A64',
+    'action--reaction': '#512DA8',
+  },
+}
+export default theme


### PR DESCRIPTION
# Description

This pull request adds a modified version of the default GMS Red theme that renders a dark mode version. It uses darker backgrounds and lighter text, but maintains the red primary theming. I used this because it's easier on my eyes but maintains the general aesthetics of the default theme, rather than altering for the solarized appearance.

## Issue Number
There is no associated Issue Number.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

This is a new theme.

## Screenshots

<img width="1920" alt="firefox_XAyrBqUq2l" src="https://github.com/user-attachments/assets/e1767ae9-64e4-4069-9544-1ff6f9fc6b5f" />
<img width="1920" alt="firefox_Y84twRT4vS" src="https://github.com/user-attachments/assets/df8921bf-201a-4575-9dd4-bec4fc0be5ed" />
<img width="1920" alt="firefox_h8AsLNk0cj" src="https://github.com/user-attachments/assets/ddc0a422-b365-4de0-9003-8b394ff844d7" />