### PR TITLE
fix: include weapon tags and on-hit effects in NPC scan export (#3431)

### DIFF
--- a/src/classes/Statblock.ts
+++ b/src/classes/Statblock.ts
@@ -5,6 +5,7 @@ import { Pilot } from './pilot/Pilot'
 import { Action } from './Action'
 import { NpcWeapon } from './npc/feature/NpcItem/NpcWeapon'
 import { Unit } from './npc/unit/Unit'
+import { ActiveEffect } from './components/feature/active_effects/ActiveEffect'
 
 function linebreak(i: number, length: number): string {
   if (i > 0 && (i + 1) % 2 === 0 && i + 1 !== length) {
@@ -443,6 +444,10 @@ function mapNpcActions(actions: Action[], tier: number): string {
 }
 
 function mapNpcWeaponStats(feature: NpcWeapon, tier: number): string {
+  // Called for every feature; weapon-only details (tags like AP, on-hit/crit
+  // effects) must be skipped for non-weapon features.
+  if (!(feature instanceof NpcWeapon)) return ''
+
   let output = ''
   if (feature.DamageData) {
     feature.Damage(tier).forEach(d => {
@@ -460,11 +465,29 @@ function mapNpcWeaponStats(feature: NpcWeapon, tier: number): string {
   if (feature.AttackBonus && feature.AttackBonus(tier)) {
     output += `${feature.AttackBonus(tier)} Attack Bonus `
   }
-  if (feature.Attacks && feature.Attacks[tier]) {
-    output += `${feature.Attacks[tier]} Attacks/Activation `
+  if (feature.Attacks && feature.Attacks[tier - 1]) {
+    output += `${feature.Attacks[tier - 1]} Attacks/Activation `
   }
 
+  const tags = feature.Tags.filter(t => !t.IsHidden).map(t => t.GetName(0, tier))
+  if (tags.length) output += `\n  ${tags.join(', ')}`
+
+  output += mapNpcWeaponEffect('On Attack', feature.OnAttack, tier)
+  output += mapNpcWeaponEffect('On Hit', feature.OnHit, tier)
+  output += mapNpcWeaponEffect('On Crit', feature.OnCrit, tier)
+  output += mapNpcWeaponEffect('On Miss', feature.OnMiss, tier)
+
   return output
+}
+
+function mapNpcWeaponEffect(
+  label: string,
+  effect: ActiveEffect | undefined,
+  tier: number
+): string {
+  const detail = effect?.getDetail(tier)
+  if (!detail) return ''
+  return `\n  ${label}: ${detail.replace(/<[^>]*>/gi, '')}`
 }
 
 export default Statblock


### PR DESCRIPTION
## Summary
The Active Mode **Scan** export's feature-detail path dropped key NPC weapon details:

- **Weapon tags** were omitted (e.g. Armor Piercing / `tg_ap`), so the Demolisher's Demolition Hammer AP tag never appeared.
- **On Attack / On Hit / On Crit / On Miss** effect text was omitted, so third-party attack descriptions (e.g. Nosferatu's "The Bite") were dropped.
- An **off-by-one** in the per-tier attack-count index reported the wrong "Attacks/Activation" value.
- `mapNpcWeaponStats` was invoked for every feature, including non-weapons.

## Changes
All scoped to `src/classes/Statblock.ts`:

- Guard `mapNpcWeaponStats` with `feature instanceof NpcWeapon` so weapon-only details are skipped for non-weapon features (it's now called via the refactored `getFeatures` path with an `item as NpcWeapon` cast).
- Fix the per-tier attack-count index (`Attacks[tier]` -> `Attacks[tier - 1]`).
- Append non-hidden weapon tags.
- Append On Attack/Hit/Crit/Miss effect text via a small `mapNpcWeaponEffect` helper (HTML stripped, mirroring existing detail formatting).

## Notes
- Rebased onto the latest `dev` (`8b4a83767`); applies cleanly with no conflicts.
- The change integrates with the recent feature-detail refactor (`getFeatures` / `GenerateNPC(..., includeFeatures)`) and improves both the detailed-feature code paths.

## Test plan
- [x] `Statblock.ts` is type-clean (no new `vue-tsc`/`tsc` errors introduced by this change).
- [ ] Manual: Scan-export an NPC with a tagged weapon (e.g. Demolisher's Demolition Hammer) and confirm the AP tag now appears.
- [ ] Manual: Scan-export an NPC with on-hit effect text (e.g. Nosferatu's "The Bite") and confirm the effect text now appears.
- [ ] Manual: Confirm per-tier "Attacks/Activation" matches the selected tier.

Closes #3431

Made with [Cursor](https://cursor.com)