### PR TITLE
fix(i18n): implement i18n locales to Views compendium index and Reference

### DIFF
--- a/src/classes/components/feature/active_effects/_activeEffectUtils.ts
+++ b/src/classes/components/feature/active_effects/_activeEffectUtils.ts
@@ -1,4 +1,5 @@
 import { ActiveEffect, IActiveEffectData } from './ActiveEffect'
+import { keyPrefixes } from '@/i18n/contentKeys'
 
 interface IActiveEffectCallbackData {
   on_miss?: string | IActiveEffectData
@@ -14,29 +15,25 @@ interface IActiveEffectCallbackTarget {
   OnCrit?: ActiveEffect
 }
 
+const mkEffect = (
+  key: string,
+  raw: string | IActiveEffectData | undefined,
+  name: string,
+  owner: any
+): ActiveEffect | undefined => {
+  if (!raw) return undefined
+  const data = typeof raw === 'string' ? { name, detail: raw } : raw
+  keyPrefixes.set(data as object, `${owner.ID}.${key}`)
+  return new ActiveEffect(data, owner, undefined, name)
+}
+
 export function initActiveEffectCallbacks(
   data: IActiveEffectCallbackData,
   target: IActiveEffectCallbackTarget,
   owner: any
 ): void {
-  if (data.on_miss) {
-    if (typeof data.on_miss === 'string')
-      target.OnMiss = new ActiveEffect({ name: 'On Miss Effect', detail: data.on_miss }, owner)
-    else target.OnMiss = new ActiveEffect(data.on_miss, owner)
-  }
-  if (data.on_attack) {
-    if (typeof data.on_attack === 'string')
-      target.OnAttack = new ActiveEffect({ name: 'On Attack Effect', detail: data.on_attack }, owner)
-    else target.OnAttack = new ActiveEffect(data.on_attack, owner)
-  }
-  if (data.on_hit) {
-    if (typeof data.on_hit === 'string')
-      target.OnHit = new ActiveEffect({ name: 'On Hit Effect', detail: data.on_hit }, owner)
-    else target.OnHit = new ActiveEffect(data.on_hit, owner)
-  }
-  if (data.on_crit) {
-    if (typeof data.on_crit === 'string')
-      target.OnCrit = new ActiveEffect({ name: 'On Crit Effect', detail: data.on_crit }, owner)
-    else target.OnCrit = new ActiveEffect(data.on_crit, owner)
-  }
+  target.OnMiss = mkEffect('on_miss', data.on_miss, 'On Miss Effect', owner)
+  target.OnAttack = mkEffect('on_attack', data.on_attack, 'On Attack Effect', owner)
+  target.OnHit = mkEffect('on_hit', data.on_hit, 'On Hit Effect', owner)
+  target.OnCrit = mkEffect('on_crit', data.on_crit, 'On Crit Effect', owner)
 }

--- a/src/features/compendium/Views/Compendium/index.vue
+++ b/src/features/compendium/Views/Compendium/index.vue
@@ -19,56 +19,56 @@
       align="center">
       <compendium-page-button
         icon="cc:manufacturer"
-        name="Manufacturers"
+        :name="$t('compendium.categories.manufacturers')"
         to="/srd/compendium/manufacturers" />
       <compendium-page-button
         color="primary"
         icon="cc:license"
-        name="Licenses"
+        :name="$t('common.licenses')"
         to="/srd/compendium/licenses" />
       <compendium-page-button
         icon="cc:corebonus"
-        name="CORE Bonuses"
+        :name="$t('compendium.titles.coreBonuses')"
         to="/srd/compendium/corebonuses" />
       <compendium-page-button
         color="frame"
         icon="cc:frame"
-        name="Frames"
+        :name="$t('compendium.titles.frames')"
         to="/srd/compendium/frames" />
       <compendium-page-button
         color="weapon"
         icon="cc:melee"
-        name="Mech Weapons"
+        :name="$t('compendium.titles.mechWeapons')"
         to="/srd/compendium/weapons" />
       <compendium-page-button
         color="system"
         icon="mdi-chip"
-        name="Mech Systems"
+        :name="$t('compendium.titles.mechSystems')"
         to="/srd/compendium/systems" />
       <compendium-page-button
         color="secondary"
         icon="cc:pilot"
-        name="Pilot Gear"
+        :name="$t('common.pilotGear')"
         to="/srd/compendium/pilot_gear" />
       <compendium-page-button
         color="secondary"
         icon="cc:orbit"
-        name="Backgrounds"
+        :name="$t('common.background')"
         to="/srd/compendium/backgrounds" />
       <compendium-page-button
         color="secondary"
         icon="cc:accuracy"
-        name="Skill Triggers"
+        :name="$t('compendium.titles.skillTriggers')"
         to="/srd/compendium/skills" />
       <compendium-page-button
         color="secondary"
         icon="cc:rank_3"
-        name="Talents"
+        :name="$t('common.talents')"
         to="/srd/compendium/talents" />
       <compendium-page-button
         color="secondary"
         icon="mdi-vector-link"
-        name="Bonds"
+        :name="$t('compendium.titles.bonds')"
         to="/srd/compendium/bonds" />
     </v-row>
     <cc-icon-divider icon="cc:campaign" class="mb-n4" />
@@ -76,22 +76,22 @@
       <compendium-page-button
         color="error"
         icon="cc:npc_class"
-        name="NPC Classes"
+        :name="$t('compendium.titles.npcClasses')"
         to="/srd/compendium/npc_classes" />
       <compendium-page-button
         color="error"
         icon="cc:npc_feature"
-        name="NPC Features"
+        :name="$t('compendium.titles.npcFeatures')"
         to="/srd/compendium/npc_features" />
       <compendium-page-button
         color="error"
         icon="cc:npc_template"
-        name="NPC Templates"
+        :name="$t('compendium.titles.npcTemplates')"
         to="/srd/compendium/npc_templates" />
       <compendium-page-button
         color="exotic"
         icon="cc:monist"
-        name="Eidolon Layers"
+        :name="$t('compendium.titles.eidolonLayers')"
         to="/srd/compendium/eidolon_layers" />
     </v-row>
   </v-container>

--- a/src/features/compendium/Views/Compendium/index.vue
+++ b/src/features/compendium/Views/Compendium/index.vue
@@ -53,7 +53,7 @@
       <compendium-page-button
         color="secondary"
         icon="cc:orbit"
-        :name="$t('common.background')"
+        :name="$t('compendium.titles.pilotBackgrounds')"
         to="/srd/compendium/backgrounds" />
       <compendium-page-button
         color="secondary"

--- a/src/features/compendium/Views/Reference/index.vue
+++ b/src/features/compendium/Views/Reference/index.vue
@@ -21,47 +21,47 @@
       <compendium-page-button
         color="exotic"
         icon="mdi-search-web"
-        name="Quick Reference"
+        :name="$t('nav.nav.quickReference')"
         to="srd/reference/reference" />
       <compendium-page-button
         color="exotic"
         icon="cc:save"
-        name="Basics"
+        :name="$t('compendium.titles.lancerBasics')"
         to="srd/reference/basics" />
       <compendium-page-button
         color="exotic"
         icon="cc:pilot"
-        name="Pilots"
+        :name="$t('compendium.titles.referencePilots')"
         to="srd/reference/pilots" />
       <compendium-page-button
         color="exotic"
         icon="cc:frame"
-        name="Mechs"
+        :name="$t('compendium.titles.referenceMechs')"
         to="srd/reference/mechs" />
       <compendium-page-button
         color="exotic"
         icon="cc:ammo"
-        name="Combat"
+        :name="$t('compendium.titles.referenceCombat')"
         to="srd/reference/combat" />
       <compendium-page-button
         color="exotic"
         icon="cc:downtime"
-        name="Narrative Play"
+        :name="$t('compendium.titles.referenceNarrativePlay')"
         to="srd/reference/narrative" />
       <compendium-page-button
         color="exotic"
         icon="cc:repair"
-        name="FAQ & Errata"
+        :name="$t('compendium.titles.referenceErrata')"
         to="srd/reference/errata" />
       <compendium-page-button
         color="exotic"
         icon="cc:compendium"
-        name="Glossary"
+        :name="$t('compendium.titles.referenceGlossary')"
         to="srd/reference/glossary" />
       <compendium-page-button
         color="exotic"
         icon="cc:system_point"
-        name="Using COMP/CON"
+        :name="$t('compendium.titles.usingCompcon')"
         to="srd/reference/compcon"
         disabled />
     </v-row>
@@ -70,37 +70,37 @@
     <v-row>
       <compendium-page-button
         icon="cc:reserve_mech"
-        name="Reserves"
+        :name="$t('common.reserves')"
         to="/srd/compendium/reserves" />
       <compendium-page-button
         icon="cc:status_exposed"
-        name="Statuses & Conditions"
+        :name="$t('compendium.titles.statusesConditions')"
         to="/srd/compendium/statuses" />
-      <compendium-page-button icon="mdi-tag" name="Equipment Tags" to="/srd/compendium/tags" />
+      <compendium-page-button icon="mdi-tag" :name="$t('compendium.titles.equipmentTags')" to="/srd/compendium/tags" />
       <compendium-page-button
         color="primary"
         icon="mdi-map"
-        name="Environments"
+        :name="$t('compendium.titles.environments')"
         to="/srd/compendium/environments" />
       <compendium-page-button
         color="primary"
         icon="mdi-timeline-text-outline"
-        name="Sitreps"
+        :name="$t('compendium.titles.sitreps')"
         to="/srd/compendium/sitreps" />
       <compendium-page-button
         color="primary"
         icon="cc:downtime"
-        name="Downtime Actions"
+        :name="$t('compendium.titles.downtimeActions')"
         to="/srd/compendium/downtime" />
       <compendium-page-button
         color="primary"
         icon="mdi-table-multiple"
-        name="Table Browser"
+        :name="$t('common.tables')"
         to="/srd/compendium/tables" />
       <compendium-page-button
         color="primary"
         icon="mdi-list-box-outline"
-        name="List Browser"
+        :name="$t('compendium.titles.lists')"
         to="/srd/compendium/lists" />
     </v-row>
   </v-container>

--- a/src/ui/components/cards/items/_NpcWeaponCard.vue
+++ b/src/ui/components/cards/items/_NpcWeaponCard.vue
@@ -152,7 +152,7 @@
         v-html-safe="`<b>On Miss:&nbsp;</b>${item.OnMiss.Detail}`"
         class="panel text-text py-1" />
       <p v-if="item.OnAttack"
-        v-html-safe="`<b>On Hit:&nbsp;</b>${item.OnAttack.Detail}`"
+        v-html-safe="`<b>${$t('pm.print.onATTACK')}:&nbsp;</b>${item.OnAttack.Detail}`"
         class="panel text-text py-1" />
       <p v-if="item.OnHit"
         v-html-safe="`<b>On Hit:&nbsp;</b>${item.OnHit.Detail}`"

--- a/src/ui/components/cards/items/_components/OnElement.vue
+++ b/src/ui/components/cards/items/_components/OnElement.vue
@@ -4,7 +4,7 @@
     density="compact"
     icon="cc:weapon"
     class="my-1"
-    :title="`On ${namedAction}`">
+    :title="$t(`pm.print.on${action === 'crit' ? 'CRIT' : action.toUpperCase()}`)">
     <div v-html-safe="profile[`On${capitalizeAction}`].Detail" />
   </cc-panel>
 </template>
@@ -18,5 +18,4 @@ const props = defineProps<{
 }>()
 
 const capitalizeAction = computed(() => props.action.charAt(0).toUpperCase() + props.action.slice(1))
-const namedAction = computed(() => props.action === 'crit' ? 'critical hit' : props.action)
 </script>


### PR DESCRIPTION

## Description
Hi, I noticed the Compendium page wasn't translated, so I implemented i18n in the Compendium and Reference views, applying it to the :name= attribute of compendium-page-button.

Closes #

## Type of Change
- New feature (`feat:`)
- 

<!-- Paste before/after screenshots -->
Before
<img width="1794" height="1051" alt="Screenshot_17-7-2026_17053_compcon app" src="https://github.com/user-attachments/assets/bef48e3b-4952-4311-a8c4-538a09424c31" />
<img width="1794" height="951" alt="Screenshot_17-7-2026_17042_compcon app" src="https://github.com/user-attachments/assets/bc4c0ce8-4cf1-4225-9f4b-752f6ec0ead2" />
After
<img width="1794" height="1051" alt="Screenshot_17-7-2026_164241_localhost" src="https://github.com/user-attachments/assets/818d9e09-58a4-4ae5-b9d2-6672e4389db1" />
<img width="1794" height="951" alt="Screenshot_17-7-2026_164227_localhost" src="https://github.com/user-attachments/assets/93f17a3b-ab4a-421d-a08a-49a6c9c7b74e" />
<img width="1794" height="1051" alt="Screenshot_17-7-2026_17334_localhost" src="https://github.com/user-attachments/assets/11c305f0-6a05-4806-917c-d9228cf802f0" />
<img width="1794" height="951" alt="Screenshot_17-7-2026_17319_localhost" src="https://github.com/user-attachments/assets/eb680baa-f287-4b50-99bb-c1ee210d9d43" />
