### PR TITLE
fix(loadout): bug in the mech loadout item browser

### DIFF
--- a/src/features/pilot_management/_components/loadout/mech_loadout/components/_composables/useLcpFilter.ts
+++ b/src/features/pilot_management/_components/loadout/mech_loadout/components/_composables/useLcpFilter.ts
@@ -2,6 +2,8 @@ import { ref, Ref } from 'vue'
 import { flavorID } from '@/io/Generators'
 import { Bonus, BonusId } from '@/classes/components/feature/bonus/Bonus'
 import { Mech } from '@/classes/mech/Mech'
+import { CompendiumStore } from '@/stores'
+import type { Frame } from '@/classes/mech/components/frame/Frame'
 
 export function useLcpFilter(mech: Ref<Mech>) {
   const showUnlicensed = ref(false)
@@ -23,8 +25,31 @@ export function useLcpFilter(mech: Ref<Mech>) {
     )
   }
 
-  function isLicensed(x: { LicenseLevel?: number; License?: string }): boolean {
-    return !x.LicenseLevel || mech.value.Pilot.has('License', x.License ?? '', x.LicenseLevel)
+  function isLicensed(x: { LicenseLevel?: number; License?: string; LicenseID?: string }): boolean {
+    if (!x.LicenseLevel) return true
+
+    if (x.LicenseID && mech.value.Pilot.has('License', x.LicenseID, x.LicenseLevel)) {
+      return true
+    }
+
+    if (x.License) {
+      if (mech.value.Pilot.has('License', x.License, x.LicenseLevel)) {
+        return true
+      }
+
+      const frame =
+        (x.LicenseID ? (CompendiumStore().referenceByID('Frames', x.LicenseID) as Frame) : null) ||
+        CompendiumStore().Frames.find(
+          f =>
+            f.TrueName.toLowerCase() === x.License!.toLowerCase() ||
+            f.Name.toLowerCase() === x.License!.toLowerCase()
+        )
+      if (frame && mech.value.Pilot.has('License', frame.Name, x.LicenseLevel)) {
+        return true
+      }
+    }
+
+    return false
   }
 
   function isAICapacityFull(): boolean {


### PR DESCRIPTION
## Description
This PR fixes a bug in the mech loadout item browser (weapons, systems, and mods) where newly unlocked licensed equipment was not appearing as licensed after leveling up when running COMP/CON in a translated language (such as pt-BR).

### Problem
In `useLcpFilter.ts`, the `isLicensed` function was checking license requirements using only `x.License` (the untranslated English string from the item data, e.g., `"Blackbeard"`):

function isLicensed(x: { LicenseLevel?: number; License?: string }): boolean {
  return !x.LicenseLevel || mech.value.Pilot.has('License', x.License ?? '', x.LicenseLevel)


However, when a localized language was active, the pilot's license stub stored the localized frame name (e.g., "barba negra"). When Pilot.has compared "Blackbeard" against the localized stub name ("barba negra"), the check failed and returned false. Because the "Show Unlicensed" toggle is off by default, the newly acquired equipment was hidden from the browser, making it appear as though the item browser wasn't accessing the updated license list.

Changes
In src/features/pilot_management/_components/loadout/mech_loadout/components/_composables/useLcpFilter.ts:

Prioritize LicenseID: If the item defines LicenseID (e.g., "mf_blackbeard"), Pilot.has checks against the canonical ID directly, matching Stub.ID reliably regardless of translation.
Raw Name Fallback: Checks against x.License as provided on the item (e.g., "Blackbeard").
Localized Name Fallback: Looks up the license's frame in CompendiumStore and also checks against the localized frame name (frame.Name, e.g., "Barba Negra").

Closes #3750 

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactor (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] Maintenance / Build (`chore:` / `build:` / `ci:`)
- [ ] Breaking change

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have tested this change locally
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated types for any changed interfaces
- [x] This change is backwards-compatible (or marked as breaking)

## Screenshots (if UI change)

<!--Paste before-->
<img width="1920" height="1032" alt="Captura de tela 2026-09-10 133238" src="https://github.com/user-attachments/assets/1c84bae5-bc55-41c9-8ba0-fdeb12d7ed90" />
<img width="1920" height="1032" alt="2" src="https://github.com/user-attachments/assets/03014753-aec4-46a4-8781-a1661d5e19ee" />
<img width="1920" height="1032" alt="3" src="https://github.com/user-attachments/assets/68160bcc-4f39-4ca7-b089-76d536fdd058" />

<!--After screenshots-->
<img width="1920" height="1032" alt="4" src="https://github.com/user-attachments/assets/483f6122-89dd-4bd8-b8ee-22e40ae22d32" />

