### PR TITLE
Remove auto cloud sync settings, add alias for HASE bonuses

### DIFF
--- a/src/classes/components/feature/bonus/Bonus.ts
+++ b/src/classes/components/feature/bonus/Bonus.ts
@@ -114,8 +114,11 @@ class Bonus {
     valStr = valStr.replace(/{grit}/g, grit)
     valStr = valStr.replace(/{hull}/g, hull)
     valStr = valStr.replace(/{agi}/g, agility)
+    valStr = valStr.replace(/{agility}/g, agility)
     valStr = valStr.replace(/{sys}/g, systems)
+    valStr = valStr.replace(/{systems}/g, systems)
     valStr = valStr.replace(/{eng}/g, engineering)
+    valStr = valStr.replace(/{engineering}/g, engineering)
     valStr = valStr.replace(/[^-()\d/*+.]/g, '')
     return Math.ceil(eval(valStr))
   }

--- a/src/features/main_menu/_components/login/SignedIn.vue
+++ b/src/features/main_menu/_components/login/SignedIn.vue
@@ -103,65 +103,6 @@
           </v-card>
         </div>
       </v-alert>
-
-      <v-card v-if="isOnV2" class="mt-3 mb-6" disabled hidden>
-        <v-card-title class="heading h3">Auto-sync settings</v-card-title>
-        <v-card-text class="px-10">
-          <v-row dense align="center">
-            <v-col>
-              <span class="heading h3">
-                On Login
-                <cc-tooltip
-                  inline
-                  content="This will automatically smart sync all item and LCP data whenever the account login process is successful. If you do not log out, this will occur shortly after the application starts. "
-                >
-                  <v-icon left>mdi-information-outline</v-icon>
-                </cc-tooltip>
-              </span>
-            </v-col>
-            <v-col cols="auto" class="mr-n3">
-              <v-switch
-                :value="false"
-                dense
-                hide-details
-                inset
-                color="accent"
-                disabled
-                @change="userUpdate()"
-              />
-            </v-col>
-            <!-- <v-col v-if="userProfile.SyncFrequency.cloudSync_v2" cols="auto"><b>ON</b></v-col> -->
-            <v-col cols="auto"><i>OFF</i></v-col>
-          </v-row>
-          <v-row dense align="center">
-            <v-col>
-              <span class="heading h3">
-                Sync Remote Resources
-                <cc-tooltip
-                  inline
-                  content="This will automatically attempt to sync all remote resources with the latest versions in their authors' cloud accounts. Remote data cannot be saved to your own cloud account."
-                >
-                  <v-icon left>mdi-information-outline</v-icon>
-                </cc-tooltip>
-              </span>
-            </v-col>
-            <v-col cols="auto" class="mr-n3">
-              <v-switch
-                :value="false"
-                dense
-                hide-details
-                inset
-                color="accent"
-                disabled
-                @change="userUpdate()"
-              />
-            </v-col>
-            <!-- <v-col v-if="userProfile.SyncFrequency.remotes" cols="auto"><b>ON</b></v-col> -->
-            <v-col cols="auto"><i>OFF</i></v-col>
-          </v-row>
-        </v-card-text>
-      </v-card>
-
       <sync-manager ref="sync" />
       <v-divider class="my-6" />
       <cloud-content-manager ref="lcps" />


### PR DESCRIPTION
HASE bonuses now accept `agility`, `systems`, `engineering` as well as `agi`, `sys`, `eng`. Since something seems wrong with how vue built the `hidden` flag or w/e, just remove the cloud sync settings entirely. If we ever need the code for it back, that's what VCS are for.
