### PR TITLE
Allow adding new range types via weapon mod

### DIFF
--- a/src/classes/mech/components/loadout/MechLoadout.ts
+++ b/src/classes/mech/components/loadout/MechLoadout.ts
@@ -389,7 +389,6 @@ class MechLoadout extends Loadout {
         frame_special_equipment = frame_special_equipment.concat(this.Parent.Frame.Traits[i].SpecialEquipment);
       }
     }
-    console.log(frame_special_equipment);
     return (this.UniqueItems.filter(x => x.SpecialEquipment.length != 0).map(y => y.SpecialEquipment)).concat(frame_special_equipment).flat();
   }
 


### PR DESCRIPTION
Manually setting the bonus for a specific added range type to -99 will now add the range type. I thought about it and made the intentional decision to NOT add a new field to handle this concept, or to overload the override field (that way you can still make a range entry that overrides when it's present, and adds if not). I'm aware this is NOT permitted by CRB, but it's added in support of homebrew content doing more exotic things intentionally.

Also overriding with 0 will now just remove the range, and range is now capped at 1 (visually - it's still stored under the hood as a real value, so its possible to have range -3 and use exbats to get to 2).

also remove a random spec equip console log i left in 2 patches ago

does not change behavior for lowercase-b "bonuses", ONLY for weapon mod added ranges. there's just no clean way to handle this for bonuses and it'd be weird regardless