### PR TITLE
fix(i18n): add utility for active effect callbacks and i18n OnElement

### DIFF
--- a/src/classes/components/feature/active_effects/_activeEffectUtils.ts
+++ b/src/classes/components/feature/active_effects/_activeEffectUtils.ts
@@ -1,4 +1,5 @@
 import { ActiveEffect, IActiveEffectData } from './ActiveEffect'
+import { keyPrefixes } from '@/i18n/contentKeys'
 
 interface IActiveEffectCallbackData {
   on_miss?: string | IActiveEffectData
@@ -14,29 +15,25 @@ interface IActiveEffectCallbackTarget {
   OnCrit?: ActiveEffect
 }
 
+const mkEffect = (
+  key: string,
+  raw: string | IActiveEffectData | undefined,
+  name: string,
+  owner: any
+): ActiveEffect | undefined => {
+  if (!raw) return undefined
+  const data = typeof raw === 'string' ? { name, detail: raw } : raw
+  keyPrefixes.set(data as object, `${owner.ID}.${key}`)
+  return new ActiveEffect(data, owner, undefined, name)
+}
+
 export function initActiveEffectCallbacks(
   data: IActiveEffectCallbackData,
   target: IActiveEffectCallbackTarget,
   owner: any
 ): void {
-  if (data.on_miss) {
-    if (typeof data.on_miss === 'string')
-      target.OnMiss = new ActiveEffect({ name: 'On Miss Effect', detail: data.on_miss }, owner)
-    else target.OnMiss = new ActiveEffect(data.on_miss, owner)
-  }
-  if (data.on_attack) {
-    if (typeof data.on_attack === 'string')
-      target.OnAttack = new ActiveEffect({ name: 'On Attack Effect', detail: data.on_attack }, owner)
-    else target.OnAttack = new ActiveEffect(data.on_attack, owner)
-  }
-  if (data.on_hit) {
-    if (typeof data.on_hit === 'string')
-      target.OnHit = new ActiveEffect({ name: 'On Hit Effect', detail: data.on_hit }, owner)
-    else target.OnHit = new ActiveEffect(data.on_hit, owner)
-  }
-  if (data.on_crit) {
-    if (typeof data.on_crit === 'string')
-      target.OnCrit = new ActiveEffect({ name: 'On Crit Effect', detail: data.on_crit }, owner)
-    else target.OnCrit = new ActiveEffect(data.on_crit, owner)
-  }
+  target.OnMiss = mkEffect('on_miss', data.on_miss, 'On Miss Effect', owner)
+  target.OnAttack = mkEffect('on_attack', data.on_attack, 'On Attack Effect', owner)
+  target.OnHit = mkEffect('on_hit', data.on_hit, 'On Hit Effect', owner)
+  target.OnCrit = mkEffect('on_crit', data.on_crit, 'On Crit Effect', owner)
 }

--- a/src/ui/components/cards/items/_NpcWeaponCard.vue
+++ b/src/ui/components/cards/items/_NpcWeaponCard.vue
@@ -152,7 +152,7 @@
         v-html-safe="`<b>On Miss:&nbsp;</b>${item.OnMiss.Detail}`"
         class="panel text-text py-1" />
       <p v-if="item.OnAttack"
-        v-html-safe="`<b>On Hit:&nbsp;</b>${item.OnAttack.Detail}`"
+        v-html-safe="`<b>${$t('pm.print.onATTACK')}:&nbsp;</b>${item.OnAttack.Detail}`"
         class="panel text-text py-1" />
       <p v-if="item.OnHit"
         v-html-safe="`<b>On Hit:&nbsp;</b>${item.OnHit.Detail}`"

--- a/src/ui/components/cards/items/_components/OnElement.vue
+++ b/src/ui/components/cards/items/_components/OnElement.vue
@@ -4,7 +4,7 @@
     density="compact"
     icon="cc:weapon"
     class="my-1"
-    :title="`On ${namedAction}`">
+    :title="$t(`pm.print.on${action === 'crit' ? 'CRIT' : action.toUpperCase()}`)">
     <div v-html-safe="profile[`On${capitalizeAction}`].Detail" />
   </cc-panel>
 </template>
@@ -18,5 +18,4 @@ const props = defineProps<{
 }>()
 
 const capitalizeAction = computed(() => props.action.charAt(0).toUpperCase() + props.action.slice(1))
-const namedAction = computed(() => props.action === 'crit' ? 'critical hit' : props.action)
 </script>


### PR DESCRIPTION
## Description
This PR refactors the active effect callback initialization logic by introducing a dedicated factory function (mkEffect). It eliminates redundant code, enhances maintainability, and integrates support for dynamic internationalization (i18n) key mapping.

Extracted Factory Function (mkEffect)
Before: The logic to check types (whether the raw data was a string or an IActiveEffectData object) and instantiate ActiveEffect was duplicated 4 times inside initActiveEffectCallbacks.

After: Isolated this logic into a single, reusable mkEffect helper. It standardizes object normalization and safely handles undefined values gracefully with an early return (if (!raw) return undefined).

Added i18n/Localization Support
Integrated keyPrefixes from @/i18n/contentKeys.

Every time an effect is created, it now automatically registers a unique translation key binding the owner's ID with the trigger key (e.g., ${owner.ID}.${key}). This allows the UI to dynamically look up and translate effect details.

3. Cleaned up initActiveEffectCallbacks
Converted the heavily nested if/else blocks into a clean, declarative one-liner per trigger (OnMiss, OnAttack, OnHit, OnCrit), drastically improving readability and adherence to the DRY (Don't Repeat Yourself) principle.

## Type of Change
- New feature (`feat:`)


## Screenshots (if UI change)

<!-- Paste before/after screenshots -->
before
<img width="1794" height="862" alt="Screenshot_17-7-2026_183659_dev compcon app" src="https://github.com/user-attachments/assets/b62aa1bc-6ccf-4302-9738-6f482fb0ae28" />

after 
<img width="1794" height="862" alt="Screenshot_17-7-2026_183514_localhost" src="https://github.com/user-attachments/assets/a8f9b1e5-b80b-47f4-8191-393f36c67fb3" />
