### PR TITLE
Fix dupe integrated weapons when granted by CBs

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -63,15 +63,21 @@ class MechLoadout extends Loadout {
 
   public SetAllIntegrated(save?: boolean) {
     const im = [
-      ...this.Parent.FeatureController.IntegratedWeapons.map(x => new IntegratedMount(x, this)),
-      ...this.Parent.Pilot.FeatureController.IntegratedWeapons.map(
-        x => new IntegratedMount(x, this)
-      ),
-    ]
+      ...this.Parent.FeatureController.IntegratedWeapons,
+      ...this.Parent.Pilot.FeatureController.IntegratedWeapons
+    ].reduce((p, x) => {
+      if (!p.some((elem) => (elem.ID == x.ID))) p.push(x);
+      return p;
+    }, []).map(x => new IntegratedMount(x, this))
+
     const is = [
       ...this.Parent.FeatureController.IntegratedSystems,
       ...this.Parent.Pilot.FeatureController.IntegratedSystems,
-    ]
+    ].reduce((p, x) => {
+      if (!p.some((elem) => (elem.ID == x.ID))) p.push(x);
+      return p;
+    }, [])
+
     Vue.set(this, '_integratedSystems', is)
     Vue.set(this, '_integratedMounts', im)
     if (save) this.saveMechLoadout()


### PR DESCRIPTION
It turns out that since CBS are applied to both Pilots & Mechs, the code collecting IWs/ISs can and will accidentally duplicate them. In lieu of refactoring the collectors to take a context or something, I've made the executive decision to just... not support adding the same thing as an integrated weapon bonus twice. This should have zero negative effects, since integrated gear is generally supposed to be entirely unique (and therefore there's no other second thing to apply it). I'm tentatively open to revisiting this if there's a genuine need for it that can't be solved with "This weapon can be attacked with twice in a Barrage" or something similar, though.

I've tested this decently thoroughly, but I'd appreciate a sanity test before this is merged by anybody else - I checked by using a LCP with a core bonus granting an integrated weapon, and also with granting the same integrated weapon/system via 2 different effects normally (and that doesn't explode, which is what I was hoping for). (try making Raleighs w/ nuclear cavalier 3 and the affected CBs)

Tester LCP attached, see CBs. Thanks to Gunny on discord for providing their draft for testing purposes.

[VortexSecurity_1.2.1.zip](https://github.com/user-attachments/files/20052965/VortexSecurity_1.2.1.zip)
