### PR TITLE
Handle Core Integrated/Special Systems & Mods correctly

### DIFF
--- a/src/classes/mech/components/frame/CoreSystem.ts
+++ b/src/classes/mech/components/frame/CoreSystem.ts
@@ -164,11 +164,19 @@ class CoreSystem {
 
   public get IntegratedEquipment(): MechEquipment[] {
     if (!this._integrated) return []
-    return this._integrated.map(x => {
+    const res = this._integrated.map(x => {
       const w = store.getters.referenceByID('MechWeapons', x)
-      if (w) return w
-      return store.getters.referenceByID('MechSystems', x)
+      if (w && !w.err) return w
+      const s = store.getters.referenceByID('MechSystems', x)
+      if (s && !s.err) return s
+      // I don't know what integrated pilot gear or weapon mods mean yet, so this is disabled to clearly indicate "not implemented"
+      // const wm = store.getters.referenceByID('WeaponMods', x)
+      // if (wm && !wm.err) return wm
+      // const pg = store.getters.referenceByID('PilotGear', x)
+      // if (pg && !pg.err) return pg
+      return false
     })
+    return res.filter(x => x)
   }
 
   public get PassiveIntegratedWeapons(): MechWeapon[] {

--- a/src/ui/components/cards/frame/_FrameCoreSystemPanel.vue
+++ b/src/ui/components/cards/frame/_FrameCoreSystemPanel.vue
@@ -65,6 +65,16 @@
       </v-col>
     </v-row>
 
+    <v-row v-if="cs.SpecialEquipment.length" no-gutters justify="center">
+      <v-col
+        v-for="(x, i) in cs.SpecialEquipment"
+        :key="`${cs.Name}_special_${i}`"
+        cols="auto"
+      >
+        <cc-integrated-info :item="x" :special="true" :panel="$vuetify.breakpoint.lgAndUp" />
+      </v-col>
+    </v-row>
+
     <v-row v-if="cs.Deployables.length" no-gutters justify="center">
       <v-col v-for="(d, i) in cs.Deployables" :key="`${cs.Name}_deployable_${i}`" cols="auto">
         <cc-deployable-info :deployable="d" :panel="$vuetify.breakpoint.lgAndUp" class="ma-2" />

--- a/src/ui/components/items/features/integrated/CCIntegratedInfo.vue
+++ b/src/ui/components/items/features/integrated/CCIntegratedInfo.vue
@@ -2,6 +2,7 @@
   <component
     :is="hover ? 'integratedInfoHover' : panel ? 'integratedInfoPanel' : 'integratedInfoPopup'"
     :item="item"
+    :special="special"
   />
 </template>
 
@@ -28,6 +29,10 @@ export default Vue.extend({
     },
     hover: {
       type: Boolean,
+    },
+    special: {
+      type: Boolean,
+      default: false,
     },
   },
 })

--- a/src/ui/components/items/features/integrated/_integratedInfoPanel.vue
+++ b/src/ui/components/items/features/integrated/_integratedInfoPanel.vue
@@ -1,17 +1,18 @@
 <template>
   <v-alert outlined dense :color="item.Color" class="light-panel pb-1">
     <v-row
-      v-if="item.ItemType === 'MechWeapon'"
       class="stark--text mb-n3"
       no-gutters
       align="center"
     >
       <v-col>
-        <v-icon large left class="mt-n2">cci-weapon</v-icon>
+        <v-icon large left class="mt-n2">
+          {{(item.ItemType === 'MechWeapon') ? 'cci-weapon' : (item.ItemType === 'MechSystem') ? 'cci-system' : 'cci-weaponmod'}}
+        </v-icon>
         <span class="heading h3">{{ item.Name }}</span>
       </v-col>
       <v-col cols="auto" class="ml-auto">
-        <span class="overline">INTEGRATED MECH WEAPON</span>
+        <span class="overline">{{special ? 'SPECIAL ' : 'INTEGRATED'}} {{(item.ItemType === 'MechWeapon') ? 'MECH WEAPON' : (item.ItemType === 'MechSystem') ? 'MECH SYSTEM' : 'WEAPON MOD'}}</span>
       </v-col>
     </v-row>
     <integrated-info-base :item="item" />
@@ -29,6 +30,10 @@ export default Vue.extend({
     item: {
       type: Object,
       required: true,
+    },
+    special: {
+      type: Boolean,
+      default: false,
     },
   },
 })


### PR DESCRIPTION
There was sorta handling for this before, but it was being bricked by an incomplete IntegratedEquipment getter that always returned "weapon not found" for systems. I copied the handling for Special Equipment, which behaves correctly, and then just dummied out the weapon mod/pilot gear lines - those could easily be added, but I wanted to make it explicit that there is no current handling for either of those two things, so go figure. 

Integrated Systems additionally now display correctly, as well as special equipment of any kind (well, system/weapon/weapon mod). Abuses ternaries, so it's a bit ugly, but it's perfectly functional. It's this or duplicate a bunch of code, ok?

To be clear - this has no effects on how integrated systems / special systems & mods are actually treated by compcon in any way other than on the frame page. They previously just didn't render, but functioned OK - and now they render & function.

<img width="2052" height="824" alt="image" src="https://github.com/user-attachments/assets/ca31c36f-071c-47fe-8016-d2ea831c2ad3" />
<img width="2129" height="1084" alt="image" src="https://github.com/user-attachments/assets/9f7940d6-aac5-4231-b763-8002978de348" />

(you're not supposed to have descriptions on integrated stuff, so ignore the encyc entry & SP on the mist feathers example. it was a tester screenshot. no SP/encyc entry looks fine, see the first screenshot)
(also ignore the long encyc entry on the special gun - compcon in general squishes weapons/systems that don't have long enough effects/descs, which is a ui "bug" (styling issue, more) unrelated to this)