### PR TITLE
fix(i18n): localize talent rank names and descriptions

### DIFF
--- a/src/classes/pilot/components/talent/Talent.ts
+++ b/src/classes/pilot/components/talent/Talent.ts
@@ -4,7 +4,7 @@ import { CompendiumItem, ICompendiumItemData } from '../../../CompendiumItem'
 import { Deployable } from '../../../components/feature/deployable/Deployable'
 import { ContentPack } from '../../../ContentPack'
 import { ItemType } from '../../../enums'
-import { keyPrefixes } from '@/i18n/contentKeys'
+import { keyPrefixes, slug } from '@/i18n/contentKeys'
 import DOMPurify from 'dompurify'
 
 interface ITalentRankData extends ICompendiumItemData {
@@ -21,8 +21,11 @@ interface ITalentData extends ICompendiumItemData {
 class TalentRank extends CompendiumItem {
   public readonly Exclusive: boolean
 
-  public constructor(data: ITalentRankData) {
-    const lkey = keyPrefixes.get(data as object)
+  public constructor(data: ITalentRankData, parentId?: string) {
+    let lkey = keyPrefixes.get(data as object)
+    if (!lkey && parentId && data.name) {
+      lkey = `${parentId}.rank_${slug(data.name)}`
+    }
     super(lkey ? { ...data, id: lkey } : data)
     this.Exclusive = data.exclusive
   }
@@ -39,7 +42,7 @@ class Talent extends CompendiumItem {
     this.Terse = data.terse || ''
     this._icon_url = data.icon_url || ''
     this._icon_svg = data.icon_svg ? DOMPurify.sanitize(data.icon_svg) : ''
-    this._ranks = data.ranks.map(x => new TalentRank(x))
+    this._ranks = data.ranks.map(x => new TalentRank(x, this.ID))
     this.ItemType = ItemType.Talent
   }
 


### PR DESCRIPTION
## Summary

This PR adds internationalization (i18n) support for talent rank names and descriptions. Previously, talent ranks could not resolve a localization key when one wasn't explicitly present in the content data, so they fell back to raw English text.

## Changes

### `Talent.ts`
- Imported `slug` alongside `keyPrefixes` from `@/i18n/contentKeys`.
- `TalentRank` constructor now accepts an optional `parentId` parameter. When no localization key is found for the rank, it derives one from the parent talent's ID and the rank name: `${parentId}.rank_${slug(data.name)}`.
- `Talent` now passes its own ID (`this.ID`) when constructing each `TalentRank`, enabling ranks to build their localization keys.

## Notes
The change preserves existing behavior when a localization key is already present, only adding a fallback key derivation for ranks that lack one.

## Type of Change
- [ ] Bug fix (`fix:`)

## Screenshots (if UI change)
before
<img width="1794" height="862" alt="Screenshot_18-7-2026_05456_localhost" src="https://github.com/user-attachments/assets/bada38dc-b137-41df-a0b5-efcc33b774ec" />
<!-- Paste before/after screenshots -->
after 
<img width="1794" height="862" alt="Screenshot_18-7-2026_05540_localhost" src="https://github.com/user-attachments/assets/028043f1-d36d-4dff-9467-45cc21dfd20d" />
