### PR TITLE
compendium select scroll issue fix

### DIFF
--- a/src/ui/components/CompendiumBrowser/CCCompendiumBrowser.vue
+++ b/src/ui/components/CompendiumBrowser/CCCompendiumBrowser.vue
@@ -986,7 +986,7 @@ export default {
         this.page = Math.ceil(
           (this.shownItems.findIndex((x: any) => x.ID === item.ID) + 1) / this.itemsPerPage
         );
-        this.$nextTick(() => this.scrollTo(item.ID));
+        this.scrollTo(item.ID);
       }
       this.$emit('select', item);
     },
@@ -999,7 +999,7 @@ export default {
         // const y = el.getBoundingClientRect().top + mEl.scrollTop + yOffset;
 
         const rect = el.getBoundingClientRect();
-        const y = rect.top + window.scrollY - window.innerHeight / 2 + rect.height / 2;
+        const y = rect.top + mEl.scrollTop - mEl.clientHeight / 2 + rect.height / 2;
 
         mEl.scrollTo({ top: y, behavior: 'smooth' });
       }


### PR DESCRIPTION
# Description
fixed an issue in the compendium where selecting an item caused it to not scroll at the correct location 1 time out of 2
tested on firefox, chrome and edge

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
