### PR TITLE
fix(i18n): add localization for frame statblock labels

### DIFF
--- a/src/classes/mech/components/frame/Frame.ts
+++ b/src/classes/mech/components/frame/Frame.ts
@@ -7,6 +7,7 @@ import { ICoreData, CoreSystem } from './CoreSystem'
 import { FrameTrait, IFrameTraitData } from './FrameTrait'
 import { CompendiumStore } from '@/features/compendium/store'
 import { Rules } from '@/classes/utility/Rules'
+import { enumLabel } from '@/i18n/enumLabel'
 
 interface IFrameStats {
   size: number
@@ -84,8 +85,8 @@ class Frame extends LicensedItem implements IFeatureContainer {
   }
 
   public get MechTypeString(): string {
-    if (this.MechType.length === 1) return this.MechType[0]
-    return `${this.MechType[0]} / ${this.MechType[1]}`
+    if (!this.MechType || this.MechType.length === 0) return ''
+    return this.MechType.map(t => enumLabel('mechType', t)).join(' / ')
   }
 
   public get Stats(): IFrameStats {

--- a/src/features/pilot_management/New/components/TemplateItem.vue
+++ b/src/features/pilot_management/New/components/TemplateItem.vue
@@ -100,7 +100,7 @@
           </div>
           <v-row dense justify="center" class="px-2 text-center">
             <v-col v-for="(m, index) in template.build.mech.mounts" :key="`mount-${index}`">
-              <div class="flavor-text text-stark text-center">{{ m.mount_type }} {{ $t('common.mount') }}</div>
+              <div class="flavor-text text-stark text-center">{{ $t('enums.mountType.' + slug(m.mount_type)) }} {{ $t('common.mount') }}</div>
               <v-row dense>
                 <v-col v-for="(w, index) in m.slots" :key="`slot-${index}`" class="text-center">
                   <cc-item-modal class="mx-1" :item="item('MechWeapons', w)" />
@@ -138,6 +138,7 @@
 import { computed, ref } from 'vue'
 import { CompendiumStore } from '@/stores';
 import { useDisplay } from 'vuetify';
+import { slug } from '@/i18n/contentKeys.mjs';
 
 defineOptions({ name: 'template-item' })
 

--- a/src/ui/components/cards/frame/_FrameStatblockItem.vue
+++ b/src/ui/components/cards/frame/_FrameStatblockItem.vue
@@ -18,13 +18,13 @@
                 start
                 size="40" />
             </template>
-            <div class="heading h3">{{ name }}</div>
+            <div class="heading h3">{{ displayName }}</div>
             <v-divider class="my-2" />
             <div v-html-safe="glossary" />
           </v-tooltip>
         </v-col>
         <v-col class="heading h3">
-          <span>{{ name }}</span>
+          <span>{{ displayName }}</span>
           <div v-if="isNaN(Number(value)) && value !== '½'"
             class="text-accent"
             style="font-size: 16px;">
@@ -48,7 +48,9 @@ import { computed } from 'vue'
 import { useDisplay } from 'vuetify'
 import { glossary as glossaryData } from '@massif/lancer-data'
 import { isArray } from 'lodash-es'
+import { useI18n } from 'vue-i18n'
 
+const { t, te } = useI18n()
 const { xs, smAndDown } = useDisplay()
 
 const props = withDefaults(defineProps<{
@@ -68,6 +70,28 @@ const props = withDefaults(defineProps<{
 const portrait = computed(() => xs.value)
 const isInline = computed(() => props.inline || smAndDown.value)
 const isArrayVal = computed(() => isArray(props.value))
+
+const statKeyMap: Record<string, string> = {
+  Structure: 'stats.structure',
+  HP: 'stats.hp',
+  Armor: 'stats.armor',
+  Stress: 'stats.stress',
+  'Heat Capacity': 'ui.titles.heatCapacity',
+  Evasion: 'stats.evasion',
+  Speed: 'stats.speed',
+  'E-Defense': 'stats.edefense',
+  'Tech Attack': 'common.techAttack',
+  Sensors: 'stats.sensors',
+  'Repair Capacity': 'ui.titles.repairCapacity',
+  'Save Target': 'ui.titles.saveTarget',
+  'System Points': 'common.systemPoints',
+}
+
+const displayName = computed(() => {
+  const key = statKeyMap[props.name]
+  return key && te(key) ? t(key) : props.name
+})
+
 const glossary = computed(() => {
   let name = props.name.toLowerCase()
   if (name === 'e-def') name = 'e-defense'

--- a/src/ui/components/cards/items/_FrameCard.vue
+++ b/src/ui/components/cards/items/_FrameCard.vue
@@ -2,7 +2,7 @@
   <v-row dense
     align="center">
     <v-col>
-      <div class="heading h2">{{ item.Source }} {{ item.MechTypeString }} {{ $t('common.frame') }}
+      <div class="heading h2">{{ item.Source }} {{ $t('compendium.content.frameSuffix', { type: item.MechTypeString }) }}
       </div>
       <div v-if="item.Variant"
         class="heading h4 text-accent">{{ item.Variant }} {{ $t('ui.card.variantFrame') }}</div>
@@ -13,7 +13,7 @@
         <div class="heading h3"><span class="text-uppercase">{{ $t('ui.fields.size') }}</span> {{ item.Size === 0.5 ? '½' : item.Size }}
         </div>
         <v-divider class="my-1" />
-        {{ glossary('size') }}
+        <div v-html-safe="glossary('size')" />
       </cc-tooltip>
     </v-col>
   </v-row>
@@ -62,8 +62,7 @@
             class="clipped"
             tile
             v-bind:="props">
-            <v-card-text class="heading h3 px-8 text-uppercase">{{ m }} {{ $t('common.mount')
-              }}</v-card-text>
+            <v-card-text class="heading h3 px-8 text-uppercase">{{ mountLabel(m) }}</v-card-text>
           </v-card>
         </template>
         <p v-html-safe="get_mount_tooltip(m)" />
@@ -80,8 +79,32 @@ import { computed } from 'vue'
 import { useDisplay } from 'vuetify'
 import { FrameCombatChart } from '../frame'
 import { glossary as glossaryData } from '@massif/lancer-data'
+import { useI18n } from 'vue-i18n'
+import { slug } from '@/i18n/contentKeys.mjs'
+import { localize } from '@/i18n/localize'
 
+const { t, te } = useI18n()
 const { smAndDown: mobile } = useDisplay()
+
+const mountSrdKeyMap: Record<string, string> = {
+  Main: 'mechs_2_3_0',
+  Heavy: 'mechs_2_3_1',
+  'Aux/Aux': 'mechs_2_3_2',
+  'Main/Aux': 'mechs_2_3_3',
+  Flex: 'mechs_2_3_4',
+  Integrated: 'mechs_2_3_5',
+}
+
+function mountLabel(m: string) {
+  const srdKey = mountSrdKeyMap[m]
+  if (srdKey) {
+    const title = localize(srdKey, 'title', '')
+    if (title) return title
+  }
+  const key = `enums.mountType.${slug(m)}`
+  const mountTypeName = te(key) ? t(key) : m
+  return `${mountTypeName} ${t('common.mount')}`
+}
 
 const props = defineProps<{
   item: Record<string, any>
@@ -96,10 +119,21 @@ const props = defineProps<{
 const mColor = computed(() => props.item.ManufacturerColor)
 
 function glossary(name: string) {
-  return glossaryData.find((x) => x.name.toLowerCase() === name.toLowerCase())!.description
+  if (name.toLowerCase() === 'size') {
+    const localizedSize = localize('mechs_2_1', 'content', '')
+    if (localizedSize) return localizedSize
+  }
+  const n = glossaryData.find((x) => x.name.toLowerCase() === name.toLowerCase())
+  return n ? n.description : ''
 }
 
 function get_mount_tooltip(mount_type: string) {
+  const srdKey = mountSrdKeyMap[mount_type]
+  if (srdKey) {
+    const content = localize(srdKey, 'content', '')
+    if (content) return content
+  }
+
   const mount_tooltips: Record<string, string> = {
     Heavy: 'Holds one <b>HEAVY</b>, <b>MAIN</b>, or <b>AUXILIARY</b> weapon',
     Main: 'Holds one <b>MAIN</b> or <b>AUXILIARY</b> weapon',


### PR DESCRIPTION
## Summary

This PR adds internationalization (i18n) support for frame statblock labels, replacing hardcoded English strings with translatable content while keeping safe fallbacks so nothing breaks when a translation is missing.

## Changes

### `Frame.ts`
- `MechTypeString` now localizes each mech type via `enumLabel('mechType', t)` instead of returning the raw value.
- Added a guard for empty/undefined `MechType`, returning an empty string.

### `TemplateItem.vue`
- Mount type (`m.mount_type`) is now translated via `$t('enums.mountType.' + slug(...))` instead of displaying the raw value.

### `_FrameStatblockItem.vue`
- Added `statKeyMap` mapping English stat names (Structure, HP, Armor, etc.) to translation keys.
- New `displayName` computed uses the translation when it exists (`te`/`t`), falling back to the original name.
- Replaced `name` with `displayName` in the template.

### `_FrameCard.vue`
- Frame title now uses the translation key `compendium.content.frameSuffix`.
- "Size" tooltip and mount labels now come from localized SRD data (`mountSrdKeyMap` + `localize`), with fallbacks.
- `glossary('size')` is now rendered with `v-html-safe` to allow HTML.
- `glossary` and `get_mount_tooltip` gained safe fallbacks to avoid errors when no matching data is found.

## Notes
All changes preserve fallbacks to the original English text, so behavior is unchanged when translations are unavailable.

Closes #

## Type of Change
- [ ] Bug fix (`fix:`)

## Screenshots (if UI change)
before
<img width="1794" height="862" alt="Screenshot_18-7-2026_05055_dev compcon app" src="https://github.com/user-attachments/assets/36724d1e-461d-4585-ab40-e163310d9c10" />
<!-- Paste before/after screenshots -->
after 
<img width="1794" height="862" alt="Screenshot_18-7-2026_0514_localhost" src="https://github.com/user-attachments/assets/b310583d-903d-4a28-9fc9-6b999be8eb83" />
