### PR TITLE
fix: setFolder and setData add all Npcs

### DIFF
--- a/src/features/gm/_components/Organizer.vue
+++ b/src/features/gm/_components/Organizer.vue
@@ -1,19 +1,29 @@
 <template>
-  <cc-organizer :items="items"
-    :headers="headers">
+  <cc-organizer
+    :items="items"
+    :headers="headers"
+  >
     <template #filters>
-      <v-row align="center"
-        dense>
+      <v-row
+        align="center"
+        dense
+      >
         <v-col cols="1"><v-divider /></v-col>
         <v-col cols="auto">
           <div class="heading h3">
-            <v-btn-toggle v-model="shownTypes"
+            <v-btn-toggle
+              v-model="shownTypes"
               density="compact"
-              multiple>
-              <v-btn v-for="t in allTypes"
+              multiple
+            >
+              <v-btn
+                v-for="t in allTypes"
                 :key="t"
                 size="small"
-                :value="t">{{ t }}</v-btn>
+                :value="t"
+              >
+                {{ t }}
+              </v-btn>
             </v-btn-toggle>
           </div>
         </v-col>
@@ -27,54 +37,86 @@
     </template>
 
     <template #item.folder="{ item }">
-      <v-chip v-if="(item as any).FolderController.Folder"
+      <v-chip
+        v-if="(item as any).FolderController.Folder"
         size="x-small"
         label
-        prepend-icon="mdi-folder">
+        prepend-icon="mdi-folder"
+      >
         {{ (item as any).FolderController.Folder }}
       </v-chip>
     </template>
 
     <template #item.labels="{ item }">
-      <cc-split-chip v-for="(label, li) in (item as any).NarrativeController.Labels"
+      <cc-split-chip
+        v-for="(label, li) in (item as any).NarrativeController.Labels"
         :key="`label-${li}`"
         :label="label"
-        class="mr-1 mb-1" />
+        class="mr-1 mb-1"
+      />
     </template>
 
-    <template #actions="{ selected, items, showDeleted, clearSelected, showDeleteConfirm, setShowDeleteConfirm }">
-      <v-list-item :title="$t('gm.folder.setFolder')"
+    <template
+      #actions="{
+        selected,
+        items,
+        showDeleted,
+        clearSelected,
+        showDeleteConfirm,
+        setShowDeleteConfirm,
+      }"
+    >
+      <v-list-item
+        :title="$t('gm.folder.setFolder')"
         :subtitle="$t('gm.subtitles.setItemFolder')"
         prepend-icon="mdi-folder"
         :disabled="!selected.length"
-        @click="($refs.folderDialog as any).open()" />
-      <v-list-item :title="$t('gm.titles.setGmLabel')"
+        @click="openFolderDialog(selected, clearSelected)"
+      />
+      <v-list-item
+        :title="$t('gm.titles.setGmLabel')"
         :subtitle="$t('gm.subtitles.addSetOrDeleteA')"
         prepend-icon="mdi-label"
         :disabled="!selected.length"
-        @click="($refs.labelDialog as any).open()" />
-      <v-list-item :title="selected.length < 2 ? 'Print' : 'Print Multiple'"
+        @click="openLabelDialog(selected, clearSelected)"
+      />
+      <v-list-item
+        :title="selected.length < 2 ? 'Print' : 'Print Multiple'"
         :subtitle="$t('gm.subtitles.generateItemPrintables')"
         prepend-icon="mdi-printer"
         :disabled="!selected.length"
-        @click="routePrint(selected)" />
-      <v-list-item :title="selected.length < 2 ? 'Export' : 'Export Collection'"
-        :subtitle="selected.length < 2 ? 'Export item JSON' : 'Generate a multi-item export package'"
+        @click="routePrint(selected)"
+      />
+      <v-list-item
+        :title="selected.length < 2 ? 'Export' : 'Export Collection'"
+        :subtitle="
+          selected.length < 2 ? 'Export item JSON' : 'Generate a multi-item export package'
+        "
         prepend-icon="mdi-upload"
         :disabled="!selected.length"
-        @click="exportItems(selected, items)" />
-      <v-list-item :title="selected.length < 2 ? 'Delete' : 'Delete Multiple'"
+        @click="exportItems(selected, items)"
+      />
+      <v-list-item
+        :title="selected.length < 2 ? 'Delete' : 'Delete Multiple'"
         :subtitle="selected.length < 2 ? 'Mark item as Deleted' : 'Mark multiple items as Deleted'"
         prepend-icon="mdi-delete"
         :disabled="!selected.length"
-        @click="deleteItems(selected, items, false, clearSelected)" />
-      <v-list-item v-if="showDeleted"
+        @click="deleteItems(selected, items, false, clearSelected)"
+      />
+      <v-list-item
+        v-if="showDeleted"
         :title="selected.length < 2 ? 'Restore' : 'Restore Multiple'"
-        :subtitle="selected.length < 2 ? 'Remove Deleted status from item' : 'Remove Deleted status from items'"
+        :subtitle="
+          selected.length < 2
+            ? 'Remove Deleted status from item'
+            : 'Remove Deleted status from items'
+        "
         prepend-icon="mdi-file-restore-outline"
         :disabled="!selected.length"
-        @click="deleteItems(selected, items, true, clearSelected)" />
-      <v-list-item v-if="showDeleted && !showDeleteConfirm"
+        @click="deleteItems(selected, items, true, clearSelected)"
+      />
+      <v-list-item
+        v-if="showDeleted && !showDeleteConfirm"
         :title="$t('common.deletePermanently')"
         variant="elevated"
         elevation="0"
@@ -82,150 +124,214 @@
         prepend-icon="mdi-delete-forever-outline"
         base-color="warning"
         :disabled="!selected.length"
-        @click="setShowDeleteConfirm(true)" />
+        @click="setShowDeleteConfirm(true)"
+      />
       <v-divider v-if="showDeleteConfirm" />
-      <v-list-item v-if="showDeleteConfirm"
+      <v-list-item
+        v-if="showDeleteConfirm"
         :title="$t('common.confirmPermanentDeletion')"
         :subtitle="$t('common.actionCannotBeUndone')"
         prepend-icon="mdi-exclamation-thick"
         :disabled="!selected.length"
+        base-color="error"
         @click="deleteItemsPermanent(selected, items, clearSelected, setShowDeleteConfirm)"
-        base-color="error" />
-      <v-list-item v-if="showDeleteConfirm"
+      />
+      <v-list-item
+        v-if="showDeleteConfirm"
         :title="$t('common.cancelPermanentDeletion')"
         prepend-icon="mdi-cancel"
+        base-color="accent"
         @click="setShowDeleteConfirm(false)"
-        base-color="accent" />
+      />
     </template>
 
     <template #dialogs>
-      <folder-dialog ref="folderDialog"
+      <folder-dialog
+        ref="folderDialog"
         :folders="allFolders"
-        @confirm="setFolder($event)" />
-      <label-dialog ref="labelDialog"
+        @confirm="setFolder($event)"
+      />
+      <label-dialog
+        ref="labelDialog"
         :all-labels="allLabels"
         :selected-labels="selectedLabels"
-        @confirm="setData('label', $event)" />
+        @confirm="setData('label', $event)"
+      />
     </template>
   </cc-organizer>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { IStatContainer } from '@/classes/components/combat/stats/IStatContainer'
-import { uniqBy } from 'lodash-es'
-import { NarrativeStore } from '../store/narrative_store'
-import { NpcStore } from '../store/npc_store'
-import exportAsJson from '@/util/jsonExport'
-import { EncounterStore } from '@/stores'
-import { DeleteItemPermanent, GenerateExportCollection } from '@/io/Importer'
-import FolderDialog from './_subcomponents/FolderDialog.vue'
-import LabelDialog from './_subcomponents/LabelDialog.vue'
-import { useI18n } from 'vue-i18n'
-const { t } = useI18n()
+  import { computed, ref } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { IStatContainer } from '@/classes/components/combat/stats/IStatContainer'
+  import { uniqBy } from 'lodash-es'
+  import { NarrativeStore } from '../store/narrative_store'
+  import { NpcStore } from '../store/npc_store'
+  import exportAsJson from '@/util/jsonExport'
+  import { EncounterStore } from '@/stores'
+  import { DeleteItemPermanent, GenerateExportCollection } from '@/io/Importer'
+  import FolderDialog from './_subcomponents/FolderDialog.vue'
+  import LabelDialog from './_subcomponents/LabelDialog.vue'
+  import { useI18n } from 'vue-i18n'
+  const { t } = useI18n()
 
-const router = useRouter()
+  const router = useRouter()
 
-const props = defineProps<{
-  type: string
-}>()
+  const props = defineProps<{
+    type: string
+  }>()
 
-const folderDialog = ref<any>(null)
-const labelDialog = ref<any>(null)
-const allTypes = ref(
-  props.type === 'npc'
-    ? ['unit', 'doodad', 'eidolon']
-    : props.type === 'narrative'
-      ? ['character', 'location', 'faction']
-      : ['encounter']
-)
-const shownTypes = ref([...allTypes.value])
+  const folderDialog = ref<any>(null)
+  const labelDialog = ref<any>(null)
+  const stagedSelected = ref<string[]>([])
+  const stagedClearSelected = ref<(() => void) | null>(null)
 
-const headers = ref([
-  { title: 'Name', key: 'Name', sortable: true },
-  { title: t('gm.titles.folder'), key: 'folder', sortable: true, value: (item: any) => item.FolderController?.Folder || '' },
-  { title: t('gm.titles.gmLabels'), key: 'labels', sortable: true, value: (item: any) => item.NarrativeController?.Labels?.map((l: any) => l.title).join(', ') || '' },
-])
+  function openFolderDialog(selected: string[], clearSel?: () => void) {
+    stagedSelected.value = [...selected]
+    stagedClearSelected.value = clearSel || null
+    folderDialog.value?.open()
+  }
 
-const items = computed(() => {
-  let all = [] as any[]
-  if (props.type === 'npc') all = NpcStore().Npcs
-  else if (props.type === 'narrative') all = NarrativeStore().CollectionItems
-  else if (props.type === 'encounter') all = EncounterStore().Encounters
-  return all.filter((x: any) => shownTypes.value.includes(x.ItemType.toLowerCase()))
-})
+  function openLabelDialog(selected: string[], clearSel?: () => void) {
+    stagedSelected.value = [...selected]
+    stagedClearSelected.value = clearSel || null
+    labelDialog.value?.open()
+  }
 
-const allFolders = computed(() => [
-  ...NpcStore().getFolders,
-  ...EncounterStore().getFolders,
-  ...NarrativeStore().getFolders,
-])
-
-const allLabels = computed(() => NarrativeStore().getAllLabels)
-
-const selectedLabels = computed(() =>
-  uniqBy(
-    items.value.flatMap((x: any) => x.NarrativeController?.Labels || []),
-    'title'
+  const allTypes = ref(
+    props.type === 'npc'
+      ? ['unit', 'doodad', 'eidolon']
+      : props.type === 'narrative'
+        ? ['character', 'location', 'faction']
+        : ['encounter']
   )
-)
+  const shownTypes = ref([...allTypes.value])
 
-function setData(_prop: string, payload: any) {
-  const op = typeof payload === 'string' ? payload : payload.op
-  const kvpKey = typeof payload === 'string' ? '' : payload.key
-  const kvpValue = typeof payload === 'string' ? '' : payload.value
-  items.value.forEach((item: any) => {
-    const key = kvpKey?.title ? kvpKey.title : kvpKey
-    const val = kvpKey?.value ? kvpKey.value : kvpValue
-    if (op === 'set') item.NarrativeController.Labels.push({ title: key, value: val })
-    if (op === 'delete')
-      item.NarrativeController.Labels = item.NarrativeController.Labels.filter((x: any) => x.title !== key)
+  const headers = ref([
+    { title: 'Name', key: 'Name', sortable: true },
+    {
+      title: t('gm.titles.folder'),
+      key: 'folder',
+      sortable: true,
+      value: (item: any) => item.FolderController?.Folder || '',
+    },
+    {
+      title: t('gm.titles.gmLabels'),
+      key: 'labels',
+      sortable: true,
+      value: (item: any) =>
+        item.NarrativeController?.Labels?.map((l: any) => l.title).join(', ') || '',
+    },
+  ])
+
+  const items = computed(() => {
+    let all = [] as any[]
+    if (props.type === 'npc') all = NpcStore().Npcs
+    else if (props.type === 'narrative') all = NarrativeStore().CollectionItems
+    else if (props.type === 'encounter') all = EncounterStore().Encounters
+    return all.filter((x: any) => shownTypes.value.includes(x.ItemType.toLowerCase()))
   })
-  NarrativeStore().SaveItemData()
-  NpcStore().SaveNpcData()
-}
 
-function setFolder(folderName: string) {
-  items.value.forEach((item: any) => {
-    item.FolderController.Folder = folderName
+  const allFolders = computed(() => [
+    ...NpcStore().getFolders,
+    ...EncounterStore().getFolders,
+    ...NarrativeStore().getFolders,
+  ])
+
+  const allLabels = computed(() => NarrativeStore().getAllLabels)
+
+  const selectedLabels = computed(() => {
+    const targetIds = new Set(stagedSelected.value)
+    const targets = items.value.filter((x: any) => targetIds.has(x.ID))
+    return uniqBy(
+      targets.flatMap((x: any) => x.NarrativeController?.Labels || []),
+      'title'
+    )
   })
-  NarrativeStore().SaveItemData()
-  NpcStore().SaveNpcData()
-}
 
-function exportItems(selected: string[], allItems: any[]) {
-  const selectedItems = selected.map((x) => allItems.find((y) => y.ID === x))
-  const json = GenerateExportCollection(selectedItems, props.type)
-  const filename = selected.length === 1
-    ? allItems.find((x: any) => x.ID === selected[0]).Name
-    : `GM_export_${new Date().toLocaleDateString().replaceAll('/', '-')}.json`
-  exportAsJson(json, filename)
-}
+  function setData(_prop: string, payload: any) {
+    const op = typeof payload === 'string' ? payload : payload.op
+    const kvpKey = typeof payload === 'string' ? '' : payload.key
+    const kvpValue = typeof payload === 'string' ? '' : payload.value
+    const targetIds = new Set(stagedSelected.value)
+    items.value
+      .filter((item: any) => targetIds.has(item.ID))
+      .forEach((item: any) => {
+        if (!item.NarrativeController) return
+        if (!item.NarrativeController.Labels) item.NarrativeController.Labels = []
+        const key = kvpKey?.title ? kvpKey.title : kvpKey
+        const val = kvpKey?.value ? kvpKey.value : kvpValue
+        if (op === 'set') item.NarrativeController.Labels.push({ title: key, value: val })
+        if (op === 'delete')
+          item.NarrativeController.Labels = item.NarrativeController.Labels.filter(
+            (x: any) => x.title !== key
+          )
+      })
+    NarrativeStore().SaveItemData()
+    NpcStore().SaveNpcData()
+    if (stagedClearSelected.value) stagedClearSelected.value()
+  }
 
-function deleteItems(selected: string[], allItems: any[], undelete: boolean, clearSelected: () => void) {
-  selected.forEach((id) => {
-    const item = allItems.find((x: any) => x.ID === id) as any
-    if (item) {
-      if (undelete) item.SaveController.Restore()
-      else item.SaveController.Delete()
-    }
-  })
-  clearSelected()
-  NarrativeStore().SaveItemData()
-  NpcStore().SaveNpcData()
-  EncounterStore().SaveEncounterData()
-}
+  function setFolder(folderName: string) {
+    const targetIds = new Set(stagedSelected.value)
+    items.value
+      .filter((item: any) => targetIds.has(item.ID))
+      .forEach((item: any) => {
+        if (item.FolderController) {
+          item.FolderController.Folder = folderName
+        }
+      })
+    NarrativeStore().SaveItemData()
+    NpcStore().SaveNpcData()
+    EncounterStore().SaveEncounterData()
+    if (stagedClearSelected.value) stagedClearSelected.value()
+  }
 
-async function deleteItemsPermanent(selected: string[], allItems: any[], clearSelected: () => void, setShowDeleteConfirm: (v: boolean) => void) {
-  await Promise.all(selected.map((id) => DeleteItemPermanent(allItems.find((x: any) => x.ID === id))))
-  clearSelected()
-  setShowDeleteConfirm(false)
-}
+  function exportItems(selected: string[], allItems: any[]) {
+    const selectedItems = selected.map(x => allItems.find(y => y.ID === x))
+    const json = GenerateExportCollection(selectedItems, props.type)
+    const filename =
+      selected.length === 1
+        ? allItems.find((x: any) => x.ID === selected[0]).Name
+        : `GM_export_${new Date().toLocaleDateString().replaceAll('/', '-')}.json`
+    exportAsJson(json, filename)
+  }
 
-function routePrint(selected: string[]) {
-  if (props.type === 'narrative')
-    router.push(`/gm/print/narrative/${JSON.stringify(selected)}`)
-  else router.push(`/gm/print/${JSON.stringify(selected)}`)
-}
+  function deleteItems(
+    selected: string[],
+    allItems: any[],
+    undelete: boolean,
+    clearSelected: () => void
+  ) {
+    selected.forEach(id => {
+      const item = allItems.find((x: any) => x.ID === id) as any
+      if (item) {
+        if (undelete) item.SaveController.Restore()
+        else item.SaveController.Delete()
+      }
+    })
+    clearSelected()
+    NarrativeStore().SaveItemData()
+    NpcStore().SaveNpcData()
+    EncounterStore().SaveEncounterData()
+  }
+
+  async function deleteItemsPermanent(
+    selected: string[],
+    allItems: any[],
+    clearSelected: () => void,
+    setShowDeleteConfirm: (v: boolean) => void
+  ) {
+    await Promise.all(
+      selected.map(id => DeleteItemPermanent(allItems.find((x: any) => x.ID === id)))
+    )
+    clearSelected()
+    setShowDeleteConfirm(false)
+  }
+
+  function routePrint(selected: string[]) {
+    if (props.type === 'narrative') router.push(`/gm/print/narrative/${JSON.stringify(selected)}`)
+    else router.push(`/gm/print/${JSON.stringify(selected)}`)
+  }
 </script>


### PR DESCRIPTION
## Description

When selecting specific NPCs (or GM items) and clicking "Set Folder" or "Set GM Label", the action was being applied to all items in the list instead of only the checked one

## Selection Staging:
 Introduced stagedSelected and stagedClearSelected refs, along with openFolderDialog and openLabelDialog helpers, to capture selected item IDs and the selection reset callback when opening action dialogs.
## Filtered setFolder: 
Updated setFolder() to filter items by stagedSelected IDs before modifying FolderController.Folder, ensuring only selected items are moved. Included EncounterStore.SaveEncounterData() and invoked selection reset.
## Filtered setData (GM Labels): 
Updated setData() to filter items by stagedSelected IDs before appending or deleting labels from NarrativeController.Labels.

## Scoped selectedLabels: 
Updated the selectedLabels computed property to only gather labels from currently selected items when deleting existing labels.
Closes # 

## Type of Change

- [x ] Bug fix (`fix:`)


## Screenshots (if UI change)
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/eeb97d27-1f81-450a-ad80-31dae25e4a8a" />
<!-- Paste before/after screenshots -->
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/ee8d1c15-024a-4f7c-b3e4-4684b5d1a4f6" />
