### PR TITLE
fix(i18n): stampContentKeys() not call for @massif/lancer-data

### DIFF
--- a/src/classes/mech/components/equipment/MechEquipment.ts
+++ b/src/classes/mech/components/equipment/MechEquipment.ts
@@ -1,7 +1,7 @@
 import { ITagData } from '@/classes/Tag'
 import { ContentPack } from '../../../ContentPack'
 import { ILicensedItemData, LicensedItem } from '../../../pilot/components/license/LicensedItem'
-import { localizeNested } from '@/i18n/localize'
+import { localize, localizeNested } from '@/i18n/localize'
 
 export interface IEquipmentData {
   id: string
@@ -33,7 +33,10 @@ interface IMechEquipmentData extends ILicensedItemData {
 abstract class MechEquipment extends LicensedItem {
   public IsIntegrated: boolean
   public readonly SP: number
-  public readonly Effect: string
+  public get Effect(): string {
+    return localize(this.ID, 'effect', this._effect)
+  }
+  private _effect: string = ''
   public readonly IsUnique: boolean = false
   public readonly IsLimited: boolean = false
   public readonly IsLoading: boolean = false
@@ -51,7 +54,7 @@ abstract class MechEquipment extends LicensedItem {
   public constructor(data: IMechEquipmentData, pack?: ContentPack) {
     super(data, pack)
     this.SP = parseInt(data.sp as any) || 0
-    this.Effect = data?.effect
+    this._effect = data?.effect
       ? typeof data.effect === 'string'
         ? data.effect
         : (data.effect as any).description

--- a/src/io/Startup.ts
+++ b/src/io/Startup.ts
@@ -13,6 +13,8 @@ import { collectionDataQuery } from '@/user/api'
 import { lt, coerce } from 'semver'
 
 import { Initialize } from './Storage'
+import { lancerData } from '@/features/compendium/store/compendiumUtils'
+import { stampContentKeys } from '@/i18n/contentKeys'
 import { AchievementManager } from '@/user/achievements/AchievementManager'
 import { UnauthorizedError } from '@/io/apis/account'
 import logger from '@/user/logger'
@@ -54,6 +56,8 @@ export default async function (skipSync = false): Promise<void> {
     logger.info('v2 localStorage migration complete', migrationResult)
   }
 
+  logger.info('stamping content keys')
+  stampContentKeys(lancerData)
   logger.info('refreshing extra content')
   await CompendiumStore().refreshExtraContent()
   logger.info('extra content refreshed')


### PR DESCRIPTION
## Description
src/classes/mech/components/equipment/MechEquipment.ts
Issue: MechEquipment.Effect was an instance property (public readonly Effect: string) defined in the constructor using the raw JSON text. This value was never passed through localize(), meaning that effect text for core game weapons, systems, and modifications always appeared in English, regardless of the selected locale.

Solution:
- Effect is no longer an instance property and has been converted into a getter that calls localize(this.ID, 'effect', this._effect).
- The original text is now stored in a private field _effect.
- Added localize to the imports.

src/io/Startup.ts
Issue: The stampContentKeys() function — which iterates over data objects and maps each one to its translation key in the WeakMap<object, string> — was only being called for installed LCPs (ContentPack.ts:147), but never for the core game data (@massif/lancer-data). Without this mapping, classes like WeaponProfile, Action, FrameTrait, Deployable, ActiveEffect, etc., would receive undefined when querying keyPrefixes.get(data). This caused them to generate index-based fallback IDs (e.g., mw_assault_cannon_profile_0) instead of the correct content keys (e.g., mw_assault_cannon.profile_standard). Consequently, localize() looked up the wrong key in the catalog, found nothing, and fell back to English.

Solution: Added stampContentKeys(lancerData) inside the Startup() function, right before CompendiumStore().refreshExtraContent(). This ensures that all core data is properly mapped before any constructor queries keyPrefixes

Closes #

## Type of Change
Bug fix (`fix:`)

## Screenshots (if UI change)
Before
<img width="1794" height="862" alt="Screenshot_17-7-2026_184931_dev compcon app" src="https://github.com/user-attachments/assets/25ea5e31-24d1-4217-909e-4b44b8e226b6" />
<img width="1794" height="862" alt="Screenshot_17-7-2026_18503_dev compcon app" src="https://github.com/user-attachments/assets/724cad15-9d39-443f-9f98-000e23e298ce" />

After
<img width="1794" height="862" alt="Screenshot_17-7-2026_18497_localhost" src="https://github.com/user-attachments/assets/0baf05be-93b3-4ffe-b6ee-1e1cfdf03dc4" />
<img width="1794" height="862" alt="Screenshot_17-7-2026_185025_localhost" src="https://github.com/user-attachments/assets/ffb4cd2c-78eb-4ee3-9704-afeb354f18a0" />


