### PR TITLE
fix(i18n): translate pilot armor stat labels via translation keys

### DIFF
--- a/src/ui/components/cards/items/_PilotArmorCard.vue
+++ b/src/ui/components/cards/items/_PilotArmorCard.vue
@@ -10,19 +10,19 @@
       <v-row dense
         justify="center">
         <cc-statblock-panel icon="mdi-shield"
-          name="Armor"
+          :name="$t('stats.armor')"
           :value="item.ArmorString" />
         <cc-statblock-panel icon="mdi-heart"
-          name="HP Bonus"
+          :name="$t('common.hpBonus')"
           :value="`+${item.HpString}`" />
         <cc-statblock-panel icon="cc:edef"
-          name="E-Defense"
+          :name="$t('stats.edefense')"
           :value="item.EdefString" />
         <cc-statblock-panel icon="cc:evasion"
-          name="Evasion"
+          :name="$t('stats.evasion')"
           :value="item.EvasionString" />
         <cc-statblock-panel icon="mdi-arrow-right-bold-hexagon-outline"
-          name="Speed"
+          :name="$t('stats.speed')"
           :value="item.SpeedString" />
       </v-row>
     </template>


### PR DESCRIPTION
## Summary

This PR localizes the stat labels on the pilot armor card, replacing hardcoded English strings with translation keys.

## Changes

### `_PilotArmorCard.vue`
Replaced hardcoded `name` props on the statblock panels with translation keys:
- `"Armor"` → `$t('stats.armor')`
- `"HP Bonus"` → `$t('common.hpBonus')`
- `"E-Defense"` → `$t('stats.edefense')`
- `"Evasion"` → `$t('stats.evasion')`
- `"Speed"` → `$t('stats.speed')`

## Notes
Purely a localization change; stat values and layout are unchanged.

- [ ] Bug fix (`fix:`)

## Screenshots (if UI change)
before
<img width="1794" height="862" alt="Screenshot_18-7-2026_1849_dev compcon app" src="https://github.com/user-attachments/assets/af8c8c36-2ede-49e3-b243-cc580f64880c" />
<!-- Paste before/after screenshots -->
after 
<img width="1794" height="862" alt="Screenshot_18-7-2026_1839_localhost" src="https://github.com/user-attachments/assets/f8f4aa9a-8f99-4036-b76b-7a6c9bede470" />
