### PR TITLE
Correctly analyze mounted systems/weapons/mods for special equipment

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -13,6 +13,7 @@ import {
   MechWeapon,
   WeaponMod,
 } from '@/class'
+import { CompendiumItem } from '../../../CompendiumItem'
 import { Bonus } from '@/classes/components/feature/bonus/Bonus'
 
 interface IMechLoadoutData {
@@ -373,6 +374,10 @@ class MechLoadout extends Loadout {
 
   public get AICount(): number {
     return this.Equipment.filter(x => x.IsAI).length
+  }
+
+  public get SpecialEquipment(): CompendiumItem[] {
+    return (this.UniqueItems.filter(x => x.SpecialEquipment.length != 0).map(y => y.SpecialEquipment)).flat();
   }
 
   public static Serialize(ml: MechLoadout): IMechLoadoutData {

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
@@ -190,6 +190,7 @@ export default Vue.extend({
       // }
 
       i = i.concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
+      i = i.concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
 
       return i
     },

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSelector.vue
@@ -164,6 +164,12 @@ export default Vue.extend({
         )
       )
 
+      i = i.concat(
+        this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(
+          x => x.ItemType === 'MechWeapon' && fittings.includes(x.Size)
+        )
+      )
+
       // filter unique
       i = i.filter(
         x =>

--- a/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSelector.vue
@@ -161,6 +161,15 @@ export default Vue.extend({
             )
         )
 
+        i = i
+        .concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'MechSystem'))
+        .filter(
+          x =>
+            !this.mech.MechLoadoutController.ActiveLoadout.UniqueSystems.map(y => y.ID).includes(
+              x.ID
+            )
+        )
+
       return _.sortBy(i, ['Source', 'Name'])
     },
   },


### PR DESCRIPTION
Previously, only special equipment stored under the pilot was being aggregated and displayed in equipment selectors, so only talents/core bonuses allowed you to add special equipment. Now, a given active mech loadout will be considered (active so you must actually have the source item equipped) and its special_equipment content added to your menus.