### PR TITLE
Replaces Text With Icons When Printing

### DIFF
--- a/src/features/pilot_management/Print/MechPrint.vue
+++ b/src/features/pilot_management/Print/MechPrint.vue
@@ -1,6 +1,10 @@
+<script lang="ts">
+</script>
+
 <template>
   <v-container fluid>
-    <v-row dense align="top">
+    <fieldset>
+    <v-row dense align="top" class="mt-1">
       <v-col cols="auto">
         <div class="overline my-n2 grey--text">{{ mech.Frame.Source }} {{ mech.Frame.Name }}</div>
         <div class="heading h2 mt-n4 font-weight-bolder">{{ mech.Name }}</div>
@@ -26,7 +30,7 @@
       </v-col>
     </v-row>
 
-    <v-row dense align="center" justify="space-around" class="mt-n5 mb-1">
+    <v-row dense align="center" justify="space-around" class="mt-n5 mb-2">
       <v-col cols="auto">
         <span class="font-weight-bold overline pr-3">HULL</span>
         <div class="ml-4 mt-n3" style="position: relative; width: max-content">
@@ -184,12 +188,12 @@
       </v-col>
     </v-row>
 
-    <div class="overline mb-n2">FRAME TRAITS</div>
-    <v-row dense justify="space-between" class="caption mt-n1">
+    <div class="overline mt-2 mb-0">FRAME TRAITS</div>
+    <v-row dense justify="space-between" class="caption mt-n1 mb-2">
       <v-col v-for="(t, i) in mech.Frame.Traits" :key="`mt_${i}`" class="mt-n1">
         <fieldset>
           <legend class="heading ml-1 px-2">{{ t.Name }}</legend>
-          <p v-html-safe="t.Description" class="ml-6 mb-0" />
+          <p v-html-safe="t.Description" class="ml-6 mb-2" />
         </fieldset>
       </v-col>
     </v-row>
@@ -223,7 +227,7 @@
       </div>
     </fieldset>
 
-    <v-row dense class="mb-n3">
+    <v-row dense class="mt-2 mb-n3">
       <v-col cols="1">
         <v-divider class="mt-3" />
       </v-col>
@@ -265,20 +269,33 @@
               mdi-hexagon-outline
             </v-icon>
           </span>
+          <div class="caption mb-n0">
+            {{ w.Effect }}
+          </div>
         </v-row>
         <div v-for="p in w.Profiles" :key="`${w.ID}_${p.Name}`">
-          <div class="caption">
-            <b v-for="(r, k) in p.Range" :key="`mmwr_${i}_${j}_${k}`">{{ r.Text }}&nbsp;</b>
-            <span v-if="p.Damage && p.Damage.length">|</span>
-            <b v-for="(d, k) in p.Damage" :key="`mmwd_${i}_${j}_${k}`">{{ d.Text }}&nbsp;</b>
-            <p v-if="p.Effect" :v-html-safe="p.Effect" print />
-            <p v-if="p.OnAttack" :v-html-safe="`<b>ON ATTACK:</b> ${p.OnAttack}`" print />
-            <p v-if="p.OnHit" :v-html-safe="`<b>ON HIT:</b> ${p.OnHit}`" print />
-            <p v-if="p.OnCrit" :v-html-safe="`<b>ON CRIT:</b> ${p.OnCrit}`" print />
+          <div class="caption mb-n0">
+            <b v-for="(r, k) in p.Range" :key="`mmwr_${i}_${j}_${k}`">
+              <span v-for="rangeType in Object.values(rangeTypes)" v-if="r.Text.includes(rangeType)">
+                <i :class="`cci-`+ rangeType.toLowerCase()"></i>
+                {{r.Text.replace(rangeType, '')}}
+              </span>
+            </b>
+            <span v-if="p.Damage && p.Damage.length">|&nbsp;</span>
+            <b v-for="(d, k) in p.Damage" :key="`mmwd_${i}_${j}_${k}`">
+              <span v-for="damageType in Object.values(damageTypes)" v-if="d.Text.includes(damageType)">
+                <i :class="`cci-`+ damageType.toLowerCase()"></i>
+                {{d.Text.replace(damageType + ' Damage', '')}}
+              </span>
+            </b>
+            <p v-if="p.Effect" print>{{ p.Effect }}</p>
+            <p v-if="p.OnAttack" print><b>ON ATTACK:</b> {{ p.OnAttack }}</p>
+            <p v-if="p.OnHit" print><b>ON HIT:</b> {{ p.OnHit }}</p>
+            <p v-if="p.OnCrit" print><b>ON CRIT:</b> {{ p.OnCrit }}</p>
             <print-action :actions="p.Actions" />
             <print-deployable :deployables="p.Deployables" />
           </div>
-          <div class="text-right" style="position: absolute; bottom: 0; left: 0; right: 0">
+          <div class="text-right mt-n2" style="position: relative; bottom: 0; left: 0; right: 0">
             <cc-tags :tags="p.Tags" :bonus="mech.Pilot.LimitedBonus" print />
           </div>
         </div>
@@ -293,7 +310,7 @@
       </div>
     </fieldset>
 
-    <fieldset>
+    <fieldset class="mt-1">
       <legend class="heading ml-1 px-2">Systems</legend>
       <div
         v-for="(s, i) in mech.MechLoadoutController.ActiveLoadout.AllActiveSystems"
@@ -322,6 +339,7 @@
         </div>
       </div>
     </fieldset>
+  </fieldset>
   </v-container>
 </template>
 
@@ -329,6 +347,8 @@
 import Vue from 'vue'
 import PrintAction from './components/PrintAction.vue'
 import PrintDeployable from './components/PrintDeployable.vue'
+import { DamageType } from '@/class'
+import { RangeType } from '@/class'
 
 export default Vue.extend({
   name: 'mech-print',
@@ -337,6 +357,16 @@ export default Vue.extend({
     mech: {
       type: Object,
       required: true,
+    },
+    damageTypes: {
+      type: Array,
+      required: true,
+      default: Object.values(DamageType),
+    },
+    rangeTypes: {
+      type: Array,
+      required: true,
+      default: Object.values(RangeType),
     },
   },
   computed: {

--- a/src/features/pilot_management/Print/PilotPrint.vue
+++ b/src/features/pilot_management/Print/PilotPrint.vue
@@ -1,269 +1,270 @@
 <template>
   <v-container fluid>
-    <v-row dense align="start">
-      <v-col cols="auto" class="mr-4">
-        <div class="overline mt-n2 mb-n4">CALLSIGN</div>
-        <div class="heading h2 my-n2">
-          {{ pilot.Callsign }}
-        </div>
-        <div class="my-n2">
-          <div>{{ pilot.Name }}, LL {{ pilot.Level }}</div>
-          <div v-if="pilot.Background" class="caption my-n1 grey--text">{{ pilot.Background }}</div>
-        </div>
-      </v-col>
-      <v-col class="ml-auto mr-auto">
-        <v-row dense justify="space-between">
-          <v-col cols="auto">
-            <div class="overline mt-n2 mb-n3">HP</div>
-            <div>
-              <v-icon size="50" color="grey lighten-3" class="mr-n1">mdi-hexagon-outline</v-icon>
-              <b class="flavor-text pt-3" v-html="`/${pilot.MaxHP}`" />
-            </div>
-          </v-col>
-          <v-col cols="auto">
-            <div class="overline mt-n2 mb-n3 ml-n7">ARMOR</div>
-            <div style="position: relative; width: max-content">
-              <v-icon size="50" color="grey lighten-3">mdi-shield-outline</v-icon>
-              <div class="heading p-stat icon-overlap" v-html="pilot.Armor" />
-            </div>
-          </v-col>
-          <v-col cols="auto">
-            <div class="overline mt-n2 mb-n3 ml-n6">E-DEF</div>
-            <div style="position: relative; width: max-content">
-              <v-icon size="50" color="grey lighten-3">cci-marker</v-icon>
-              <div class="heading p-stat icon-overlap" v-html="pilot.EDefense" />
-            </div>
-          </v-col>
-          <v-col cols="auto">
-            <div class="overline mt-n2 mb-n3 ml-n8">EVASION</div>
-            <div style="position: relative; width: max-content">
-              <v-icon size="50" color="grey lighten-3">cci-evasion</v-icon>
-              <div class="heading p-stat icon-overlap" v-html="pilot.Evasion" />
-            </div>
-          </v-col>
-          <v-col cols="auto">
-            <div class="overline mt-n2 mb-n3 ml-n6">SPEED</div>
-            <div style="position: relative; width: max-content">
-              <v-icon size="50" color="grey lighten-3">$vuetify.icons.move</v-icon>
-              <div class="heading p-stat icon-overlap" v-html="pilot.Speed" />
-            </div>
+    <fieldset>
+      <v-row dense align="start">
+        <v-col cols="auto" class="mr-4">
+          <div class="overline mt-0 mb-0">CALLSIGN</div>
+          <div class="heading h2 my-n2">
+            {{ pilot.Callsign }}
+          </div>
+          <div class="my-n2">
+            <div>{{ pilot.Name }}, LL {{ pilot.Level }}</div>
+            <div v-if="pilot.Background" class="caption my-n1 grey--text">{{ pilot.Background }}</div>
+          </div>
+        </v-col>
+        <v-col class="ml-auto mr-auto">
+          <v-row dense justify="space-between">
+            <v-col cols="auto">
+              <div class="overline mt-0 mb-0">HP</div>
+              <div>
+                <v-icon size="50" color="grey lighten-3" class="mr-n1">mdi-hexagon-outline</v-icon>
+                <b class="flavor-text pt-3" v-html="`/${pilot.MaxHP}`" />
+              </div>
+            </v-col>
+            <v-col cols="auto">
+              <div class="overline mt-0 mb-0 ml-n7">ARMOR</div>
+              <div style="position: relative; width: max-content">
+                <v-icon size="50" color="grey lighten-3">mdi-shield-outline</v-icon>
+                <div class="heading p-stat icon-overlap" v-html="pilot.Armor" />
+              </div>
+            </v-col>
+            <v-col cols="auto">
+              <div class="overline mt-0 mb-0 ml-n6">E-DEF</div>
+              <div style="position: relative; width: max-content">
+                <v-icon size="50" color="grey lighten-3">cci-marker</v-icon>
+                <div class="heading p-stat icon-overlap" v-html="pilot.EDefense" />
+              </div>
+            </v-col>
+            <v-col cols="auto">
+              <div class="overline mt-0 mb-0 ml-n8">EVASION</div>
+              <div style="position: relative; width: max-content">
+                <v-icon size="50" color="grey lighten-3">cci-evasion</v-icon>
+                <div class="heading p-stat icon-overlap" v-html="pilot.Evasion" />
+              </div>
+            </v-col>
+            <v-col cols="auto">
+              <div class="overline mt-0 mb-0 ml-n6">SPEED</div>
+              <div style="position: relative; width: max-content">
+                <v-icon size="50" color="grey lighten-3">$vuetify.icons.move</v-icon>
+                <div class="heading p-stat icon-overlap" v-html="pilot.Speed" />
+              </div>
+            </v-col>
+          </v-row>
+        </v-col>
+        <v-col cols="auto" class="text-right mt-0 ml-4">
+          <div class="overline mr-9">GRIT</div>
+          <div class="heading mt-0" style="font-size: 65px; line-height: 60px">
+            +{{ pilot.Grit }}
+          </div>
+        </v-col>
+      </v-row>
+
+        <v-row dense align="start" justify="space-between" class="ml-2">
+          <v-col cols="4" class="mt-n1">
+            <v-row dense justify="space-between" class="mt-0 mr-n16">
+              <v-col>
+                <span class="font-weight-bold overline">HULL</span>
+                <div class="mt-0" style="position: relative; width: max-content">
+                  <v-icon size="50" color="grey lighten-1" class="mr-n1">mdi-hexagon-outline</v-icon>
+                  <div
+                    class="heading h2 icon-overlap mt-2"
+                    v-html="pilot.MechSkillsController.MechSkills.Hull"
+                  />
+                </div>
+              </v-col>
+              <v-col>
+                <span class="font-weight-bold overline">AGI</span>
+                <div class="mt-0" style="position: relative; width: max-content">
+                  <v-icon size="50" color="grey lighten-1" class="mr-n1">mdi-hexagon-outline</v-icon>
+                  <div
+                    class="heading h2 icon-overlap mt-2"
+                    v-html="pilot.MechSkillsController.MechSkills.Agi"
+                  />
+                </div>
+              </v-col>
+              <v-col>
+                <span class="font-weight-bold overline">SYS</span>
+                <div class="mt-0" style="position: relative; width: max-content">
+                  <v-icon size="50" color="grey lighten-1" class="mr-n1">mdi-hexagon-outline</v-icon>
+                  <div
+                    class="heading h2 icon-overlap mt-2"
+                    v-html="pilot.MechSkillsController.MechSkills.Sys"
+                  />
+                </div>
+              </v-col>
+              <v-col>
+                <span class="font-weight-bold overline">ENG</span>
+                <div class="mt-0" style="position: relative; width: max-content">
+                  <div>
+                    <v-icon size="50" color="grey lighten-1" class="mr-n1">mdi-hexagon-outline</v-icon>
+                  </div>
+                  <div
+                    class="heading h2 icon-overlap mt-2"
+                    v-html="pilot.MechSkillsController.MechSkills.Eng"
+                  />
+                </div>
+              </v-col>
+            </v-row>
           </v-col>
         </v-row>
-      </v-col>
-      <v-col cols="auto" class="text-right mt-n1 ml-4">
-        <div class="overline mr-9">GRIT</div>
-        <div class="heading mt-n5" style="font-size: 65px; line-height: 60px">
-          +{{ pilot.Grit }}
-        </div>
-      </v-col>
-    </v-row>
 
-    <v-row dense align="start" justify="space-between">
-      <v-col>
-        <div class="overline">SKILL TRIGGERS</div>
-        <div class="text-left">
-          <v-chip
-            v-for="(s, i) in pilot.SkillsController.Skills"
-            :key="`psk_${i}`"
-            label
-            outlined
-            small
-            class="mx-1 mb-1"
-          >
+      <v-row dense justify="space-between" class="mt-0 caption" style="position: relative; page-break-inside: avoid">
+        <v-col>
+          <fieldset>
+            <legend class="overline ml-1 px-2">SKILL TRIGGERS</legend>
+            <v-chip v-for="(s, i) in pilot.SkillsController.Skills" :key="`psk_${i}`"
+                    label
+                    outlined
+                    small
+                    class="mx-1 mb-1">
             <span style="background-color: var(--v-gray-lighten2)" class="stat-text ml-n2 mr-2">
               +{{ s.Bonus }}
             </span>
-            <span>{{ s.Skill.Trigger }}</span>
-          </v-chip>
-        </div>
-      </v-col>
-      <v-col cols="4">
-        <v-row dense justify="space-between" class="mt-n5 pl-3">
-          <v-col>
-            <span class="font-weight-bold overline pr-4">HULL</span>
-            <div class="ml-3 mt-n3" style="position: relative; width: max-content">
-              <v-icon x-large color="grey lighten-1" style="margin-right: -3px !important">
-                mdi-hexagon-outline
-              </v-icon>
-              <div
-                class="heading h2 icon-overlap mt-1"
-                v-html="pilot.MechSkillsController.MechSkills.Hull"
+              <span>{{ s.Skill.Trigger }}</span>
+            </v-chip>
+          </fieldset>
+        </v-col>
+      </v-row>
+
+      <v-row dense justify="space-between" class="mt-2 caption" style="position: relative; page-break-inside: avoid">
+        <v-col>
+          <fieldset>
+            <legend class="overline ml-1 px-2">LICENSES</legend>
+            <v-chip
+              v-for="(l, i) in pilot.LicenseController.Licenses"
+              :key="`plr_${i}`"
+              small
+              outlined
+              class="mx-1 mb-1"
+            >
+              <v-icon left>cci-rank-{{ l.Rank }}</v-icon>
+              <span
+                class="flavor-text black--text"
+                v-html="
+              `${l.License.Source} ${l.License.Name}
+          ${'I'.repeat(l.rank)}`
+            "
               />
-            </div>
-          </v-col>
+            </v-chip>
+          </fieldset>
+        </v-col>
+      </v-row>
+
+
+      <fieldset class="mt-2">
+        <legend class="overline ml-1 px-2">TALENTS</legend>
+        <v-row
+          v-for="(t, i) in pilot.TalentsController.Talents"
+          :key="`pt_${i}`"
+          dense
+          justify="space-between"
+          class="mt-0 caption"
+          style="position: relative; page-break-inside: avoid"
+        >
           <v-col>
-            <span class="font-weight-bold overline pr-3">AGI</span>
-            <div class="ml-3 mt-n3" style="position: relative; width: max-content">
-              <v-icon x-large color="grey lighten-1" style="margin-right: -3px !important">
-                mdi-hexagon-outline
-              </v-icon>
-              <div
-                class="heading h2 icon-overlap mt-1"
-                v-html="pilot.MechSkillsController.MechSkills.Agi"
-              />
-            </div>
-          </v-col>
-          <v-col>
-            <span class="font-weight-bold overline pr-3">SYS</span>
-            <div class="ml-3 mt-n3" style="position: relative; width: max-content">
-              <v-icon x-large color="grey lighten-1" style="margin-right: -3px !important">
-                mdi-hexagon-outline
-              </v-icon>
-              <div
-                class="heading h2 icon-overlap mt-1"
-                v-html="pilot.MechSkillsController.MechSkills.Sys"
-              />
-            </div>
-          </v-col>
-          <v-col>
-            <span class="font-weight-bold overline pr-3">ENG</span>
-            <div class="ml-3 mt-n3" style="position: relative; width: max-content">
-              <v-icon x-large color="grey lighten-1" style="margin-right: -3px !important">
-                mdi-hexagon-outline
-              </v-icon>
-              <div
-                class="heading h2 icon-overlap mt-1"
-                v-html="pilot.MechSkillsController.MechSkills.Eng"
-              />
+            <div>
+              <fieldset class="my-2">
+                <legend class="heading ml-1 px-2">{{ t.Talent.Name }}</legend>
+                <v-row v-for="n in t.Rank" :key="`ptr_${i}_${n}`" align="center" dense no-gutters>
+                  <v-col cols="auto" class="mr-1">
+                    <v-icon>cci-rank-{{ n }}</v-icon>
+                  </v-col>
+                  <v-col>
+                    <span v-html-safe="t.Talent.Ranks[n - 1].Description" />
+                  </v-col>
+                </v-row>
+              </fieldset>
             </div>
           </v-col>
         </v-row>
-      </v-col>
-    </v-row>
+      </fieldset>
 
-    <v-row
-      v-if="pilot.LicenseController.Licenses.length"
-      dense
-      align="start"
-      justify="space-between"
-      class="mt-n2"
-    >
-      <v-col>
-        <div class="overline mb-n2 mt-n1">LICENSES</div>
-        <div class="text-left">
-          <v-chip
-            v-for="(l, i) in pilot.LicenseController.Licenses"
-            :key="`plr_${i}`"
-            small
-            outlined
+      <fieldset v-if="pilot.CoreBonusController.CoreBonuses.length" class="mb-0 mt-2">
+        <legend class="overline ml-1 px-2">CORE BONUSES</legend>
+
+        <v-row
+          v-for="(b, i) in pilot.CoreBonusController.CoreBonuses"
+          :key="`pb_${i}`"
+          dense
+          justify="space-between"
+          class="mt-0 caption"
+        >
+          <v-col class="mt-n2">
+            <div>
+              <fieldset class="my-2">
+                <legend class="heading ml-1 px-2">{{ b.Name }}</legend>
+                <span v-html-safe="b.Effect" />
+              </fieldset>
+            </div>
+          </v-col>
+        </v-row>
+      </fieldset>
+
+      <fieldset v-if="pilot.CoreBonusController.CoreBonuses.length" class="mb-1 mt-2">
+        <legend class="overline ml-1 px-2">PILOT LOADOUT</legend>
+        <v-row dense justify="space-between" class="mt-0 caption">
+          <v-col
+            v-for="(a, i) in pilot.Loadout.Armor.filter(x => x)"
+            :key="`pla_${i}`"
+            style="position: relative; page-break-inside: avoid"
           >
-            <v-icon left>cci-rank-{{ l.Rank }}</v-icon>
-            <span
-              class="flavor-text black--text"
-              v-html="
-                `${l.License.Source} ${l.License.Name}
-            ${'I'.repeat(l.rank)}`
+            <fieldset v-if="a">
+              <legend class="heading ml-1 px-2">
+                {{ a.Name }}
+                <span class="overline flavor-text">//ARMOR</span>
+              </legend>
+              <div
+                class="pa-1 mt-0"
+                v-html="
+                `+${a.Armor(pilot) || 0} Armor / E-Def: ${a.EDefense(pilot) || 'N/A'} / Evasion: ${
+                  a.Evasion(pilot) || 'N/A'
+                }<br>${a.HPBonus(pilot) ? `HP Bonus: +${a.HPBonus(pilot)}` : ''}${
+                  a.Speed(pilot) ? ` / Speed: ${a.Speed(pilot)}` : ''
+                }`
               "
-            />
-          </v-chip>
-        </div>
-      </v-col>
-    </v-row>
-
-    <div class="overline mb-n3 mt-n1">TALENTS</div>
-    <v-row
-      v-for="(t, i) in pilot.TalentsController.Talents"
-      :key="`pt_${i}`"
-      dense
-      justify="space-between"
-      class="mt-n1 caption"
-      style="position: relative; page-break-inside: avoid"
-    >
-      <v-col>
-        <fieldset>
-          <legend class="heading ml-1 px-2">{{ t.Talent.Name }}</legend>
-          <v-row v-for="n in t.Rank" :key="`ptr_${i}_${n}`" align="center" dense no-gutters>
-            <v-col cols="auto" class="mr-1">
-              <v-icon>cci-rank-{{ n }}</v-icon>
-            </v-col>
-            <v-col>
-              <span v-html-safe="t.Talent.Ranks[n - 1].Description" />
-            </v-col>
-          </v-row>
-        </fieldset>
-      </v-col>
-    </v-row>
-
-    <div v-if="pilot.CoreBonusController.CoreBonuses.length" class="overline mb-n3 mt-n1">
-      CORE BONUSES
-    </div>
-    <v-row
-      v-for="(b, i) in pilot.CoreBonusController.CoreBonuses"
-      :key="`pb_${i}`"
-      dense
-      justify="space-between"
-      class="mt-n1 caption"
-    >
-      <v-col>
-        <fieldset>
-          <legend class="heading ml-1 px-2">{{ b.Name }}</legend>
-          <span v-html-safe="b.Effect" />
-        </fieldset>
-      </v-col>
-    </v-row>
-
-    <div class="overline mb-n3 mt-n1">PILOT LOADOUT</div>
-    <v-row dense justify="space-between" class="mt-n1 caption">
-      <v-col
-        v-for="(a, i) in pilot.Loadout.Armor.filter(x => x)"
-        :key="`pla_${i}`"
-        style="position: relative; page-break-inside: avoid"
-      >
-        <fieldset v-if="a">
-          <legend class="heading ml-1 px-2">
-            {{ a.Name }}
-            <span class="overline flavor-text">//ARMOR</span>
-          </legend>
-          <div
-            class="pa-1 mt-n2"
-            v-html="
-              `+${a.Armor(pilot) || 0} Armor / E-Def: ${a.EDefense(pilot) || 'N/A'} / Evasion: ${
-                a.Evasion(pilot) || 'N/A'
-              }<br>${a.HPBonus(pilot) ? `HP Bonus: +${a.HPBonus(pilot)}` : ''}${
-                a.Speed(pilot) ? ` / Speed: ${a.Speed(pilot)}` : ''
-              }`
-            "
-          />
-        </fieldset>
-      </v-col>
-      <v-col v-for="(w, i) in pilot.Loadout.Weapons.filter(x => x)" :key="`plw_${i}`">
-        <fieldset v-if="w">
-          <legend class="heading ml-1 px-2">
-            {{ w.Name }}
-            <span class="overline flavor-text">//WEAPON</span>
-          </legend>
-          <div class="pa-1 mt-n2">
-            <b v-for="(r, j) in w.Range" :key="`plwr_${i}_${j}`">{{ r.Text }}</b>
-            |
-            <b v-for="(d, j) in w.Damage" :key="`plwd_${i}_${j}`">{{ d.Text }}</b>
-            <div v-if="w.Effect" v-html-safe="w.Effect" />
-            <div class="text-right">
-              <span v-for="(t, j) in i.Tags" :key="`plwt_${i}_${j}`" class="mx-1">
-                {{ t.Name() }}
-              </span>
-            </div>
-          </div>
-        </fieldset>
-      </v-col>
-    </v-row>
-    <v-row dense justify="space-between" class="mt-n1 caption">
-      <v-col v-for="(g, i) in pilot.Loadout.Gear.filter(x => x)" :key="`plg_${i}`">
-        <fieldset v-if="g">
-          <legend class="heading ml-1 px-2">
-            {{ g.Name }}
-            <span class="overline flavor-text">//GEAR</span>
-          </legend>
-          <div class="pa-1 my-n2">
-            <div v-if="g.Description" v-html-safe="g.Description" />
-            <div class="text-right">
-              <span v-for="(t, j) in i.Tags" :key="`plgt_${i}_${j}`" class="mx-1">
-                {{ t.Name() }}
-              </span>
-            </div>
-          </div>
-        </fieldset>
-      </v-col>
-    </v-row>
+              />
+            </fieldset>
+          </v-col>
+          <v-col v-for="(w, i) in pilot.Loadout.Weapons.filter(x => x)" :key="`plw_${i}`">
+            <fieldset v-if="w">
+              <legend class="heading ml-1 px-2">
+                {{ w.Name }}
+                <span class="overline flavor-text">//WEAPON</span>
+              </legend>
+              <div class="pa-1 mt-0">
+                <b v-for="(r, j) in w.Range" :key="`plwr_${i}_${j}`">{{ r.Text }}</b>
+                |
+                <b v-for="(d, j) in w.Damage" :key="`plwd_${i}_${j}`">{{ d.Text }}</b>
+                <div v-if="w.Effect" v-html-safe="w.Effect" />
+                <div class="text-right">
+                <span v-for="(t, j) in i.Tags" :key="`plwt_${i}_${j}`" class="mx-1">
+                  {{ t.Name() }}
+                </span>
+                </div>
+              </div>
+            </fieldset>
+          </v-col>
+        </v-row>
+        <v-row dense justify="space-between" class="mt-0 caption mb-1">
+          <v-col v-for="(g, i) in pilot.Loadout.Gear.filter(x => x)" :key="`plg_${i}`">
+            <fieldset v-if="g">
+              <legend class="heading ml-1 px-2">
+                {{ g.Name }}
+                <span class="overline flavor-text">//GEAR</span>
+              </legend>
+              <div class="pa-1 my-n1">
+                <div v-if="g.Description" v-html-safe="g.Description" />
+                <div class="text-right">
+                <span v-for="(t, j) in i.Tags" :key="`plgt_${i}_${j}`" class="mx-1">
+                  {{ t.Name() }}
+                </span>
+                </div>
+              </div>
+            </fieldset>
+          </v-col>
+        </v-row>
+      </fieldset>
+    </fieldset>
   </v-container>
 </template>
 

--- a/src/features/pilot_management/Print/components/PrintAction.vue
+++ b/src/features/pilot_management/Print/components/PrintAction.vue
@@ -11,11 +11,11 @@
       <div class="ml-3">
         <div v-if="a.Init" v-html-safe="a.Init" class="caption" />
         <div v-if="a.Trigger">
-          <div class=" overline my-n2">Trigger</div>
+          <div class="overline my-n1 font-weight-bold">Trigger</div>
           <div v-html-safe="a.Trigger" class="caption " />
         </div>
         <div v-if="a.Detail">
-          <div class="overline my-n2">Effect</div>
+          <div class="overline my-n1 font-weight-bold">Effect</div>
           <div v-html-safe="a.Detail" class="caption " />
         </div>
       </div>

--- a/src/features/pilot_management/Print/components/PrintDeployable.vue
+++ b/src/features/pilot_management/Print/components/PrintDeployable.vue
@@ -4,23 +4,20 @@
       <div class="text-center caption font-weight-bold">{{ d.name }}</div>
       <v-row justify="center" dense class="text-center mt-n1">
         <v-col v-if="d.size" cols="auto">
-          <div class="caption font-weight-bold" v-html="`Size ${d.size === 0.5 ? '½' : d.size}`" />
+          <div class="caption"><i :class="`cci-size-` + d.size"/> {{ d.size === 0.5 ? '½' : d.size }} </div>
         </v-col>
         <v-col v-if="d.armor" cols="auto">
           <div class="caption" v-html="`<b>Armor</b>: ${d.armor}`" />
         </v-col>
         <v-col v-if="d.hp || d.size" cols="auto">
-          <div
-            class="caption"
-            v-html="
-              `<b>HP</b>: ${
-                d.hp ? d.hp.toString().replace(/[{}]/gim, '') : parseFloat(d.size || 0.5) * 10
-              }`
-            "
-          />
+
+          <div class="caption">
+            <i class="mdi mdi-heart"></i>
+            {{d.hp ? d.hp.toString().replace(/[{}]/gim, '') : parseFloat(d.size || 0.5) * 10}}
+          </div>
         </v-col>
         <v-col v-if="d.size" cols="auto">
-          <div class="caption" v-html="`<b>Evasion:</b> ${d.evasion || 10}`" />
+          <div class="caption"><i class="cci-evasion" />{{d.evasion || 10}}</div>
         </v-col>
         <v-col v-if="d.edef" cols="auto">
           <div class="caption" v-html="`<b>E-Defense:</b> ${d.edef}`" />


### PR DESCRIPTION
# Description

When printing character sheets, this changes certain texts to reflect the Mastiff icon's in place of certain texts.

This also contains changes from https://github.com/Kommunizdiy/compcon/tree/print_weapon_effects

![image](https://github.com/user-attachments/assets/8532def7-c4fb-4236-b91c-b129c26301e9)
![image](https://github.com/user-attachments/assets/e7f46588-c97b-44af-915f-6d1af4dcf038)

![image](https://github.com/user-attachments/assets/d5901b47-ae4d-41c0-bf1c-c00ff31769a1)
![image](https://github.com/user-attachments/assets/0898aa1b-7b12-4f25-9fb0-390b7933ce1b)


## Issue Number
N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
