### PR TITLE
fix: implement PilotLoadout and Skill classes for pilot data management

### DIFF
--- a/src/classes/pilot/components/Loadout/PilotLoadout.ts
+++ b/src/classes/pilot/components/Loadout/PilotLoadout.ts
@@ -7,6 +7,7 @@ import { PilotWeapon } from './equipment/PilotWeapon'
 import Tag from '../../../Tag'
 import { PilotLoadoutController } from './PilotLoadoutController'
 import { IEquipmentData } from '@/classes/mech/components/equipment/MechEquipment'
+import { i18n } from '@/i18n'
 
 declare interface IPilotLoadoutData {
   name: string
@@ -36,6 +37,7 @@ class PilotLoadout {
   }
 
   public get Name(): string {
+    if (this._name === 'Default Loadout') return i18n.global.t('common.loadout')
     return this._name
   }
   public set Name(name: string) {

--- a/src/classes/pilot/components/skill/Skill.ts
+++ b/src/classes/pilot/components/skill/Skill.ts
@@ -2,6 +2,7 @@ import { CompendiumStore } from '../../../../stores'
 import { CompendiumItem, ICompendiumItemData } from '../../../CompendiumItem'
 import { ContentPack } from '../../../ContentPack'
 import { SkillFamily, ItemType } from '../../../enums'
+import { localize } from '@/i18n/localize'
 
 interface ISkillData extends ICompendiumItemData {
   detail: string
@@ -21,7 +22,7 @@ class Skill extends CompendiumItem {
   }
 
   public get Trigger(): string {
-    return this._name
+    return localize(this.ID, 'name', this._name)
   }
 
   public get Color(): string {


### PR DESCRIPTION
## Summary

This PR adds internationalization (i18n) support for pilot loadout names and pilot skill triggers, replacing hardcoded English strings with localized values while keeping fallbacks to the original text.

## Changes

### `PilotLoadout.ts`
- Imported the `i18n` instance.
- `Name` getter now returns the localized `common.loadout` string when the loadout name is the default (`'Default Loadout'`), otherwise returns the custom name unchanged.

### `Skill.ts`
- Imported `localize` from `@/i18n/localize`.
- `Trigger` getter now returns the localized skill name via `localize(this.ID, 'name', this._name)`, falling back to the raw name when no translation exists.

## Notes
Custom loadout names are preserved; only the default loadout name is localized. Skill triggers fall back to the original English text when a translation is unavailable.

## Type of Change

- [ ] Bug fix (`fix:`)

## Screenshots (if UI change)
before
<img width="1794" height="596" alt="Screenshot_18-7-2026_146_dev compcon app" src="https://github.com/user-attachments/assets/99a76737-6ec0-4c38-b072-5e70a7a36f29" />
<!-- Paste before/after screenshots -->
after 
<img width="1794" height="425" alt="Screenshot_18-7-2026_1522_localhost" src="https://github.com/user-attachments/assets/16817958-cede-41d7-a3b7-1f97aae9f340" />
