### PR TITLE
fix(UI): added 'Status' badge back to pilot narrative section

### DIFF
--- a/src/features/pilot_management/PilotSheet/sections/narrative/components/IdentBlock.vue
+++ b/src/features/pilot_management/PilotSheet/sections/narrative/components/IdentBlock.vue
@@ -7,6 +7,14 @@
       sm="6"
       md="3"
       :class="mobile && 'd-flex justify-start'">
+      <cc-text-label v-model="pilot.Status"
+        :readonly="pilot.IsRemote"
+        :label="$t('common.status')" />
+    </v-col>
+    <v-col cols="12"
+      sm="6"
+      md="3"
+      :class="mobile && 'd-flex justify-start'">
       <cc-text-label v-model="pilot.Callsign"
         :readonly="pilot.IsRemote"
         :label="$t('common.callsign')" />


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link related issues with "Closes #123". -->
Displays Pilot Status similar to how it used to in V2

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Maintenance / Build (`chore:` / `build:` / `ci:`)
- [ ] Breaking change

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have tested this change locally
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added/updated types for any changed interfaces
- [x] This change is backwards-compatible (or marked as breaking)

## Screenshots (if UI change)

<!-- Paste before/after screenshots -->
