### PR TITLE
Hide non-licensed (i.e. integrateds with LL>0 mistakenly) from the standard equip viewr

### DIFF
--- a/src/io/ContentPackParser.ts
+++ b/src/io/ContentPackParser.ts
@@ -41,6 +41,7 @@ const readZipJSON = async function <T>(zip: JSZip, filename: string): Promise<T 
 const getPackID = async function (manifest: IContentPackManifest): Promise<string> {
   const enc = new TextEncoder()
   const signature = `${manifest.author}/${manifest.name}`
+  if (!crypto.subtle) throw new Error("Connection not secure, unable to hash content pack ID, run in secure context (https or localhost) or update your browser")
   const hash = await crypto.subtle.digest('SHA-1', enc.encode(signature))
   return btoa(String.fromCharCode.apply(null, new Uint8Array(hash)))
 }

--- a/src/ui/components/selectors/CCEquipmentSelector.vue
+++ b/src/ui/components/selectors/CCEquipmentSelector.vue
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { getModule } from 'vuex-module-decorators'
 import { CompendiumStore } from '@/store'
 import { CompendiumItem } from '@/classes/CompendiumItem'
-import { PilotLicense } from '@/class'
+import { LicensedItem, PilotLicense } from '@/class'
 
 export default Vue.extend({
   name: 'equipment-selector',
@@ -58,7 +58,8 @@ export default Vue.extend({
       .concat(compendium.MechSystems.filter(x => x.LicenseLevel > 0) as CompendiumItem[])
       .concat(compendium.Frames.filter(x => x.LicenseLevel > 0) as CompendiumItem[])
 
-    this.items = items.filter(x => !x.IsExotic && !x.IsHidden)
+    this.items = items.filter(x => !x.IsExotic && !x.IsHidden && ((x as LicensedItem).LicenseID || (x as LicensedItem).License))
+    // need to filter out unlicensed items, having LL>1 unlicensed items can break the system selector/etc. views I think
   },
 })
 </script>


### PR DESCRIPTION
Breaks system selector/etc. I think, didn't fix when I touched special equipment because I didn't realize this was an actual issue

Also note if running in insecure context (aka accessing via 192.168) so you're not confused why you can't import lcps