### PR TITLE
fix: properly filter exotic mods

### DIFF
--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
@@ -151,7 +151,10 @@ export default Vue.extend({
       return this.weapon.Mod ? this.mech.FreeSP + this.weapon.Mod.SP : this.mech.FreeSP
     },
     availableMods(): MechSystem[] {
-      let i = this.mods.filter(x => !x.IsHidden)
+      let i = this.mods.filter(x => !x.IsHidden && !x.IsExotic)
+
+      i = i.concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
+      i = i.concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
 
       if (!this.showIncompatible) {
         // filter by applied_to
@@ -188,9 +191,6 @@ export default Vue.extend({
       // if (!this.showOverSP) {
       //   i = i.filter(x => x.SP <= this.freeSP)
       // }
-
-      i = i.concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
-      i = i.concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
 
       return i
     },


### PR DESCRIPTION
# Description
currently, exotic mods show up in the mod selector menu even when not added to a pilot as special equipment, and are in the list regardless of compatibility with the weapon. this pr causes them to behave as any other exotic item, only appearing when they are added to a pilot and when compatible with the weapon they are being equipped to (unless show incompatible is toggled).

## Issue Number
n/a

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
