### PR TITLE
bugfix: rm dupe entries when special equip + "show unlicensed"

### DIFF
--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_ModSelector.vue
@@ -153,8 +153,14 @@ export default Vue.extend({
     availableMods(): MechSystem[] {
       let i = this.mods.filter(x => !x.IsHidden && !x.IsExotic)
 
-      i = i.concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
-      i = i.concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod'))
+      if (!this.showUnlicensed) {
+        i = i.filter(
+          x => !x.LicenseLevel || this.mech.Pilot.has('License', x.LicenseID, x.LicenseLevel)
+        )
+      }
+
+      i = i.concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod').filter(x => !i.map(y => y.ID).includes(x.ID)))
+      i = i.concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'WeaponMod').filter(x => !i.map(y => y.ID).includes(x.ID)))
 
       if (!this.showIncompatible) {
         // filter by applied_to
@@ -175,17 +181,11 @@ export default Vue.extend({
       )
 
       // filter ai
-      if (
+      if (!this.showUnlicensed &&
         this.mech.MechLoadoutController.ActiveLoadout.AICount >=
         1 + Bonus.get('ai_cap', this.mech)
       ) {
         i = i.filter(x => !x.IsAI)
-      }
-
-      if (!this.showUnlicensed) {
-        i = i.filter(
-          x => !x.LicenseLevel || this.mech.Pilot.has('License', x.LicenseID, x.LicenseLevel)
-        )
       }
 
       // if (!this.showOverSP) {

--- a/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/mount/weapon/_WeaponSelector.vue
@@ -144,14 +144,6 @@ export default Vue.extend({
       // filter already equipped
       if (this.weaponSlot.Weapon) i = i.filter(x => x.ID !== this.weaponSlot.Weapon.ID)
 
-      // filter ai
-      if (
-        this.mech.MechLoadoutController.ActiveLoadout.AICount >=
-        1 + Bonus.get('ai_cap', this.mech)
-      ) {
-        i = i.filter(x => !x.IsAI)
-      }
-
       if (!this.showUnlicensed) {
         i = i.filter(
           x => !x.LicenseLevel || this.mech.Pilot.has('License', x.LicenseID, x.LicenseLevel)
@@ -161,14 +153,23 @@ export default Vue.extend({
       i = i.concat(
         this.mech.Pilot.SpecialEquipment.filter(
           x => x.ItemType === 'MechWeapon' && fittings.includes(x.Size)
-        )
+        ).filter(x => !i.map(y => y.ID).includes(x.ID))
       )
 
       i = i.concat(
         this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(
           x => x.ItemType === 'MechWeapon' && fittings.includes(x.Size)
-        )
+        ).filter(x => !i.map(y => y.ID).includes(x.ID))
       )
+
+      // filter ai
+      if (!this.showUnlicensed &&
+        this.mech.MechLoadoutController.ActiveLoadout.AICount >=
+        1 + Bonus.get('ai_cap', this.mech)
+      ) {
+        i = i.filter(x => !x.IsAI)
+      }
+
 
       // filter unique
       i = i.filter(

--- a/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSelector.vue
+++ b/src/ui/components/panels/loadout/mech_loadout/components/system/_SystemSelector.vue
@@ -145,7 +145,7 @@ export default Vue.extend({
       // }
 
       i = i
-        .concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'MechSystem'))
+        .concat(this.mech.Pilot.SpecialEquipment.filter(x => x.ItemType === 'MechSystem').filter(x => !i.map(y => y.ID).includes(x.ID)))
         .filter(
           x =>
             !this.mech.MechLoadoutController.ActiveLoadout.UniqueSystems.map(y => y.ID).includes(
@@ -153,8 +153,8 @@ export default Vue.extend({
             )
         )
 
-        i = i
-        .concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'MechSystem'))
+      i = i
+        .concat(this.mech.MechLoadoutController.ActiveLoadout.SpecialEquipment.filter(x => x.ItemType === 'MechSystem').filter(x => !i.map(y => y.ID).includes(x.ID)))
         .filter(
           x =>
             !this.mech.MechLoadoutController.ActiveLoadout.UniqueSystems.map(y => y.ID).includes(
@@ -162,13 +162,13 @@ export default Vue.extend({
             )
         )
 
-        // filter ai
-        if (!this.showUnlicensed && 
-            this.mech.MechLoadoutController.ActiveLoadout.AICount >= 
-            1 + Bonus.get('ai_cap', this.mech)
-        ) {
-          i = i.filter(x => !x.IsAI)
-        }
+      // filter ai
+      if (!this.showUnlicensed && 
+          this.mech.MechLoadoutController.ActiveLoadout.AICount >= 
+          1 + Bonus.get('ai_cap', this.mech)
+      ) {
+        i = i.filter(x => !x.IsAI)
+      }
 
       return _.sortBy(i, ['Source', 'Name'])
     },


### PR DESCRIPTION
previously you got janky behavior where you'd have two consecutive entries for the same item and clicking on one would also click on the other

also fix weapon mods not showing up when added via standard equipment due to a misplaced "unlicensed" check (caused & fixed earlier inadvertently for system/weapons, forgot weapon mods existed).

also also fixes allowing selecting AI weapons/weapon mods while at AI cap (fixed for systems earlier, forgot AI weapon mods do/AI weapon could exist)