### PR TITLE
fix: double Orator dice

### DIFF
--- a/src/classes/components/combat/counters/CounterController.ts
+++ b/src/classes/components/combat/counters/CounterController.ts
@@ -73,7 +73,13 @@ class CounterController {
       ? actor.FeatureController.Counters
       : []
 
-    return [...parent_counters, ...this.CustomCounterData].flat().filter(x => x)
+    const all = [...parent_counters, ...this.CustomCounterData].flat().filter(x => x)
+    const map = new Map<string, ICounterData>()
+    for (const c of all) {
+      const key = c.id || c.name
+      map.set(key, c)
+    }
+    return Array.from(map.values())
   }
 
   public static Serialize(parent: ICounterContainer, target: any) {


### PR DESCRIPTION
## Description

Rank 2 (Voice of Reason): Defines a counter with ID ctr_voice_of_reason with default_value: 1 and max: 3.

Rank 3 (The March of the Ten Thousand): Defines the same ctr_voice_of_reason counter with the upgraded value default_value: 2 and max: 4.

Counter Collection and Rendering (CounterController.ts):

When fetching the list of active counters (CounterData), the CounterController accumulated all counters returned by the pilot's talents without deduplicating them by ID.

As a result, the system returned both the Rank 2 and Rank 3 counters, causing Vue to render two "Orator Die" cards on the screen (one with a value of 1 and another with a value of 2).

🛠️ Fix Applied

Updated the CounterData getter in CounterController.ts to group and deduplicate the list of counters by id.

With this change, when a higher rank updates an existing counter (using the same ID), the new Rank 3 definition overrides Rank 2, ensuring that only one updated "Orator Die" counter is displayed on the interface.

Closes #
#3682 
## Type of Change

- [x ] Bug fix (`fix:`)


## Screenshots (if UI change)
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/c350ab78-69bb-45ac-9ad4-fd845749731c" />

<!-- Paste before/after screenshots -->
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/dee74b36-e6f2-4298-9f6e-1394aa672887" />
